### PR TITLE
Add sub-crate to support potential Kafka source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1887,6 +1887,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2429,6 +2438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
 dependencies = [
  "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -2450,6 +2460,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3052,6 +3068,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3493,6 +3531,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-parse"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4aeaa1f2460f1d348eeaeed86aea999ce98c1bded6f089ff8514c9d9dbdc973"
+dependencies = [
+ "anyhow",
+ "indexmap 2.9.0",
+ "log",
+ "protobuf",
+ "protobuf-support",
+ "tempfile",
+ "thiserror 1.0.69",
+ "which",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "psl-types"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3721,6 +3795,36 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rdkafka"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1beea247b9a7600a81d4cc33f659ce1a77e1988323d7d2809c7ed1c21f4c316d"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "libc",
+ "log",
+ "rdkafka-sys",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "slab",
+ "tokio",
+]
+
+[[package]]
+name = "rdkafka-sys"
+version = "4.9.0+2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5230dca48bc354d718269f3e4353280e188b610f7af7e2fcf54b7a79d5802872"
+dependencies = [
+ "libc",
+ "libz-sys",
+ "num_enum",
+ "pkg-config",
 ]
 
 [[package]]
@@ -4094,6 +4198,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
@@ -4101,7 +4218,7 @@ dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -4721,6 +4838,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "surreal-sync-kafka"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bytes",
+ "log",
+ "protobuf",
+ "protobuf-parse",
+ "rdkafka",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-test",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "surrealdb"
 version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4950,7 +5088,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -5787,6 +5925,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+[workspace]
+members = ["kafka"]
+resolver = "2"
+
 [package]
 name = "surreal-sync"
 version = "0.1.0"
@@ -11,11 +15,11 @@ clap = { version = "4.5", features = ["derive", "env"] }
 tokio = { version = "1.47", features = ["full"] }
 
 # Serialization
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
 
 # Error handling
-anyhow = "1.0"
+anyhow = "1.0.100"
 
 # Logging
 tracing = "0.1"

--- a/kafka/Cargo.toml
+++ b/kafka/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "surreal-sync-kafka"
+version = "0.1.0"
+edition = "2021"
+description = "Kafka consumer with protobuf support for surreal-sync"
+authors = ["surreal-sync contributors"]
+
+[dependencies]
+# Kafka client
+rdkafka = { version = "0.36", features = ["tokio"] }
+
+# Protobuf support
+protobuf = "3.5"
+protobuf-parse = "3.5"
+
+# Async runtime
+tokio = { version = "1.47", features = ["full"] }
+
+# Error handling
+anyhow = "1.0.100"
+thiserror = "1.0"
+
+# Serialization
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
+
+# Logging
+tracing = "0.1"
+log = "0.4"
+
+# Utilities
+bytes = "1.0"
+base64 = "0.22"
+tempfile = "3.0"
+
+[dev-dependencies]
+tokio-test = "0.4"
+tempfile = "3.0"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -1,0 +1,20 @@
+# surreal-sync-kafka
+
+A Kafka consumer library designed for `surreal-sync`'s specific use case of processing Kafka messages
+whose values are encoded in protobuf.
+
+Features:
+
+- Runtime Protobuf Support: Parse `.proto` files at runtime and decode messages without code generation
+- Field Introspection: List fields and extract values from decoded messages dynamically
+- Consumer Groups: Spawn multiple consumers in the same consumer group
+- Batch Processing: Process messages in batches with atomic commits
+
+Please see [the example](examples/multi_consumer.rs) for the expected usage.
+
+### Components
+
+1. **ProtoParser** (`proto_parser.rs`): Parses `.proto` files and extracts message schemas
+2. **ProtoDecoder** (`proto_decoder.rs`): Decodes protobuf messages using runtime schema
+3. **KafkaConsumer** (`consumer.rs`): Low-level consumer with peek buffer and manual offsets
+4. **KafkaClient** (`client.rs`): High-level API for spawning consumer tasks

--- a/kafka/examples/multi_consumer.rs
+++ b/kafka/examples/multi_consumer.rs
@@ -1,0 +1,105 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use surreal_sync_kafka::{Client, ConsumerConfig, Message};
+
+/// Example demonstrating multiple consumers in a consumer group
+///
+/// This example shows how to:
+/// 1. Parse a .proto file
+/// 2. Create a Kafka client
+/// 3. Spawn multiple consumers in the same consumer group
+/// 4. Process messages with automatic offset commits
+/// 5. Extract field values from decoded messages
+///
+/// To run this example:
+/// 1. Start Kafka with Docker
+///   docker run -d --name kafka -p 9092:9092 apache/kafka:latest
+/// 2. Run tests
+///   cargo test
+/// 3. Run examples
+///   cargo run --example multi_consumer
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing
+    tracing_subscriber::fmt::init();
+
+    // Example .proto content
+    let proto_content = r#"
+        syntax = "proto3";
+
+        package example;
+
+        message UserEvent {
+            string user_id = 1;
+            string event_type = 2;
+            int64 timestamp = 3;
+            string data = 4;
+        }
+    "#;
+
+    let config = ConsumerConfig {
+        brokers: "localhost:9092".to_string(),
+        group_id: "peek-example-group".to_string(),
+        topic: "user-events".to_string(),
+        message_type: "UserEvent".to_string(),
+        buffer_size: 100,
+        ..Default::default()
+    };
+
+    // Create Kafka client
+    let client = Client::from_proto_string(proto_content, config)?;
+
+    println!("Kafka client created successfully");
+
+    // Shared counter for processed messages
+    let processed_count = Arc::new(AtomicU64::new(0));
+
+    // Message processor function
+    let processor = {
+        let counter = Arc::clone(&processed_count);
+        move |messages: Vec<Message>| {
+            let counter = Arc::clone(&counter);
+            async move {
+                for message in messages {
+                    // Extract fields from the decoded message
+                    let user_id = message.message.get_string("user_id")?;
+                    let event_type = message.message.get_string("event_type")?;
+                    let timestamp = message.message.get_int64("timestamp")?;
+                    let data = message.message.get_string("data")?;
+
+                    println!(
+                        "[Partition {}] User: {}, Event: {}, Timestamp: {}, Data: {}",
+                        message.partition, user_id, event_type, timestamp, data
+                    );
+
+                    // Increment counter
+                    let count = counter.fetch_add(1, Ordering::SeqCst) + 1;
+                    if count % 100 == 0 {
+                        println!("Processed {count} messages total");
+                    }
+                }
+
+                Ok(())
+            }
+        }
+    };
+
+    // Spawn 3 consumers in the same consumer group
+    // Each consumer will process different partitions
+    println!("Spawning 3 consumers in the same consumer group...");
+    let handles = client.spawn_batch_consumer_group(3, 10, processor)?;
+
+    println!("Consumers running. Press Ctrl+C to stop.");
+
+    // Wait for all consumers (runs indefinitely until Ctrl+C)
+    for (i, handle) in handles.into_iter().enumerate() {
+        match handle.await {
+            Ok(Ok(())) => println!("Consumer {i} finished successfully"),
+            Ok(Err(e)) => eprintln!("Consumer {i} error: {e}"),
+            Err(e) => eprintln!("Consumer {i} task error: {e}"),
+        }
+    }
+
+    Ok(())
+}

