### PR TITLE
Fix loadtest to use appropriate runner for each preset

### DIFF
--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -50,6 +50,7 @@ jobs:
       preset: ${{ steps.set-inputs.outputs.preset }}
       timeout: ${{ steps.set-inputs.outputs.timeout }}
       row_count: ${{ steps.set-inputs.outputs.row_count }}
+      runner: ${{ steps.set-runner.outputs.runner }}
     steps:
       - name: Set inputs
         id: set-inputs
@@ -78,6 +79,25 @@ jobs:
           JSON_ARRAY=$(echo "$SOURCES" | tr ',' '\n' | jq -R . | jq -s -c .)
           echo "matrix={\"source\":$JSON_ARRAY}" >> $GITHUB_OUTPUT
 
+      # Select runner based on preset to optimize cost and resource utilization.
+      # Preset definitions: crates/loadtest-distributed/src/preset.rs
+      # Schema files: loadtest/config/schemas/{small,medium,large}.yaml
+      #
+      # | Preset | Runner    | Containers | Tables | Sync CPU | DB CPU | SurrealDB CPU |
+      # |--------|-----------|------------|--------|----------|--------|---------------|
+      # | small  | 4-cores   | 2          | 2      | 1.0      | 1.0    | 1.0           |
+      # | medium | 8-cores   | 4          | 4      | 2.0      | 2.0    | 2.0           |
+      # | large  | 16-cores  | 8          | 8      | 5.0      | 5.0    | 5.0           |
+      - name: Set runner based on preset
+        id: set-runner
+        run: |
+          case "${{ steps.set-inputs.outputs.preset }}" in
+            small)  echo "runner=ubuntu-latest-4-cores" >> $GITHUB_OUTPUT ;;
+            medium) echo "runner=ubuntu-latest-8-cores" >> $GITHUB_OUTPUT ;;
+            large)  echo "runner=ubuntu-latest-16-cores" >> $GITHUB_OUTPUT ;;
+            *)      echo "runner=ubuntu-latest-4-cores" >> $GITHUB_OUTPUT ;;
+          esac
+
   # Build Docker image (Dockerfile handles cargo build internally)
   build:
     needs: setup
@@ -101,7 +121,7 @@ jobs:
   # Run loadtest for each source
   loadtest:
     needs: [setup, build]
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ needs.setup.outputs.runner }}
     strategy:
       matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
       fail-fast: false

--- a/crates/loadtest-distributed/src/preset.rs
+++ b/crates/loadtest-distributed/src/preset.rs
@@ -59,6 +59,7 @@ impl Preset {
     }
 
     /// Small preset: 2 containers, 10K rows.
