### PR TITLE
Add mathematical braces if JSON lines id is complex

### DIFF
--- a/src/jsonl.rs
+++ b/src/jsonl.rs
@@ -211,7 +211,11 @@ fn convert_json_to_bindable(
             if key == id_field {
                 // Extract ID for the record
                 if let Value::String(id) = val {
-                    record_id = Some(format!("{table_name}:{id}"));
+                    if id.chars().any(|c| !c.is_alphanumeric() && c != '_') {
+                        record_id = Some(format!("{table_name}:⟨{id}⟩"));
+                    } else {
+                        record_id = Some(format!("{table_name}:{id}"));
+                    }
                 } else if let Value::Number(n) = val {
                     record_id = Some(format!("{table_name}:{n}"));
                 } else {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

If you have a .jsonl file with the following and use the flag `--id-field "timestamp"`, the parser will fail because it can't `CREATE somerecord:2025-07-22T03:18:59.349350Z`.

```
{"timestamp":"2025-07-22T03:18:59.349350Z","level":"INFO","fields":{"message":"Running 3.0.0+20250721.eaff383ce for macos on aarch64"},"target":"surreal::env"}
```

## What does this change do?

Checks to see if any characters are both non-alphanumeric and not equal to `_`, in which case it will enclose that part with mathematical braces.

## What is your testing strategy?

Added a test.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](/CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](/CONTRIBUTING.md)
