### PR TITLE
Use BSON directly for MongoDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,6 +623,7 @@ dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
  "bitvec",
+ "chrono",
  "getrandom 0.2.16",
  "getrandom 0.3.3",
  "hex",
@@ -4368,6 +4369,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
+ "bson",
  "chrono",
  "chrono-tz",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Database clients
 surrealdb = { version = "2.3.5", features = ["protocol-ws", "kv-mem"] }
 mongodb = "3.2.3"
+bson = { version = "2.15.0", features = ["chrono-0_4"] }
 chrono = "0.4.41"
 chrono-tz = "0.10"
 void = "1.0.2"

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ To use the devcontainer:
 ## Roadmap
 
 - [x] Add support for time zones assumed when converting local datetime and time from Neo4j
+- [x] Add support for MongoDB `$regularExpression` to SurrealDB `regex` type conversion once SurrealDB v2.3 gets released
+- [x] Explore option to use BSON insted JSON Extended Format v2 for MongoDB
 - [ ] Explore batching writes to SurrealDB for potentially better performance
-- [ ] Add support for MongoDB `$regularExpression` to SurrealDB `regex` type conversion once SurrealDB v3 gets released
-- [ ] Explore option to use BSON insted JSON Extended Format v2 for MongoDB
+- [ ] More paralleism on the surreal-sync side for better performance

--- a/docs/mongodb-data-types.md
+++ b/docs/mongodb-data-types.md
@@ -2,32 +2,33 @@
 
 This document provides an overview of MongoDB data type support in surreal-sync, detailing which types are supported during migration from MongoDB to SurrealDB.
 
-surreal-sync converts MongoDB documents to SurrealDB records by processing BSON data through MongoDB's Extended JSON v2 format. The conversion handles all the MongoDB data types while maintaining data integrity where possible.
+surreal-sync converts MongoDB documents to SurrealDB records by processing data in BSON. The conversion handles all the MongoDB data types while maintaining data integrity where possible.
 
 ## Data Type Support Table
 
 | MongoDB Data Type | BSON Type | JSON Extended Format v2 | Support Status | SurrealDB Mapping | Notes |
 |-------------------|-----------|---------------------|----------------|-------------------|-------|
+| **Double** | Double | `3.14` (Relaxed) or `{"$numberDouble": "3.14"}` (Canonical) | ✅ **Fully Supported** | `float` (f64) | Direct conversion |
 | **String** | String | `"text"` | ✅ **Fully Supported** | `string` | Direct conversion |
-| **Number (Int32)** | Int32 | `42` (Relaxed) or `{"$numberInt": "42"}` (Canonical) | ✅ **Fully Supported** | `int` | Converted to 64-bit integer |
-| **Number (Int64)** | Int64 | `{"$numberLong": "123"}` | ✅ **Fully Supported** | `int` | Explicitly handled with parsing |
-| **Number (Double)** | Double | `3.14` (Relaxed) or `{"$numberDouble": "3.14"}` (Canonical) | ✅ **Fully Supported** | `float` (f64) | Supports both Relaxed and Canonical formats |
-| **Number (Decimal128)** | Decimal128 | `{"$numberDecimal": "123.45"}` | ✅ **Fully Supported** | `number` (surrealdb::sql::Number) | Converted to SurrealDB Number type |
-| **Boolean** | Boolean | `true`/`false` | ✅ **Fully Supported** | `bool` | Direct conversion |
-| **Date** | DateTime | `{"$date": "2024-01-01T00:00:00Z"}` (Relaxed) or `{"$date": {"$numberLong": "1672531200000"}}` (Canonical) | ✅ **Fully Supported** | `datetime` | Supports both Relaxed and Canonical formats |
-| **ObjectId** | ObjectId | `{"$oid": "507f1f77bcf86cd799439011"}` | ✅ **Fully Supported** | `string` | Converted to string, used for SurrealDB record IDs |
+| **Object** | Document | `{"key": "value"}` | ✅ **Fully Supported** | `object` | Recursively processed as nested object |
 | **Array** | Array | `[1, 2, 3]` | ✅ **Fully Supported** | `array` | Recursively processed, nested types converted |
