### PR TITLE
Add test-pr workflow job step to prevent "No space left on device"

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -12,9 +12,25 @@ jobs:
       contents: read
       packages: read
     steps:
+    - name: Free disk space
+      run: |
+        echo "=== Disk usage BEFORE cleanup ==="
+        df -h
+        echo ""
+        # Remove pre-installed tools and libraries to free up disk space
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
+        # Clean up Docker images
+        docker system prune -af --volumes
+        echo ""
+        echo "=== Disk usage AFTER cleanup ==="
+        df -h
+
     - name: Checkout repository
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      
+
     - name: Run cargo tests in dev container
       uses: devcontainers/ci@8bf61b26e9c3a98f69cb6ce2f88d24ff59b785c6 # v0.3.1900000417
       with:


### PR DESCRIPTION
## What is the motivation?

`cargo-test` job is failing like https://github.com/surrealdb/surreal-sync/actions/runs/21052096785/job/60540468885?pr=37

## What does this change do?

Clean up unused tools before running the devcontainer-based test so that there is hopefully enough space to complete the test.

## What is your testing strategy?

See the `cargo-test` job succeeds or not on this PR and another PRs.

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](/CONTRIBUTING.md)
