### PR TITLE
Enhance Neo4j DateTimeZoneId support to convert to SurrealDB datetime

### DIFF
--- a/docs/neo4j-data-types.md
+++ b/docs/neo4j-data-types.md
@@ -24,7 +24,7 @@ surreal-sync converts Neo4j nodes and relationships to SurrealDB records by proc
 | **LocalTime** | LocalTime | 🔶 **Partially Supported** | `object` | Converted to object with `type: "$Neo4jLocalTime"`, hour, minute, second, nanosecond fields |
 | **Point2D** | Point2D | 🔶 **Partially Supported** | `object` | GeoJSON-like object with `type: "Point"`, `srid` (4326), `coordinates: [longitude, latitude]` |
 | **Point3D** | Point3D | 🔶 **Partially Supported** | `object` | GeoJSON-like object with `type: "Point"`, `srid` (4979), `coordinates: [longitude, latitude, elevation]` |
-| **DateTimeZoneId** | DateTimeZoneId | 🔶 **Partially Supported** | `string` | Converted to debug string representation |
+| **DateTimeZoneId** | DateTimeZoneId | ✅ **Fully Supported** | `datetime` | Converted to UTC datetime using embedded timezone ID |
 
 ## Support Status Definitions
 


### PR DESCRIPTION
## What is the motivation?

`surreal-sync` converts Neo4j `DateTimeZoneId` as `string`, even though the original `DateTimeZoneId` contains everything you need to create a datetime with the timezone.

## What does this change do?

Enhances the `DateTimeZoneId` handling to leverage the neo4j crate's feature to convert it into a chrono datetime, allowing for a proper conversion into a SurrealDB datetime.

## What is your testing strategy?

I've written comprehensive unit tests for the DateTimeZoneId -> SurrealDB datetime conversion.

## Is this related to any issues?



## Have you read the [Contributing Guidelines](/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](/CONTRIBUTING.md)
