### PR TITLE
Fix loadtest to not report incorrect sync container count

### DIFF
--- a/crates/loadtest-distributed/src/config.rs
+++ b/crates/loadtest-distributed/src/config.rs
@@ -277,6 +277,13 @@ pub struct ClusterConfig {
     /// Dry-run mode (populate/verify won't write data)
     #[serde(default)]
     pub dry_run: bool,
+    /// Number of sync containers (1 for most sources, N for Kafka where N = table count)
+    #[serde(default = "default_num_sync_containers")]
+    pub num_sync_containers: usize,
+}
+
+fn default_num_sync_containers() -> usize {
+    1
 }
 
 fn default_network_name() -> String {
@@ -361,6 +368,11 @@ pub fn build_cluster_config(
         proto_contents: None, // Set by caller for Kafka source on Kubernetes
         network_name: default_network_name(),
         dry_run,
+        num_sync_containers: if source_type == SourceType::Kafka {
+            tables.len()
+        } else {
+            1
+        },
     })
 }
 

--- a/crates/loadtest-distributed/src/generator/kubernetes.rs
+++ b/crates/loadtest-distributed/src/generator/kubernetes.rs
@@ -1350,6 +1350,7 @@ mod tests {
             proto_contents: None, // Only needed for Kafka source
             network_name: "loadtest".to_string(),
             dry_run,
+            num_sync_containers: 1, // MySQL uses single sync container
         }
     }
 


### PR DESCRIPTION
## What is the motivation?

To fix the loadtest for kafka source "seems failing" even though it's passing as far as I can see from related metrics.

Ref https://github.com/surrealdb/surreal-sync/actions/runs/21066140907

## What does this change do?

Following up on the work done in #37, making the run_ci.py to obtain the number of sync containers to wait from the generator, instead of guessing/hard-coding it.

## What is your testing strategy?

Trigger the loadtest after once this pull requst gets merged.

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](/CONTRIBUTING.md)
