### PR TITLE
fix: mac compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3408,6 +3408,7 @@ dependencies = [
  "clap",
  "comfy-table",
  "hostname",
+ "libc",
  "loadtest-generator",
  "nix",
  "num_cpus",

--- a/crates/loadtest-distributed/Cargo.toml
+++ b/crates/loadtest-distributed/Cargo.toml
@@ -26,8 +26,13 @@ serde_yaml = "0.9"
 # System info for environment verification
 sysinfo = "0.32"
 num_cpus = "1.16"
-nix = { version = "0.29", features = ["fs"] }
 hostname = "0.4"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+nix = { version = "0.29", features = ["fs"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = "0.2"
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
## What is the motivation?

Because of the `nix` dependency, `surreal-sync` was failing to build on mac os.

## What does this change do?

Added conditional compilation to use a different dependency when building on mac.

## What is your testing strategy?

Run postgres:

```bash
docker run --name some-postgres -e POSTGRES_PASSWORD=mysecretpassword -d -p 5432:5432 postgres
```

Get into the container to create the DB:

```bash
# get container id
docker ps

# login (update the container ID here)
docker exec -it 2a38fe566b7e bash

# login to postgres instance
psql -U postgres
```

```sql
# run sql to create db, table, PK, records
CREATE DATABASE oldschool;
CREATE TABLE users (
  name VARCHAR(255)
);
ALTER TABLE users ADD PRIMARY KEY (name);
INSERT INTO users (name) VALUES ('Martin');
```

Quit psql with `\q`.

Spin surrealdb up:

```bash
surreal start -u root -p root
```

Run `surreal-sync`:

```bash
cargo run from postgresql-trigger full --connection-string "postgresql://postgres:mysecretpassword@0.0.0.0:5432/postgres" --to-namespace test --to-database test --surreal-endpoint ws://0.0.0.0:8000/rpc
```

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](/CONTRIBUTING.md)