--- a/kafka/src/client.rs
+++ b/kafka/src/client.rs
@@ -1,0 +1,122 @@
+use crate::consumer::{Consumer, ConsumerConfig, Message};
+use crate::error::Result;
+use crate::proto::decoder::ProtoDecoder;
+use crate::proto::parser::ProtoSchema;
+use std::future::Future;
+use std::path::Path;
+use std::pin::Pin;
+use std::sync::Arc;
+use tokio::task::JoinHandle;
+
+/// Type alias for message processor functions
+pub type MessageProcessor =
+    Arc<dyn Fn(Message) -> Pin<Box<dyn Future<Output = Result<()>> + Send>> + Send + Sync>;
+
+/// Kafka client for managing multiple consumers
+pub struct Client {
+    schema: Arc<ProtoSchema>,
+    config: ConsumerConfig,
+}
+
+impl Client {
+    /// Create a new Kafka client from a .proto file
+    pub fn from_proto_file<P: AsRef<Path>>(proto_path: P, config: ConsumerConfig) -> Result<Self> {
+        let schema = ProtoSchema::from_file(proto_path)?;
+        Ok(Self {
+            schema: Arc::new(schema),
+            config,
+        })
+    }
+
+    /// Create a new Kafka client from a .proto string
+    pub fn from_proto_string(proto_content: &str, config: ConsumerConfig) -> Result<Self> {
+        let schema = ProtoSchema::from_string(proto_content)?;
+        Ok(Self {
+            schema: Arc::new(schema),
+            config,
+        })
+    }
+
+    /// Create a decoder for this client's schema
+    pub fn create_decoder(&self) -> ProtoDecoder {
+        ProtoDecoder::new((*self.schema).clone())
+    }
+
+    /// Create a single consumer
+    pub fn create_consumer(&self) -> Result<Consumer> {
+        let decoder = self.create_decoder();
+        Consumer::new(self.config.clone(), decoder)
+    }
+
+    /// Spawn a batch consumer task that processes messages in batches
+    pub fn spawn_batch_consumer_task<F, Fut>(
+        &self,
+        batch_size: usize,
+        processor: F,
+    ) -> Result<JoinHandle<Result<()>>>
+    where
+        F: Fn(Vec<Message>) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<()>> + Send + 'static,
+    {
+        let consumer = self.create_consumer()?;
+
+        let handle = tokio::spawn(async move {
+            loop {
+                // Receive a batch of messages
+                let messages = consumer.receive_batch(batch_size).await?;
+
+                if messages.is_empty() {
+                    continue;
+                }
+
+                // Process the batch
+                if let Err(e) = processor(messages.clone()).await {
+                    tracing::error!("Error processing batch: {}", e);
+                    // Don't commit on error - messages will be reprocessed
+                    continue;
+                }
+
+                // Commit all messages in the batch after successful processing
+                consumer.commit_batch(&messages).await?;
+            }
+        });
+
+        Ok(handle)
+    }
+
+    /// Spawn multiple batch consumer tasks in the same consumer group
+    ///
+    /// When spawning multiple consumers:
+    /// - All consumers join the same consumer group (same `group_id`)
+    /// - Kafka assigns different partitions of the specified topic to each consumer
+    /// - Each partition is processed by exactly one consumer
+    pub fn spawn_batch_consumer_group<F, Fut>(
+        &self,
+        num_consumers: usize,
+        batch_size: usize,
+        processor: F,
+    ) -> Result<Vec<JoinHandle<Result<()>>>>
+    where
+        F: Fn(Vec<Message>) -> Fut + Send + Clone + 'static,
+        Fut: Future<Output = Result<()>> + Send + 'static,
+    {
+        let mut handles = Vec::new();
+
+        for _ in 0..num_consumers {
+            let handle = self.spawn_batch_consumer_task(batch_size, processor.clone())?;
+            handles.push(handle);
+        }
+
+        Ok(handles)
+    }
+
+    /// Get the schema
+    pub fn schema(&self) -> &ProtoSchema {
+        &self.schema
+    }
+
+    /// Get the config
+    pub fn config(&self) -> &ConsumerConfig {
+        &self.config
+    }
+}