+    /// Optimized for 4-core runner: 2×0.5 + 1.0 + 1.0 = 3.0 cores
     pub fn small() -> Self {
         Self {
             size: PresetSize::Small,
@@ -91,18 +92,19 @@ impl Preset {
     }
 
     /// Medium preset: 4 containers, 100K rows.
+    /// Optimized for 8-core runner: 4×0.5 + 2.0 + 2.0 = 6.0 cores
     pub fn medium() -> Self {
         Self {
             size: PresetSize::Medium,
             num_containers: 4,
             container_resources: ResourceLimits {
-                cpu_limit: "1.0".to_string(),
-                memory_limit: "1Gi".to_string(),
-                cpu_request: Some("0.5".to_string()),
-                memory_request: Some("512Mi".to_string()),
+                cpu_limit: "0.5".to_string(),
+                memory_limit: "512Mi".to_string(),
+                cpu_request: Some("0.25".to_string()),
+                memory_request: Some("256Mi".to_string()),
             },
             container_tmpfs: TmpfsConfig {
-                size: "1Gi".to_string(),
+                size: "512Mi".to_string(),
                 path: "/data".to_string(),
             },
             database_resources: ResourceLimits {
@@ -123,30 +125,31 @@ impl Preset {
     }
 
     /// Large preset: 8 containers, 1M rows.
+    /// Optimized for 16-core runner: 8×0.625 + 5.0 + 5.0 = 15.0 cores
     pub fn large() -> Self {
         Self {
             size: PresetSize::Large,
             num_containers: 8,
             container_resources: ResourceLimits {
-                cpu_limit: "2.0".to_string(),
-                memory_limit: "4Gi".to_string(),
-                cpu_request: Some("1.0".to_string()),
-                memory_request: Some("2Gi".to_string()),
+                cpu_limit: "0.625".to_string(),
+                memory_limit: "512Mi".to_string(),
+                cpu_request: Some("0.3".to_string()),
+                memory_request: Some("256Mi".to_string()),
             },
             container_tmpfs: TmpfsConfig {
-                size: "4Gi".to_string(),
+                size: "512Mi".to_string(),
                 path: "/data".to_string(),
             },
             database_resources: ResourceLimits {
-                cpu_limit: "4.0".to_string(),
+                cpu_limit: "5.0".to_string(),
                 memory_limit: "8Gi".to_string(),
-                cpu_request: Some("2.0".to_string()),
+                cpu_request: Some("2.5".to_string()),
                 memory_request: Some("4Gi".to_string()),
             },
             surrealdb_resources: ResourceLimits {
-                cpu_limit: "4.0".to_string(),
+                cpu_limit: "5.0".to_string(),
                 memory_limit: "8Gi".to_string(),
-                cpu_request: Some("2.0".to_string()),
+                cpu_request: Some("2.5".to_string()),
                 memory_request: Some("4Gi".to_string()),
             },
             row_count: 1_000_000,
@@ -218,7 +221,7 @@ mod tests {
 
         assert_eq!(preset.num_containers, 6);
         assert_eq!(preset.container_resources.cpu_limit, "3.0");
-        assert_eq!(preset.container_resources.memory_limit, "1Gi"); // unchanged
+        assert_eq!(preset.container_resources.memory_limit, "512Mi"); // unchanged
         assert_eq!(preset.row_count, 500_000);
     }
 }

--- a/loadtest/config/schemas/large.yaml
+++ b/loadtest/config/schemas/large.yaml
@@ -1,0 +1,330 @@
+# Large preset schema: 8 tables for 8 containers
+# Each container handles 1 table for optimal distribution.
+version: 1
+
+tables:
+  - name: users
+    id:
+      type: big_int
+      generator:
+        type: sequential
+        start: 1
+    fields:
+      - name: username
+        type:
+          type: var_char
+          length: 50
+        generator:
+          type: pattern
+          pattern: "user_{index}"
+      - name: email
+        type:
+          type: var_char
+          length: 100
+        generator:
+          type: pattern
+          pattern: "user_{index}@test.com"
+      - name: created_at
+        type: date_time
+        generator:
+          type: timestamp_range
+          start: "2024-01-01T00:00:00Z"
+          end: "2024-12-31T23:59:59Z"
+      - name: is_active
+        type: bool
+        generator:
+          type: weighted_bool
+          true_weight: 0.8
+      - name: profile_data
+        type: json
+        generator:
+          type: static
+          value:
+            version: 1
+            source: "loadtest"
+
+  - name: products
+    id:
+      type: big_int
+      generator:
+        type: sequential
+        start: 1
+    fields:
+      - name: name
+        type:
+          type: var_char
+          length: 100
+        generator:
+          type: pattern
+          pattern: "Product {index}"
+      - name: description
+        type: text
+        generator:
+          type: pattern
+          pattern: "Description for product {index}"
+      - name: price
+        type:
+          type: decimal
+          precision: 10
+          scale: 2
+        generator:
+          type: decimal_range
+          min: 1.0
+          max: 1000.0
+      - name: stock_quantity
+        type: int
+        generator:
+          type: int_range
+          min: 0
+          max: 1000
+      - name: created_at
+        type: date_time
+        generator:
+          type: timestamp_range
+          start: "2024-01-01T00:00:00Z"
+          end: "2024-12-31T23:59:59Z"
+      - name: updated_at
+        type: date_time
+        generator:
+          type: timestamp_range
+          start: "2024-01-01T00:00:00Z"
+          end: "2024-12-31T23:59:59Z"
+
+  - name: orders
+    id:
+      type: big_int
+      generator:
+        type: sequential
+        start: 1
+    fields:
+      - name: user_id
+        type: big_int
+        generator:
+          type: int_range
+          min: 1
+          max: 1000
+      - name: total_amount
+        type:
+          type: decimal
+          precision: 12
+          scale: 2
+        generator:
+          type: decimal_range
+          min: 10.0
+          max: 5000.0
+      - name: status
+        type:
+          type: var_char
+          length: 20
+        generator:
+          type: one_of
+          values: ["pending", "completed", "shipped", "cancelled"]
+      - name: created_at
+        type: date_time
+        generator:
+          type: timestamp_range
+          start: "2024-01-01T00:00:00Z"
+          end: "2024-12-31T23:59:59Z"
+      - name: shipped_at
+        type: date_time
+        generator:
+          type: timestamp_range
+          start: "2024-01-01T00:00:00Z"
+          end: "2024-12-31T23:59:59Z"
+
+  - name: order_items
+    id:
+      type: big_int
+      generator:
+        type: sequential
+        start: 1
+    fields:
+      - name: order_id
+        type: big_int
+        generator:
+          type: int_range
+          min: 1
+          max: 1000
+      - name: product_id
+        type: big_int
+        generator:
+          type: int_range
+          min: 1
+          max: 1000
+      - name: quantity
+        type: int
+        generator:
+          type: int_range
+          min: 1
+          max: 10
+      - name: unit_price
+        type:
+          type: decimal
+          precision: 10
+          scale: 2
+        generator:
+          type: decimal_range
+          min: 1.0
+          max: 500.0
+
+  - name: reviews
+    id:
+      type: big_int
+      generator:
+        type: sequential
+        start: 1
+    fields:
+      - name: user_id
+        type: big_int
+        generator:
+          type: int_range
+          min: 1
+          max: 1000
+      - name: product_id
+        type: big_int
+        generator:
+          type: int_range
+          min: 1
+          max: 1000
+      - name: rating
+        type: int
+        generator:
+          type: int_range
+          min: 1
+          max: 5
+      - name: title
+        type:
+          type: var_char
+          length: 100
+        generator:
+          type: pattern
+          pattern: "Review {index}"
+      - name: content
+        type: text
+        generator:
+          type: pattern
+          pattern: "Review content for item {index}"
+      - name: created_at
+        type: date_time
+        generator:
+          type: timestamp_range
+          start: "2024-01-01T00:00:00Z"
+          end: "2024-12-31T23:59:59Z"
+
+  - name: inventory
+    id:
+      type: big_int
+      generator:
+        type: sequential
+        start: 1
+    fields:
+      - name: product_id
+        type: big_int
+        generator:
+          type: int_range
+          min: 1
+          max: 1000
+      - name: warehouse_id
+        type: int
+        generator:
+          type: int_range
+          min: 1
+          max: 10
+      - name: quantity
+        type: int
+        generator:
+          type: int_range
+          min: 0
+          max: 10000
+      - name: reserved
+        type: int
+        generator:
+          type: int_range
+          min: 0
+          max: 100
+      - name: last_restock
+        type: date_time
+        generator:
+          type: timestamp_range
+          start: "2024-01-01T00:00:00Z"
+          end: "2024-12-31T23:59:59Z"
+
+  - name: categories
+    id:
+      type: big_int
+      generator:
+        type: sequential
+        start: 1
+    fields:
+      - name: name
+        type:
+          type: var_char
+          length: 100
+        generator:
+          type: pattern
+          pattern: "Category {index}"
+      - name: description
+        type: text
+        generator:
+          type: pattern
+          pattern: "Description for category {index}"
+      - name: parent_id
+        type: big_int
+        generator:
+          type: int_range
+          min: 0
+          max: 100
+      - name: is_active
+        type: bool
+        generator:
+          type: weighted_bool
+          true_weight: 0.9
+      - name: created_at
+        type: date_time
+        generator:
+          type: timestamp_range
+          start: "2024-01-01T00:00:00Z"
+          end: "2024-12-31T23:59:59Z"
+
+  - name: payments
+    id:
+      type: big_int
+      generator:
+        type: sequential
+        start: 1
+    fields:
+      - name: order_id
+        type: big_int
+        generator:
+          type: int_range
+          min: 1
+          max: 1000
+      - name: amount
+        type:
+          type: decimal
+          precision: 12
+          scale: 2
+        generator:
+          type: decimal_range
+          min: 10.0
+          max: 5000.0
+      - name: method
+        type:
+          type: var_char
+          length: 20
+        generator:
+          type: one_of
+          values: ["credit_card", "debit_card", "paypal", "bank_transfer"]
+      - name: status
+        type:
+          type: var_char
+          length: 20
+        generator:
+          type: one_of
+          values: ["pending", "completed", "failed", "refunded"]
+      - name: processed_at
+        type: date_time
+        generator:
+          type: timestamp_range
+          start: "2024-01-01T00:00:00Z"
+          end: "2024-12-31T23:59:59Z"

--- a/loadtest/config/schemas/medium.yaml
+++ b/loadtest/config/schemas/medium.yaml
@@ -1,0 +1,168 @@
+# Medium preset schema: 4 tables for 4 containers
+# Each container handles 1 table for optimal distribution.
+version: 1
+
+tables:
+  - name: users
+    id:
+      type: big_int
+      generator:
+        type: sequential
+        start: 1
+    fields:
+      - name: username
+        type:
+          type: var_char
+          length: 50
+        generator:
+          type: pattern
+          pattern: "user_{index}"
+      - name: email
+        type:
+          type: var_char
+          length: 100
+        generator:
+          type: pattern
+          pattern: "user_{index}@test.com"
+      - name: created_at
+        type: date_time
+        generator:
+          type: timestamp_range
+          start: "2024-01-01T00:00:00Z"
+          end: "2024-12-31T23:59:59Z"
+      - name: is_active
+        type: bool
+        generator:
+          type: weighted_bool
+          true_weight: 0.8
+      - name: profile_data
+        type: json
+        generator:
+          type: static
+          value:
+            version: 1
+            source: "loadtest"
+
+  - name: products
+    id:
+      type: big_int
+      generator:
+        type: sequential
+        start: 1
+    fields:
+      - name: name
+        type:
+          type: var_char
+          length: 100
+        generator:
+          type: pattern
+          pattern: "Product {index}"
+      - name: description
+        type: text
+        generator:
+          type: pattern
+          pattern: "Description for product {index}"
+      - name: price
+        type:
+          type: decimal
+          precision: 10
+          scale: 2
+        generator:
+          type: decimal_range
+          min: 1.0
+          max: 1000.0
+      - name: stock_quantity
+        type: int
+        generator:
+          type: int_range
+          min: 0
+          max: 1000
+      - name: created_at
+        type: date_time
+        generator:
+          type: timestamp_range
+          start: "2024-01-01T00:00:00Z"
+          end: "2024-12-31T23:59:59Z"
+      - name: updated_at
+        type: date_time
+        generator:
+          type: timestamp_range
+          start: "2024-01-01T00:00:00Z"
+          end: "2024-12-31T23:59:59Z"
+
+  - name: orders
+    id:
+      type: big_int
+      generator:
+        type: sequential
+        start: 1
+    fields:
+      - name: user_id
+        type: big_int
+        generator:
+          type: int_range
+          min: 1
+          max: 1000
+      - name: total_amount
+        type:
+          type: decimal
+          precision: 12
+          scale: 2
+        generator:
+          type: decimal_range
+          min: 10.0
+          max: 5000.0
+      - name: status
+        type:
+          type: var_char
+          length: 20
+        generator:
+          type: one_of
+          values: ["pending", "completed", "shipped", "cancelled"]
+      - name: created_at
+        type: date_time
+        generator:
+          type: timestamp_range
+          start: "2024-01-01T00:00:00Z"
+          end: "2024-12-31T23:59:59Z"
+      - name: shipped_at
+        type: date_time
+        generator:
+          type: timestamp_range
+          start: "2024-01-01T00:00:00Z"
+          end: "2024-12-31T23:59:59Z"
+
+  - name: order_items
+    id:
+      type: big_int
+      generator:
+        type: sequential
+        start: 1
+    fields:
+      - name: order_id
+        type: big_int
+        generator:
+          type: int_range
+          min: 1
+          max: 1000
+      - name: product_id
+        type: big_int
+        generator:
+          type: int_range
+          min: 1
+          max: 1000
+      - name: quantity
+        type: int
+        generator:
+          type: int_range
+          min: 1
+          max: 10
+      - name: unit_price
+        type:
+          type: decimal
+          precision: 10
+          scale: 2
+        generator:
+          type: decimal_range
+          min: 1.0
+          max: 500.0

--- a/loadtest/config/schemas/small.yaml
+++ b/loadtest/config/schemas/small.yaml
@@ -1,0 +1,91 @@
+# Small preset schema: 2 tables for 2 containers
+# Each container handles 1 table for optimal distribution.
+version: 1
+
+tables:
+  - name: users
+    id:
+      type: big_int
+      generator:
+        type: sequential
+        start: 1
+    fields:
+      - name: username
+        type:
+          type: var_char
+          length: 50
+        generator:
+          type: pattern
+          pattern: "user_{index}"
+      - name: email
+        type:
+          type: var_char
+          length: 100
+        generator:
+          type: pattern
+          pattern: "user_{index}@test.com"
+      - name: created_at
+        type: date_time
+        generator:
+          type: timestamp_range
+          start: "2024-01-01T00:00:00Z"
+          end: "2024-12-31T23:59:59Z"
+      - name: is_active
+        type: bool
+        generator:
+          type: weighted_bool
+          true_weight: 0.8
+      - name: profile_data
+        type: json
+        generator:
+          type: static
+          value:
+            version: 1
+            source: "loadtest"
+
+  - name: products
+    id:
+      type: big_int
+      generator:
+        type: sequential
+        start: 1
+    fields:
+      - name: name
+        type:
+          type: var_char
+          length: 100
+        generator:
+          type: pattern
+          pattern: "Product {index}"
+      - name: description
+        type: text
+        generator:
+          type: pattern
+          pattern: "Description for product {index}"
+      - name: price
+        type:
+          type: decimal
+          precision: 10
+          scale: 2
+        generator:
+          type: decimal_range
+          min: 1.0
+          max: 1000.0
+      - name: stock_quantity
+        type: int
+        generator:
+          type: int_range
+          min: 0
+          max: 1000
+      - name: created_at
+        type: date_time
+        generator:
+          type: timestamp_range
+          start: "2024-01-01T00:00:00Z"
+          end: "2024-12-31T23:59:59Z"
+      - name: updated_at
+        type: date_time
+        generator:
+          type: timestamp_range
+          start: "2024-01-01T00:00:00Z"
+          end: "2024-12-31T23:59:59Z"


### PR DESCRIPTION
## What is the motivation?

Previously, the loadtest workflow was using the 16 cores runner regardless of the preset selected, which resulted especially smaller presets did not leverage available cores and memory enough.

## What does this change do?

Enhanced the loadtest workflow and the presets and the schema files, so that each preset (small, medium, and large) uses different set of container resources (cpu, mem) and the runner size.

## What is your testing strategy?

Tested by running run_ci.py locally. Will trigger the workflow manually after this gets merged.

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](/CONTRIBUTING.md)