-| **Object/Document** | Document | `{"key": "value"}` | ✅ **Fully Supported** | `object` | Recursively processed as nested object |
-| **Null** | Null | `null` | ✅ **Fully Supported** | Null | Direct conversion |
-| **Binary Data** | Binary | `{"$binary": {"base64": "...", "subType": "..."}}` | ✅ **Fully Supported** | `bytes` | Base64 decoded to bytes, invalid base64 falls back to string |
-| **Regular Expression** | Regex | `{"$regex": "pattern"}` | 🔶 **Partially Supported** | `object` | Preserved as generic object with pattern and flags |
-| **JavaScript Code** | Code | `{"$code": "function(){}"}` | 🔶 **Partially Supported** | `object` | Preserved as generic object, loses executable nature |
-| **Timestamp** | Timestamp | `{"$timestamp": {"t": 1672531200, "i": 1}}` | ✅ **Fully Supported** | `datetime` | Converted using timestamp seconds |
-| **MinKey** | MinKey | `{"$minKey": 1}` | 🔶 **Partially Supported** | `object` | Preserved as generic object, loses special ordering behavior |
-| **MaxKey** | MaxKey | `{"$maxKey": 1}` | 🔶 **Partially Supported** | `object` | Preserved as generic object, loses special ordering behavior |
-| **DBRef** | DBRef | `{"$ref": "collection", "$id": "..."}` | ✅ **Fully Supported** | `record` (surrealdb::sql::Thing) | Converted to SurrealDB Thing (collection:id) |
-| **Symbol** | Symbol | `{"$symbol": "text"}` | 🔶 **Partially Supported** | `object` | Preserved as generic object, loses symbol type semantics |
-| **Undefined** | Undefined | `{"$undefined": true}` | 🔶 **Partially Supported** | `object` | Preserved as generic object |
+| **Binary ata** | Binary | `{"$binary": {"base64": "...", "subType": "..."}}` | ✅ **Fully Supported** | `bytes` | Direct conversion to bytes |
+| **Undefined** | Undefined | `{"$undefined": true}` | ✅ **Fully Supported** | `none` | See [None and null](https://surrealdb.com/docs/surrealql/datamodel/none-and-null) |
+| **ObjectId** | ObjectId | `{"$oid": "507f1f77bcf86cd799439011"}` | ✅ **Fully Supported** | `string` | Converted to string, used for SurrealDB record IDs |
+| **Boolean** | Boolean | `true`/`false` | ✅ **Fully Supported** | `bool` | Direct conversion |
+| **Date** | DateTime | `{"$date": "2024-01-01T00:00:00Z"}` (Relaxed) or `{"$date": {"$numberLong": "1672531200000"}}` (Canonical) | ✅ **Fully Supported** | `datetime` | Converted using chrono |
+| **Null** | Null | `null` | ✅ **Fully Supported** | `null` | See [None and null](https://surrealdb.com/docs/surrealql/datamodel/none-and-null) |
+| **Regular Expression** | RegularExpression | `{"$regularExpression": {"pattern": "...", "options": "..."}}` | ✅ **Fully Supported** | `regex` | Converted to string format "(?<options>)<pattern>" |
+| **DBPointer** | DbPointer | `{"$dbPointer": {"$ref": "...", "$id": {...}}}` | 🔶 **Partially Supported** | `string` | Stored as "$dbPointer" string (deprecated type) |
+| **JavaScript** | JavaScriptCode | `{"$code": "function(){}"}` | ✅ **Fully Supported** | `string` | Code converted to string |
+| **Symbol** | Symbol | `{"$symbol": "text"}` | ✅ **Fully Supported** | `string` | Direct conversion to string |
+| **JavaScript with scope** | JavaScriptCodeWithScope | `{"$code": "...", "$scope": {...}}` | ✅ **Fully Supported** | `object` | Stored as `{"$code": CODE, "$scope": SCOPE}` object |
+| **32-bit integer** | Int32 | `42` (Relaxed) or `{"$numberInt": "42"}` (Canonical) | ✅ **Fully Supported** | `int` | Converted to 64-bit integer |
+| **Timestamp** | Timestamp | `{"$timestamp": {"t": 1672531200, "i": 1}}` | ✅ **Fully Supported** | `datetime` | Converted using timestamp seconds, increment as nanoseconds |
+| **64-bit integer** | Int64 | `{"$numberLong": "123"}` | ✅ **Fully Supported** | `int` | Direct conversion |
+| **Decimal128** | Decimal128 | `{"$numberDecimal": "123.45"}` | ✅ **Fully Supported** | `number` (surrealdb::sql::Number) | Converted to SurrealDB Number type |
+| **Min key** | MinKey | `{"$minKey": 1}` | 🔶 **Partially Supported** | `object` | Stored as `{"$minKey": 1}` object, loses special ordering |
+| **Max key** | MaxKey | `{"$maxKey": 1}` | 🔶 **Partially Supported** | `object` | Stored as `{"$maxKey": 1}` object, loses special ordering |
 
 ## Support Status Definitions
 
@@ -37,20 +38,23 @@ surreal-sync converts MongoDB documents to SurrealDB records by processing BSON 
 
 ## Limitations and Considerations
 
-### Not Yet Implemented Types
+### Type Conversion Notes
 
-- **Timestamp**: TODO implementation planned (see src/mongodb.rs:307-308)
-- **Regular Expression**: Loses executable nature and becomes a generic object. Use [string::matches](https://surrealdb.com/docs/surrealql/datamodel/regex) function with the pattern extracted from the object for pattern matching.
-  [We will also have `regex` data type since SurrealDB v3](https://surrealdb.com/docs/surrealql/datamodel/regex#regex).
-- **JavaScript Code**: Preserved as generic object but loses executable nature
-- **Special Keys (MinKey/MaxKey)**: Lose their special ordering behavior in queries and comparisons
-- **Symbol/DBRef**: Lose their specialized MongoDB semantics but preserve structural data
+- **JavaScript Code**: Preserved as string but loses executable nature
+- **JavaScript with Scope**: Preserved as an object containing code and scope but loses executable nature
+- **Special Keys (MinKey/MaxKey)**: Converted to special marker objects, lose their ordering behavior
+- **DBPointer**: Deprecated MongoDB type, stored as marker string, loses its content
+- **Symbol**: Converted to regular string, loses symbol semantics
 
 ### Special Limitations
 
-- **Negative Timestamps**: Dates before 1970 or after 9999 are not supported and will cause conversion errors
-- **Invalid Binary Data**: Base64 decoding failures fall back to string representation with warning logs
+- **DBRef**: When the document contains both `$ref` and `$id` fields, it's converted to a SurrealDB Thing (record reference). Otherwise treated as a regular document.
+- **Decimal128**: Conversion may fail if the decimal string cannot be parsed as a SurrealDB Number
 
 ## Testing and Validation
 
 See `/tests/e2e_mongodb.rs` for test examples demonstrating the conversion of various MongoDB data types.
+
+## References
+
+- Refer to https://www.mongodb.com/docs/manual/reference/bson-types for all the documented MongoDB BSON data types

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,8 @@ pub async fn migrate_batch(
                 BindableValue::Decimal(d) => q.bind((field_name.clone(), *d)),
                 BindableValue::Thing(t) => q.bind((field_name.clone(), t.clone())),
                 BindableValue::Geometry(g) => q.bind((field_name.clone(), g.clone())),
-                BindableValue::Null => q.bind((field_name.clone(), Option::<String>::None)),
+                BindableValue::Null => q.bind((field_name.clone(), surrealdb::sql::Value::Null)),
+                BindableValue::None => q.bind((field_name.clone(), surrealdb::sql::Value::None)),
             };
         }
 
@@ -212,6 +213,7 @@ fn bindable_to_surrealdb_value(bindable: &BindableValue) -> surrealdb::sql::Valu
         BindableValue::Thing(t) => surrealdb::sql::Value::Thing(t.clone()),
         BindableValue::Geometry(g) => surrealdb::sql::Value::Geometry(g.clone()),
         BindableValue::Null => surrealdb::sql::Value::Null,
+        BindableValue::None => surrealdb::sql::Value::None,
     }
 }
 
@@ -240,4 +242,5 @@ pub enum BindableValue {
     Thing(surrealdb::sql::Thing),
     Geometry(surrealdb::sql::Geometry),
     Null,
+    None,
 }


### PR DESCRIPTION
## What is the motivation?

surreal-sync's MongoDB source implementation had unnecessary conversion from the MongoDB data (BSON) into its serde_json JSON value equivalent, which is then converted to the corresponding SurrealDB data types.

## What does this change do?

This changes the conversion logic to map BSON types to our internal types directly, which should improve efficiency.

## What is your testing strategy?

I've enhanced our existing integration test case and verified that the new implementation passes all the existing test cases and even more.

## Is this related to any issues?


## Have you read the [Contributing Guidelines](/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](/CONTRIBUTING.md)