--- a/kafka/src/consumer.rs
+++ b/kafka/src/consumer.rs
@@ -1,0 +1,223 @@
+use crate::error::{Error, Result};
+use crate::proto::decoder::{ProtoDecoder, ProtoMessage};
+use rdkafka::config::ClientConfig;
+use rdkafka::consumer::{Consumer as RdkafkaConsumer, StreamConsumer as RdkafkaStreamConsumer};
+use rdkafka::message::{BorrowedMessage as RdkafkaBorrowedMessage, Message as RdkafkaMessage};
+use rdkafka::{Offset, TopicPartitionList};
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Mutex;
+
+/// Configuration for Kafka consumer
+#[derive(Debug, Clone)]
+pub struct ConsumerConfig {
+    /// Kafka brokers (comma-separated list)
+    pub brokers: String,
+    /// Consumer group ID
+    pub group_id: String,
+    /// Topic to consume from
+    pub topic: String,
+    /// Protobuf message type name
+    pub message_type: String,
+    /// Maximum buffer size for peeked messages
+    pub buffer_size: usize,
+    /// Auto offset reset strategy ("earliest" or "latest")
+    pub auto_offset_reset: String,
+    /// Session timeout in milliseconds
+    pub session_timeout_ms: String,
+    /// Enable auto commit (should be false for manual offset management)
+    pub enable_auto_commit: bool,
+}
+
+impl Default for ConsumerConfig {
+    fn default() -> Self {
+        Self {
+            brokers: "localhost:9092".to_string(),
+            group_id: "surreal-sync-consumer".to_string(),
+            topic: "".to_string(),
+            message_type: "".to_string(),
+            buffer_size: 100,
+            auto_offset_reset: "earliest".to_string(),
+            session_timeout_ms: "6000".to_string(),
+            enable_auto_commit: false,
+        }
+    }
+}
+
+/// A Kafka message with decoded protobuf content
+#[derive(Debug, Clone)]
+pub struct Message {
+    /// Decoded protobuf message content
+    pub message: ProtoMessage,
+    /// Kafka topic
+    pub topic: String,
+    /// Kafka partition
+    pub partition: i32,
+    /// Kafka offset
+    pub offset: i64,
+    /// Message key (if any)
+    pub key: Option<Vec<u8>>,
+    /// Message timestamp (milliseconds since epoch)
+    pub timestamp: Option<i64>,
+}
+
+/// Kafka consumer with peek buffer and manual offset management
+pub struct Consumer {
+    consumer: Arc<RdkafkaStreamConsumer>,
+    decoder: Arc<ProtoDecoder>,
+    config: ConsumerConfig,
+    buffer: Arc<Mutex<VecDeque<Message>>>,
+}
+
+impl Consumer {
+    /// Create a new Kafka consumer
+    pub fn new(config: ConsumerConfig, decoder: ProtoDecoder) -> Result<Self> {
+        let consumer: RdkafkaStreamConsumer = ClientConfig::new()
+            .set("bootstrap.servers", &config.brokers)
+            .set("group.id", &config.group_id)
+            .set("enable.auto.commit", config.enable_auto_commit.to_string())
+            .set("auto.offset.reset", &config.auto_offset_reset)
+            .set("session.timeout.ms", &config.session_timeout_ms)
+            .set("enable.partition.eof", "false")
+            .create()
+            .map_err(|e| Error::Consumer(format!("Failed to create consumer: {e}")))?;
+
+        consumer
+            .subscribe(&[&config.topic])
+            .map_err(|e| Error::Consumer(format!("Failed to subscribe to topic: {e}")))?;
+
+        Ok(Self {
+            consumer: Arc::new(consumer),
+            decoder: Arc::new(decoder),
+            config,
+            buffer: Arc::new(Mutex::new(VecDeque::new())),
+        })
+    }
+
+    /// Peek at buffered messages without marking them as consumed
+    /// This fetches messages into the buffer up to buffer_size
+    pub async fn peek(&self, count: usize) -> Result<Vec<Message>> {
+        let mut buffer = self.buffer.lock().await;
+
+        // Fill buffer if needed
+        while buffer.len() < count && buffer.len() < self.config.buffer_size {
+            match tokio::time::timeout(Duration::from_millis(100), self.consumer.recv()).await {
+                Ok(Ok(msg)) => {
+                    let kafka_msg = self.decode_message(&msg)?;
+                    buffer.push_back(kafka_msg);
+                }
+                Ok(Err(e)) => {
+                    return Err(Error::Consumer(format!(
+                        "Error receiving message: {e}"
+                    )))
+                }
+                Err(_) => break, // Timeout, no more messages available right now
+            }
+        }
+
+        // Return uncommitted messages
+        Ok(buffer.iter().take(count).cloned().collect::<Vec<_>>())
+    }
+
+    /// Receive multiple messages (blocks until at least one message is available)
+    pub async fn receive_batch(&self, max_count: usize) -> Result<Vec<Message>> {
+        let mut messages = Vec::new();
+        let mut buffer = self.buffer.lock().await;
+
+        // Drain from buffer first
+        while let Some(buffered) = buffer.pop_front() {
+            messages.push(buffered);
+            if messages.len() >= max_count {
+                return Ok(messages);
+            }
+        }
+
+        drop(buffer); // Release lock before fetching
+
+        // Fetch at least one message
+        if messages.is_empty() {
+            let msg = self
+                .consumer
+                .recv()
+                .await
+                .map_err(|e| Error::Consumer(format!("Error receiving message: {e}")))?;
+            messages.push(self.decode_message(&msg)?);
+        }
+
+        // Try to fetch more with timeout
+        while messages.len() < max_count {
+            match tokio::time::timeout(Duration::from_millis(10), self.consumer.recv()).await {
+                Ok(Ok(msg)) => messages.push(self.decode_message(&msg)?),
+                _ => break,
+            }
+        }
+
+        Ok(messages)
+    }
+
+    /// Commit multiple messages' offsets
+    pub async fn commit_batch(&self, messages: &[Message]) -> Result<()> {
+        if messages.is_empty() {
+            return Ok(());
+        }
+
+        let mut tpl = TopicPartitionList::new();
+        for message in messages {
+            tpl.add_partition_offset(
+                &message.topic,
+                message.partition,
+                Offset::Offset(message.offset + 1),
+            )
+            .map_err(|e| Error::Consumer(format!("Failed to add partition offset: {e}")))?;
+        }
+
+        self.consumer
+            .commit(&tpl, rdkafka::consumer::CommitMode::Sync)
+            .map_err(|e| Error::Consumer(format!("Failed to commit offset: {e}")))?;
+
+        self.clear_buffer().await;
+
+        Ok(())
+    }
+
+    /// Clear the peek buffer
+    async fn clear_buffer(&self) {
+        let mut buffer = self.buffer.lock().await;
+        buffer.clear();
+    }
+
+    fn decode_message(&self, msg: &RdkafkaBorrowedMessage) -> Result<Message> {
+        let payload = msg
+            .payload()
+            .ok_or_else(|| Error::Consumer("Message has no payload".to_string()))?;
+
+        let decoded = self.decoder.decode(&self.config.message_type, payload)?;
+
+        Ok(Message {
+            message: decoded,
+            topic: msg.topic().to_string(),
+            partition: msg.partition(),
+            offset: msg.offset(),
+            key: msg.key().map(|k| k.to_vec()),
+            timestamp: msg.timestamp().to_millis(),
+        })
+    }
+
+    /// Get the underlying consumer (for advanced use cases)
+    pub fn inner(&self) -> &RdkafkaStreamConsumer {
+        &self.consumer
+    }
+}
+
+/// Clone support for spawning multiple consumer tasks
+impl Clone for Consumer {
+    fn clone(&self) -> Self {
+        Self {
+            consumer: Arc::clone(&self.consumer),
+            decoder: Arc::clone(&self.decoder),
+            config: self.config.clone(),
+            buffer: Arc::clone(&self.buffer),
+        }
+    }
+}

