### PR TITLE
Enable specifying SurrealDB container image for loadtesting

### DIFF
--- a/crates/loadtest-distributed/src/cli.rs
+++ b/crates/loadtest-distributed/src/cli.rs
@@ -167,6 +167,10 @@ pub struct GenerateArgs {
     /// Generate configs in dry-run mode (populate/verify won't write data)
     #[arg(long)]
     pub dry_run: bool,
+
+    /// SurrealDB Docker image (e.g., "surrealdb/surrealdb:v2.0.0")
+    #[arg(long)]
+    pub surrealdb_image: Option<String>,
 }
 
 /// Arguments for the aggregate command (file-based - deprecated in favor of aggregate-server).

--- a/crates/loadtest-distributed/src/config.rs
+++ b/crates/loadtest-distributed/src/config.rs
@@ -310,6 +310,7 @@ pub fn build_cluster_config(
     schema_path: Option<PathBuf>,
     tables: &[String],
     dry_run: bool,
+    surrealdb_image_override: Option<String>,
 ) -> Result<ClusterConfig> {
     // Get base preset
     let preset = Preset::by_size(preset_size).with_overrides(
@@ -350,6 +351,7 @@ pub fn build_cluster_config(
 
     // Build SurrealDB configuration
     let surrealdb = SurrealDbConfig {
+        image: surrealdb_image_override.unwrap_or_else(default_surrealdb_image),
         resources: preset.surrealdb_resources,
         ..Default::default()
     };

--- a/loadtest/Makefile
+++ b/loadtest/Makefile
@@ -85,6 +85,7 @@ OUTPUT_DIR ?= ./output
 IMAGE_NAME ?= surreal-sync:latest
 KIND_CLUSTER ?= loadtest
 PLATFORM ?= docker-compose
+SURREALDB_IMAGE ?= surrealdb/surrealdb:latest
 
 # Timeout and polling configuration
 TIMEOUT ?= 300
@@ -120,6 +121,7 @@ help:
 	@echo "  ROW_COUNT=$(ROW_COUNT)"
 	@echo "  OUTPUT_DIR=$(OUTPUT_DIR)"
 	@echo "  IMAGE_NAME=$(IMAGE_NAME)"
+	@echo "  SURREALDB_IMAGE=$(SURREALDB_IMAGE)"
 	@echo "  TIMEOUT=$(TIMEOUT) (seconds)"
 	@echo "  POLL_INTERVAL=$(POLL_INTERVAL) (seconds)"
 	@echo ""
@@ -145,7 +147,8 @@ generate: $(SCHEMA)
 		--schema $(SCHEMA) \
 		--output-dir $(OUTPUT_DIR) \
 		$(if $(WORKERS),--workers $(WORKERS)) \
-		$(if $(ROW_COUNT),--row-count $(ROW_COUNT))
+		$(if $(ROW_COUNT),--row-count $(ROW_COUNT)) \
+		$(if $(SURREALDB_IMAGE),--surrealdb-image $(SURREALDB_IMAGE))
 
 # Stop and remove containers
 down:
@@ -432,9 +435,9 @@ kind-load: docker-build
 	@echo "Loading busybox image for init containers..."
 	docker pull busybox:latest 2>/dev/null || true
 	kind load docker-image busybox:latest --name $(KIND_CLUSTER) 2>/dev/null || true
-	@echo "Loading SurrealDB image..."
-	docker pull surrealdb/surrealdb:latest 2>/dev/null || true
-	kind load docker-image surrealdb/surrealdb:latest --name $(KIND_CLUSTER) 2>/dev/null || true
+	@echo "Loading SurrealDB image ($(SURREALDB_IMAGE))..."
+	docker pull $(SURREALDB_IMAGE) 2>/dev/null || true
+	kind load docker-image $(SURREALDB_IMAGE) --name $(KIND_CLUSTER) 2>/dev/null || true
 	@echo "Loading source-specific image for $(SOURCE)..."
 	@$(MAKE) -s kind-load-source-image SOURCE=$(SOURCE)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2951,6 +2951,7 @@ async fn run_loadtest_generate(args: GenerateArgs) -> anyhow::Result<()> {
         Some(args.schema.clone()),
         &tables,
         args.dry_run,
+        args.surrealdb_image.clone(),
     )?;
 
     // Set schema content for Kubernetes ConfigMap embedding


### PR DESCRIPTION
## What is the motivation?

surreal-sync currently supports v2.x only

## What does this change do?

Enhances the load testing harness to support specifying which SurrealDB version/image to use, making it easier to see which SurrealDB version works with surreal-sync.

## What is your testing strategy?

Ran the loadtests with various SurrealDB versions locally.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](/CONTRIBUTING.md)
