### PR TITLE
Enable specifying Neo4j timezone for parsing naive date and datetime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4369,6 +4369,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "chrono",
+ "chrono-tz",
  "clap",
  "geo 0.25.1",
  "mongodb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 surrealdb = { version = "2.3.5", features = ["protocol-ws", "kv-mem"] }
 mongodb = "3.2.3"
 chrono = "0.4.41"
+chrono-tz = "0.10"
 void = "1.0.2"
 neo4rs = "0.9.0-rc.6"
 base64 = "0.22"

--- a/README.md
+++ b/README.md
@@ -44,9 +44,12 @@ surreal-sync sync neo4j \
   --source-uri "bolt://localhost:7687" \
   --source-username "neo4j" \
   --source-password "password" \
+  --neo4j-timezone "America/New_York" \
   --to-namespace "production" \
   --to-database "graph_data"
 ```
+
+By default, Neo4j local datetime and time values are assumed to be in UTC. You can specify a different timezone using the `--neo4j-timezone` option or the `NEO4J_TIMEZONE` environment variable.
 
 ## Environment Variables
 
@@ -56,6 +59,7 @@ You can set these environment variables instead of using command-line flags:
 - `SOURCE_DATABASE`: Source database name
 - `SOURCE_USERNAME`: Source database username
 - `SOURCE_PASSWORD`: Source database password
+- `NEO4J_TIMEZONE`: Timezone for Neo4j local datetime/time values (default: UTC)
 - `SURREAL_ENDPOINT`: SurrealDB endpoint (default: http://localhost:8000)
 - `SURREAL_USERNAME`: SurrealDB username (default: root)
 - `SURREAL_PASSWORD`: SurrealDB password (default: root)
@@ -68,6 +72,7 @@ You can set these environment variables instead of using command-line flags:
 - `--source-database`: Name of the source database (optional for some sources)
 - `--source-username`: Username for source database authentication
 - `--source-password`: Password for source database authentication
+- `--neo4j-timezone`: Timezone for Neo4j local datetime/time values (default: UTC). Use IANA timezone names like "America/New_York", "Europe/London", etc.
 
 ### Target SurrealDB Options
 
@@ -92,7 +97,7 @@ To use the devcontainer:
 
 ## Roadmap
 
-- [ ] Add support for time zones assumed when converting local datetime and time from Neo4j
+- [x] Add support for time zones assumed when converting local datetime and time from Neo4j
 - [ ] Explore batching writes to SurrealDB for potentially better performance
 - [ ] Add support for MongoDB `$regularExpression` to SurrealDB `regex` type conversion once SurrealDB v3 gets released
 - [ ] Explore option to use BSON insted JSON Extended Format v2 for MongoDB

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,12 @@ pub struct SourceOpts {
     /// Source database password
     #[arg(long, env = "SOURCE_PASSWORD")]
     pub source_password: Option<String>,
+
+    /// Timezone to use for converting Neo4j local datetime and time values
+    /// Format: IANA timezone name (e.g., "America/New_York", "Europe/London", "UTC")
+    /// Default: "UTC"
+    #[arg(long, default_value = "UTC", env = "NEO4J_TIMEZONE")]
+    pub neo4j_timezone: String,
 }
 
 #[derive(Parser)]

--- a/tests/e2e_mongodb.rs
+++ b/tests/e2e_mongodb.rs
@@ -69,6 +69,7 @@ async fn test_mongodb_migration_e2e() -> Result<(), Box<dyn std::error::Error>> 
         source_database: Some(test_db_name.to_string()),
         source_username: None,
         source_password: None,
+        neo4j_timezone: "UTC".to_string(),
     };
 
     let to_opts = surreal_sync::SurrealOpts {
@@ -413,6 +414,7 @@ async fn test_mongodb_binary_migration() -> Result<(), Box<dyn std::error::Error
         source_database: Some(test_db_name.to_string()),
         source_username: None,
         source_password: None,
+        neo4j_timezone: "UTC".to_string(),
     };
 
     let to_opts = surreal_sync::SurrealOpts {
@@ -592,6 +594,7 @@ async fn test_mongodb_number_double_migration() -> Result<(), Box<dyn std::error
         source_database: Some(test_db_name.to_string()),
         source_username: None,
         source_password: None,
+        neo4j_timezone: "UTC".to_string(),
     };
 
     let to_opts = surreal_sync::SurrealOpts {
@@ -757,6 +760,7 @@ async fn test_mongodb_number_int_migration() -> Result<(), Box<dyn std::error::E
         source_database: Some(test_db_name.to_string()),
         source_username: None,
         source_password: None,
+        neo4j_timezone: "UTC".to_string(),
     };
 
     let to_opts = surreal_sync::SurrealOpts {
@@ -925,6 +929,7 @@ async fn test_mongodb_decimal128_migration() -> Result<(), Box<dyn std::error::E
         source_database: Some(test_db_name.to_string()),
         source_username: None,
         source_password: None,
+        neo4j_timezone: "UTC".to_string(),
     };
 
     let to_opts = surreal_sync::SurrealOpts {
@@ -1150,6 +1155,7 @@ async fn test_mongodb_document_migration() -> Result<(), Box<dyn std::error::Err
         source_database: Some(test_db_name.to_string()),
         source_username: None,
         source_password: None,
+        neo4j_timezone: "UTC".to_string(),
     };
 
     let to_opts = surreal_sync::SurrealOpts {
@@ -1447,6 +1453,7 @@ async fn test_mongodb_array_migration() -> Result<(), Box<dyn std::error::Error>
         source_database: Some(test_db_name.to_string()),
         source_username: None,
         source_password: None,
+        neo4j_timezone: "UTC".to_string(),
     };
 
     let to_opts = surreal_sync::SurrealOpts {
@@ -1723,6 +1730,7 @@ async fn test_mongodb_date_canonical_migration() -> Result<(), Box<dyn std::erro
         source_database: Some(test_db_name.to_string()),
         source_username: None,
         source_password: None,
+        neo4j_timezone: "UTC".to_string(),
     };
 
     let to_opts = surreal_sync::SurrealOpts {
@@ -1982,6 +1990,7 @@ async fn test_mongodb_timestamp_migration() -> Result<(), Box<dyn std::error::Er
         source_database: Some(test_db_name.to_string()),
         source_username: None,
         source_password: None,
+        neo4j_timezone: "UTC".to_string(),
     };
 
     let to_opts = surreal_sync::SurrealOpts {
@@ -2214,6 +2223,7 @@ async fn test_mongodb_dbref_migration() -> Result<(), Box<dyn std::error::Error>
         source_database: Some(test_db_name.to_string()),
         source_username: None,
         source_password: None,
+        neo4j_timezone: "UTC".to_string(),
     };
 
     let to_opts = surreal_sync::SurrealOpts {

--- a/tests/e2e_neo4j.rs
+++ b/tests/e2e_neo4j.rs
@@ -101,6 +101,7 @@ async fn test_neo4j_migration_e2e() -> Result<(), Box<dyn std::error::Error>> {
         source_database: Some(neo4j_database.to_string()),
         source_username: Some(neo4j_username.to_string()),
         source_password: Some(neo4j_password.to_string()),
+        neo4j_timezone: "UTC".to_string(),
     };
 
     let to_opts = surreal_sync::SurrealOpts {
@@ -194,6 +195,7 @@ async fn test_neo4j_data_types_migration() -> Result<(), Box<dyn std::error::Err
         source_database: Some(neo4j_database.to_string()),
         source_username: Some(neo4j_username.to_string()),
         source_password: Some(neo4j_password.to_string()),
+        neo4j_timezone: "UTC".to_string(),
     };
 
     let to_opts = surreal_sync::SurrealOpts {
@@ -281,6 +283,7 @@ async fn test_neo4j_large_dataset_migration() -> Result<(), Box<dyn std::error::
         source_database: Some(neo4j_database.to_string()),
         source_username: Some(neo4j_username.to_string()),
         source_password: Some(neo4j_password.to_string()),
+        neo4j_timezone: "UTC".to_string(),
     };
 
     let to_opts = surreal_sync::SurrealOpts {
@@ -966,6 +969,7 @@ async fn test_neo4j_relationship_conversion() -> Result<(), Box<dyn std::error::
         source_database: Some(neo4j_database.to_string()),
         source_username: Some(neo4j_username.to_string()),
         source_password: Some(neo4j_password.to_string()),
+        neo4j_timezone: "UTC".to_string(),
     };
 
     let to_opts = surreal_sync::SurrealOpts {
@@ -1345,6 +1349,7 @@ async fn test_neo4j_bytes_migration() -> Result<(), Box<dyn std::error::Error>> 
         source_database: Some(neo4j_database.to_string()),
         source_username: Some(neo4j_username.to_string()),
         source_password: Some(neo4j_password.to_string()),
+        neo4j_timezone: "UTC".to_string(),
     };
 
     let to_opts = surreal_sync::SurrealOpts {
@@ -1500,6 +1505,7 @@ async fn test_neo4j_geometry_conversion() -> Result<(), Box<dyn std::error::Erro
         source_database: Some(neo4j_database.to_string()),
         source_username: Some(neo4j_username.to_string()),
         source_password: Some(neo4j_password.to_string()),
+        neo4j_timezone: "UTC".to_string(),
     };
     let to_opts = surreal_sync::SurrealOpts {
         surreal_endpoint: surreal_endpoint.to_string(),

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -7,12 +7,14 @@ fn test_source_opts_creation() {
         source_database: Some("test_db".to_string()),
         source_username: Some("test".to_string()),
         source_password: Some("password".to_string()),
+        neo4j_timezone: "UTC".to_string(),
     };
 
     assert_eq!(opts.source_uri, "mongodb://test:test@localhost:27017");
     assert_eq!(opts.source_database, Some("test_db".to_string()));
     assert_eq!(opts.source_username, Some("test".to_string()));
     assert_eq!(opts.source_password, Some("password".to_string()));
+    assert_eq!(opts.neo4j_timezone, "UTC");
 }
 
 #[test]


### PR DESCRIPTION
## What is the motivation?

Neo4j has variants of datetime that do not include the timezone component, making it impossible to convert them to the appropriate SurrealDB datetime, which does include the timezone.

## What does this change do?

Adds `--neo4j-timezone TZ_ID` to specify which timezone surreal-sync should assume when converting Neo4j datetimes to SurrealDB datetimes.

## What is your testing strategy?

Added comprehensive unit tests for datetime conversion that respects `--neo4j-timezone`.

## Is this related to any issues?

## Have you read the [Contributing Guidelines](/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](/CONTRIBUTING.md)