--- a/kafka/src/error.rs
+++ b/kafka/src/error.rs
@@ -1,0 +1,44 @@
+use thiserror::Error;
+
+use crate::ProtoType;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Kafka error: {0}")]
+    Kafka(#[from] rdkafka::error::KafkaError),
+
+    #[error("Protobuf parse error: {0}")]
+    ProtobufParse(String),
+
+    #[error("Protobuf decode error: {0}")]
+    ProtobufDecode(String),
+
+    #[error("Field not found: {0}")]
+    FieldNotFound(String),
+
+    #[error("Invalid field type: expected {expected}, got {actual}")]
+    InvalidFieldType {
+        expected: ProtoType,
+        actual: ProtoType,
+    },
+
+    #[error("Message type not found: {0}")]
+    MessageTypeNotFound(String),
+
+    #[error("No messages available")]
+    NoMessagesAvailable,
+
+    #[error("Consumer error: {0}")]
+    Consumer(String),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Invalid configuration: {0}")]
+    InvalidConfig(String),
+
+    #[error("Message processing error: {0}")]
+    MessageProcessing(String),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/kafka/src/lib.rs
+++ b/kafka/src/lib.rs
@@ -1,0 +1,29 @@
+//! KA Kafka consumer library designed for `surreal-sync`'s specific use case of processing Kafka messages
+//! whose values are encoded in protobuf.
+//!
+//! Features:
+//!
+//! - Runtime Protobuf Support: Parse `.proto` files at runtime and decode messages without code generation
+//! - Field Introspection: List fields and extract values from decoded messages dynamically
+//! - Consumer Groups: Spawn multiple consumers in the same consumer group
+//! - Batch Processing: Process messages in batches with atomic commits
+
+/// High-level API for spawning consumer tasks
+///
+/// Takes the consumer config and .proto schema, to create one or more consumers
+/// in the same consumer group, each running in its own async task.
+pub mod client;
+
+/// Low-level consumer with peek buffer and manual offsets
+///
+/// Created by the client given the consumer config and .proto schema.
+pub mod consumer;
+pub mod error;
+pub mod proto;
+
+// Re-export main types for easy access
+pub use client::Client;
+pub use consumer::{Consumer, ConsumerConfig, Message};
+pub use error::{Error, Result};
+pub use proto::decoder::{ProtoDecoder, ProtoFieldValue, ProtoMessage};
+pub use proto::parser::{ProtoFieldDescriptor, ProtoMessageDescriptor, ProtoSchema, ProtoType};

--- a/kafka/src/proto.rs
+++ b/kafka/src/proto.rs
@@ -1,0 +1,4 @@
+/// Parses `.proto` files and extracts message schemas
+pub mod parser;
+// Decodes protobuf messages using runtime schema
+pub mod decoder;

--- a/kafka/src/proto/decoder.rs
+++ b/kafka/src/proto/decoder.rs
@@ -1,0 +1,347 @@
+use super::parser::{ProtoFieldDescriptor, ProtoMessageDescriptor, ProtoSchema, ProtoType};
+use crate::error::{Error, Result};
+use protobuf::CodedInputStream;
+use std::collections::HashMap;
+
+/// Represents a decoded protobuf message
+#[derive(Debug, Clone)]
+pub struct ProtoMessage {
+    /// Message type name
+    pub message_type: String,
+    /// Decoded field values
+    fields: HashMap<String, ProtoFieldValue>,
+    /// Schema reference for field introspection
+    descriptor: ProtoMessageDescriptor,
+}
+
+/// Represents a field value in a decoded message
+#[derive(Debug, Clone)]
+pub enum ProtoFieldValue {
+    Double(f64),
+    Float(f32),
+    Int32(i32),
+    Int64(i64),
+    Uint32(u32),
+    Uint64(u64),
+    Bool(bool),
+    String(String),
+    Bytes(Vec<u8>),
+    Message(Box<ProtoMessage>),
+    Repeated(Vec<ProtoFieldValue>),
+    Null,
+}
+
+impl ProtoFieldValue {
+    /// Get the type name of this field value
+    pub fn proto_field_type(&self) -> ProtoType {
+        match self {
+            ProtoFieldValue::Double(_) => ProtoType::Double,
+            ProtoFieldValue::Float(_) => ProtoType::Float,
+            ProtoFieldValue::Int32(_) => ProtoType::Int32,
+            ProtoFieldValue::Int64(_) => ProtoType::Int64,
+            ProtoFieldValue::Uint32(_) => ProtoType::Uint32,
+            ProtoFieldValue::Uint64(_) => ProtoType::Uint64,
+            ProtoFieldValue::Bool(_) => ProtoType::Bool,
+            ProtoFieldValue::String(_) => ProtoType::String,
+            ProtoFieldValue::Bytes(_) => ProtoType::Bytes,
+            ProtoFieldValue::Message(_) => ProtoType::Message("message".into()),
+            ProtoFieldValue::Repeated(_) => ProtoType::Repeated(Box::new(ProtoType::Null)), // Placeholder,
+            ProtoFieldValue::Null => ProtoType::Null,
+        }
+    }
+}
+
+/// Runtime protobuf decoder
+pub struct ProtoDecoder {
+    schema: ProtoSchema,
+}
+
+impl ProtoDecoder {
+    /// Create a new decoder from a schema
+    pub fn new(schema: ProtoSchema) -> Self {
+        Self { schema }
+    }
+
+    /// Decode a protobuf message from bytes
+    pub fn decode(&self, message_type: &str, data: &[u8]) -> Result<ProtoMessage> {
+        let descriptor = self.schema.get_message(message_type)?;
+        let mut stream = CodedInputStream::from_bytes(data);
+        self.decode_message(descriptor, &mut stream)
+    }
+
+    fn decode_message(
+        &self,
+        descriptor: &ProtoMessageDescriptor,
+        stream: &mut CodedInputStream,
+    ) -> Result<ProtoMessage> {
+        let mut fields = HashMap::new();
+
+        loop {
+            if stream
+                .eof()
+                .map_err(|e| Error::ProtobufDecode(e.to_string()))?
+            {
+                break;
+            }
+
+            let tag = stream
+                .read_raw_varint32()
+                .map_err(|e| Error::ProtobufDecode(e.to_string()))?;
+
+            if tag == 0 {
+                break;
+            }
+
+            let field_number = (tag >> 3) as i32;
+
+            // Find the field descriptor by number
+            let field_desc = descriptor
+                .fields
+                .values()
+                .find(|f| f.number == field_number)
+                .ok_or_else(|| {
+                    Error::ProtobufDecode(format!(
+                        "Unknown field number: {} in message {}",
+                        field_number, descriptor.name
+                    ))
+                })?;
+
+            let value = if field_desc.is_repeated {
+                let existing = fields
+                    .entry(field_desc.name.clone())
+                    .or_insert_with(|| ProtoFieldValue::Repeated(Vec::new()));
+
+                if let ProtoFieldValue::Repeated(values) = existing {
+                    let new_value = self.decode_field_value(field_desc, stream)?;
+                    values.push(new_value);
+                }
+                continue;
+            } else {
+                self.decode_field_value(field_desc, stream)?
+            };
+
+            fields.insert(field_desc.name.clone(), value);
+        }
+
+        Ok(ProtoMessage {
+            message_type: descriptor.name.clone(),
+            fields,
+            descriptor: descriptor.clone(),
+        })
+    }
+
+    fn decode_field_value(
+        &self,
+        field_desc: &ProtoFieldDescriptor,
+        stream: &mut CodedInputStream,
+    ) -> Result<ProtoFieldValue> {
+        match &field_desc.field_type {
+            ProtoType::Double => {
+                let v = stream
+                    .read_double()
+                    .map_err(|e| Error::ProtobufDecode(e.to_string()))?;
+                Ok(ProtoFieldValue::Double(v))
+            }
+            ProtoType::Float => {
+                let v = stream
+                    .read_float()
+                    .map_err(|e| Error::ProtobufDecode(e.to_string()))?;
+                Ok(ProtoFieldValue::Float(v))
+            }
+            ProtoType::Int32 | ProtoType::Sint32 | ProtoType::Sfixed32 => {
+                let v = stream
+                    .read_int32()
+                    .map_err(|e| Error::ProtobufDecode(e.to_string()))?;
+                Ok(ProtoFieldValue::Int32(v))
+            }
+            ProtoType::Int64 | ProtoType::Sint64 | ProtoType::Sfixed64 => {
+                let v = stream
+                    .read_int64()
+                    .map_err(|e| Error::ProtobufDecode(e.to_string()))?;
+                Ok(ProtoFieldValue::Int64(v))
+            }
+            ProtoType::Uint32 | ProtoType::Fixed32 => {
+                let v = stream
+                    .read_uint32()
+                    .map_err(|e| Error::ProtobufDecode(e.to_string()))?;
+                Ok(ProtoFieldValue::Uint32(v))
+            }
+            ProtoType::Uint64 | ProtoType::Fixed64 => {
+                let v = stream
+                    .read_uint64()
+                    .map_err(|e| Error::ProtobufDecode(e.to_string()))?;
+                Ok(ProtoFieldValue::Uint64(v))
+            }
+            ProtoType::Bool => {
+                let v = stream
+                    .read_bool()
+                    .map_err(|e| Error::ProtobufDecode(e.to_string()))?;
+                Ok(ProtoFieldValue::Bool(v))
+            }
+            ProtoType::String => {
+                let v = stream
+                    .read_string()
+                    .map_err(|e| Error::ProtobufDecode(e.to_string()))?;
+                Ok(ProtoFieldValue::String(v))
+            }
+            ProtoType::Bytes => {
+                let v = stream
+                    .read_bytes()
+                    .map_err(|e| Error::ProtobufDecode(e.to_string()))?;
+                Ok(ProtoFieldValue::Bytes(v.to_vec()))
+            }
+            ProtoType::Message(type_name) => {
+                let len = stream
+                    .read_uint32()
+                    .map_err(|e| Error::ProtobufDecode(e.to_string()))?;
+                let old_limit = stream
+                    .push_limit(len as u64)
+                    .map_err(|e| Error::ProtobufDecode(e.to_string()))?;
+
+                // Extract just the type name without package prefix
+                let simple_type = type_name.split('.').next_back().unwrap_or(type_name);
+                let nested_descriptor = self.schema.get_message(simple_type)?;
+                let nested_message = self.decode_message(nested_descriptor, stream)?;
+
+                stream.pop_limit(old_limit);
+
+                Ok(ProtoFieldValue::Message(Box::new(nested_message)))
+            }
+            ProtoType::Enum(_) => {
+                let v = stream
+                    .read_int32()
+                    .map_err(|e| Error::ProtobufDecode(e.to_string()))?;
+                Ok(ProtoFieldValue::Int32(v))
+            }
+            _ => Err(Error::ProtobufDecode(format!(
+                "Unsupported field type: {:?}",
+                field_desc.field_type
+            ))),
+        }
+    }
+}
+
+impl ProtoMessage {
+    /// List all field names in this message
+    pub fn list_fields(&self) -> Vec<String> {
+        self.descriptor.field_order.clone()
+    }
+
+    /// Get a field value by name
+    pub fn get_field(&self, name: &str) -> Result<&ProtoFieldValue> {
+        self.fields
+            .get(name)
+            .ok_or_else(|| Error::FieldNotFound(name.to_string()))
+    }
+
+    /// Get a field value as a specific type
+    pub fn get_string(&self, name: &str) -> Result<&str> {
+        match self.get_field(name)? {
+            ProtoFieldValue::String(s) => Ok(s),
+            other => Err(Error::InvalidFieldType {
+                expected: ProtoType::String,
+                actual: other.proto_field_type(),
+            }),
+        }
+    }
+
+    pub fn get_int64(&self, name: &str) -> Result<i64> {
+        match self.get_field(name)? {
+            ProtoFieldValue::Int64(v) => Ok(*v),
+            other => Err(Error::InvalidFieldType {
+                expected: ProtoType::Int64,
+                actual: other.proto_field_type(),
+            }),
+        }
+    }
+
+    pub fn get_int32(&self, name: &str) -> Result<i32> {
+        match self.get_field(name)? {
+            ProtoFieldValue::Int32(v) => Ok(*v),
+            other => Err(Error::InvalidFieldType {
+                expected: ProtoType::Int32,
+                actual: other.proto_field_type(),
+            }),
+        }
+    }
+
+    pub fn get_uint64(&self, name: &str) -> Result<u64> {
+        match self.get_field(name)? {
+            ProtoFieldValue::Uint64(v) => Ok(*v),
+            other => Err(Error::InvalidFieldType {
+                expected: ProtoType::Uint64,
+                actual: other.proto_field_type(),
+            }),
+        }
+    }
+
+    pub fn get_uint32(&self, name: &str) -> Result<u32> {
+        match self.get_field(name)? {
+            ProtoFieldValue::Uint32(v) => Ok(*v),
+            other => Err(Error::InvalidFieldType {
+                expected: ProtoType::Uint32,
+                actual: other.proto_field_type(),
+            }),
+        }
+    }
+
+    pub fn get_bool(&self, name: &str) -> Result<bool> {
+        match self.get_field(name)? {
+            ProtoFieldValue::Bool(v) => Ok(*v),
+            other => Err(Error::InvalidFieldType {
+                expected: ProtoType::Bool,
+                actual: other.proto_field_type(),
+            }),
+        }
+    }
+
+    pub fn get_double(&self, name: &str) -> Result<f64> {
+        match self.get_field(name)? {
+            ProtoFieldValue::Double(v) => Ok(*v),
+            other => Err(Error::InvalidFieldType {
+                expected: ProtoType::Double,
+                actual: other.proto_field_type(),
+            }),
+        }
+    }
+
+    pub fn get_float(&self, name: &str) -> Result<f32> {
+        match self.get_field(name)? {
+            ProtoFieldValue::Float(v) => Ok(*v),
+            other => Err(Error::InvalidFieldType {
+                expected: ProtoType::Float,
+                actual: other.proto_field_type(),
+            }),
+        }
+    }
+
+    pub fn get_bytes(&self, name: &str) -> Result<&[u8]> {
+        match self.get_field(name)? {
+            ProtoFieldValue::Bytes(v) => Ok(v),
+            other => Err(Error::InvalidFieldType {
+                expected: ProtoType::Bytes,
+                actual: other.proto_field_type(),
+            }),
+        }
+    }
+
+    pub fn get_message(&self, name: &str) -> Result<&ProtoMessage> {
+        match self.get_field(name)? {
+            ProtoFieldValue::Message(m) => Ok(m),
+            other => Err(Error::InvalidFieldType {
+                expected: ProtoType::Message("".to_string()), // Placeholder
+                actual: other.proto_field_type(),
+            }),
+        }
+    }
+
+    pub fn get_repeated(&self, name: &str) -> Result<&[ProtoFieldValue]> {
+        match self.get_field(name)? {
+            ProtoFieldValue::Repeated(values) => Ok(values),
+            other => Err(Error::InvalidFieldType {
+                expected: ProtoType::Repeated(Box::new(ProtoType::Null)), // Placeholder
+                actual: other.proto_field_type(),
+            }),
+        }
+    }
+}

--- a/kafka/src/proto/parser.rs
+++ b/kafka/src/proto/parser.rs
@@ -1,0 +1,254 @@
+use crate::error::{Error, Result};
+use protobuf_parse::Parser;
+use std::collections::HashMap;
+use std::path::Path;
+
+/// Represents a parsed protobuf schema
+#[derive(Debug, Clone)]
+pub struct ProtoSchema {
+    /// Map of message type names to their field descriptors
+    pub(crate) messages: HashMap<String, ProtoMessageDescriptor>,
+}
+
+/// Describes a protobuf message type
+#[derive(Debug, Clone)]
+pub struct ProtoMessageDescriptor {
+    /// Fully qualified message name (e.g., "mypackage.MyMessage")
+    pub name: String,
+    /// Map of field names to their descriptors
+    pub fields: HashMap<String, ProtoFieldDescriptor>,
+    /// Ordered list of field names
+    pub field_order: Vec<String>,
+}
+
+/// Describes a single field in a message
+#[derive(Debug, Clone)]
+pub struct ProtoFieldDescriptor {
+    /// Field name
+    pub name: String,
+    /// Field number (tag)
+    pub number: i32,
+    /// Field type
+    pub field_type: ProtoType,
+    /// Whether the field is repeated
+    pub is_repeated: bool,
+    /// Whether the field is optional
+    pub is_optional: bool,
+}
+
+/// Protobuf field types
+#[derive(Debug, Clone, PartialEq)]
+pub enum ProtoType {
+    Double,
+    Float,
+    Int32,
+    Int64,
+    Uint32,
+    Uint64,
+    Sint32,
+    Sint64,
+    Fixed32,
+    Fixed64,
+    Sfixed32,
+    Sfixed64,
+    Bool,
+    String,
+    Bytes,
+    Message(String), // Nested message type name
+    Enum(String),    // Enum type name
+    Repeated(Box<ProtoType>),
+    Optional(Box<ProtoType>),
+    Null,
+}
+
+impl std::fmt::Display for ProtoType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.type_name())
+    }
+}
+
+impl ProtoType {
+    pub fn type_name(&self) -> String {
+        match self {
+            ProtoType::Double => "double".to_string(),
+            ProtoType::Float => "float".to_string(),
+            ProtoType::Int32 => "int32".to_string(),
+            ProtoType::Int64 => "int64".to_string(),
+            ProtoType::Uint32 => "uint32".to_string(),
+            ProtoType::Uint64 => "uint64".to_string(),
+            ProtoType::Sint32 => "sint32".to_string(),
+            ProtoType::Sint64 => "sint64".to_string(),
+            ProtoType::Fixed32 => "fixed32".to_string(),
+            ProtoType::Fixed64 => "fixed64".to_string(),
+            ProtoType::Sfixed32 => "sfixed32".to_string(),
+            ProtoType::Sfixed64 => "sfixed64".to_string(),
+            ProtoType::Bool => "bool".to_string(),
+            ProtoType::String => "string".to_string(),
+            ProtoType::Bytes => "bytes".to_string(),
+            ProtoType::Message(name) => format!("message:{name}"),
+            ProtoType::Enum(name) => format!("enum:{name}"),
+            ProtoType::Repeated(inner) => format!("repeated<{}>", inner.type_name()),
+            ProtoType::Optional(inner) => format!("optional<{}>", inner.type_name()),
+            ProtoType::Null => "null".to_string(),
+        }
+    }
+}
+
+impl ProtoSchema {
+    /// Parse a .proto file and create a schema
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let path = path.as_ref();
+        let content = std::fs::read_to_string(path)?;
+        Self::from_string(&content)
+    }
+
+    /// Parse a .proto file content from string
+    pub fn from_string(content: &str) -> Result<Self> {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        // Write content to a temporary file
+        let mut temp_file = NamedTempFile::new()
+            .map_err(|e| Error::ProtobufParse(format!("Failed to create temp file: {e}")))?;
+        temp_file
+            .write_all(content.as_bytes())
+            .map_err(|e| Error::ProtobufParse(format!("Failed to write temp file: {e}")))?;
+        let temp_path = temp_file.path();
+
+        // Parse using protobuf_parse
+        let mut parser = Parser::new();
+        parser.input(temp_path);
+        let parsed = parser
+            .parse_and_typecheck()
+            .map_err(|e| Error::ProtobufParse(e.to_string()))?;
+
+        let file_descriptor = parsed
+            .file_descriptors
+            .into_iter()
+            .next()
+            .ok_or_else(|| Error::ProtobufParse("No file descriptor found".to_string()))?;
+
+        let mut messages = HashMap::new();
+
+        // Extract all message types from the file descriptor
+        for message in &file_descriptor.message_type {
+            let mut fields = HashMap::new();
+            let mut field_order = Vec::new();
+
+            for field in &message.field {
+                let field_name = field.name.clone().unwrap_or_default();
+                if field_name.is_empty() {
+                    continue;
+                }
+                field_order.push(field_name.clone());
+
+                let field_type = Self::parse_field_type(field)?;
+
+                let descriptor = ProtoFieldDescriptor {
+                    name: field_name.clone(),
+                    number: field.number.unwrap_or(0),
+                    field_type,
+                    is_repeated: field.label
+                        == Some(
+                            protobuf::descriptor::field_descriptor_proto::Label::LABEL_REPEATED
+                                .into(),
+                        ),
+                    is_optional: field.label
+                        == Some(
+                            protobuf::descriptor::field_descriptor_proto::Label::LABEL_OPTIONAL
+                                .into(),
+                        ),
+                };
+
+                fields.insert(field_name, descriptor);
+            }
+
+            let message_name_simple = message.name.clone().unwrap_or_default();
+            let message_name = if let Some(ref package) = file_descriptor.package {
+                format!("{package}.{message_name_simple}")
+            } else {
+                message_name_simple.clone()
+            };
+
+            messages.insert(
+                message_name_simple,
+                ProtoMessageDescriptor {
+                    name: message_name,
+                    fields,
+                    field_order,
+                },
+            );
+        }
+
+        Ok(ProtoSchema { messages })
+    }
+
+    fn parse_field_type(field: &protobuf::descriptor::FieldDescriptorProto) -> Result<ProtoType> {
+        use protobuf::descriptor::field_descriptor_proto::Type;
+
+        let field_type_enum_or_unknown = field
+            .type_
+            .ok_or_else(|| Error::ProtobufParse("Field missing type".to_string()))?;
+
+        // Convert EnumOrUnknown to the enum value
+        let field_type_enum = field_type_enum_or_unknown.enum_value_or_default();
+
+        Ok(match field_type_enum {
+            Type::TYPE_DOUBLE => ProtoType::Double,
+            Type::TYPE_FLOAT => ProtoType::Float,
+            Type::TYPE_INT64 => ProtoType::Int64,
+            Type::TYPE_UINT64 => ProtoType::Uint64,
+            Type::TYPE_INT32 => ProtoType::Int32,
+            Type::TYPE_FIXED64 => ProtoType::Fixed64,
+            Type::TYPE_FIXED32 => ProtoType::Fixed32,
+            Type::TYPE_BOOL => ProtoType::Bool,
+            Type::TYPE_STRING => ProtoType::String,
+            Type::TYPE_MESSAGE => {
+                let type_name = field.type_name.clone().unwrap_or_default();
+                ProtoType::Message(type_name)
+            }
+            Type::TYPE_BYTES => ProtoType::Bytes,
+            Type::TYPE_UINT32 => ProtoType::Uint32,
+            Type::TYPE_ENUM => {
+                let type_name = field.type_name.clone().unwrap_or_default();
+                ProtoType::Enum(type_name)
+            }
+            Type::TYPE_SFIXED32 => ProtoType::Sfixed32,
+            Type::TYPE_SFIXED64 => ProtoType::Sfixed64,
+            Type::TYPE_SINT32 => ProtoType::Sint32,
+            Type::TYPE_SINT64 => ProtoType::Sint64,
+            Type::TYPE_GROUP => {
+                return Err(Error::ProtobufParse(
+                    "TYPE_GROUP is Proto2 syntax only and deprecated hence not supported"
+                        .to_string(),
+                ))
+            }
+        })
+    }
+
+    /// Get a message descriptor by name
+    pub fn get_message(&self, name: &str) -> Result<&ProtoMessageDescriptor> {
+        self.messages
+            .get(name)
+            .ok_or_else(|| Error::MessageTypeNotFound(name.to_string()))
+    }
+
+    /// List all message types in the schema
+    pub fn list_messages(&self) -> Vec<String> {
+        self.messages.keys().cloned().collect()
+    }
+}
+
+impl ProtoMessageDescriptor {
+    /// Get a field descriptor by name
+    pub fn get_field(&self, name: &str) -> Result<&ProtoFieldDescriptor> {
+        self.fields
+            .get(name)
+            .ok_or_else(|| Error::FieldNotFound(name.to_string()))
+    }
+
+    /// List all field names in order
+    pub fn list_fields(&self) -> &[String] {
+        &self.field_order
+    }
+}


### PR DESCRIPTION
## What is the motivation?

I want to explore the possibility of supporting Kafka as a new source, without being forced to submit a single huge PR.

## What does this change do?

Adds `surreal_sync_kafka` sub-crate for isolating Kafka-related code that will be needed to support a potential Kafka source.

## What is your testing strategy?

There is only one example that demonstrates it compiles for now, as it's currently not used by surreal-sync.

## Have you read the [Contributing Guidelines](/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](/CONTRIBUTING.md)
