### PR TITLE
Add support for neo4j composite

### DIFF
--- a/crates/neo4j-source/src/full_sync.rs
+++ b/crates/neo4j-source/src/full_sync.rs
@@ -166,30 +166,13 @@ pub async fn run_full_sync<S: SurrealSink, CS: CheckpointStore>(
     let mut total_migrated = 0;
 
     // Migrate nodes first and track min/max timestamps
-    let (nodes_migrated, nodes_min_ts, nodes_max_ts) = migrate_neo4j_nodes(
-        &graph,
-        surreal,
-        &sync_opts,
-        &ctx,
-        &from_opts.labels,
-        &from_opts.change_tracking_property,
-        &from_opts.id_property,
-        &from_opts.composite_constituent,
-    )
-    .await?;
+    let (nodes_migrated, nodes_min_ts, nodes_max_ts) =
+        migrate_neo4j_nodes(&graph, surreal, &sync_opts, &ctx, &from_opts).await?;
     total_migrated += nodes_migrated;
 
     // Then migrate relationships and track min/max timestamps
-    let (rels_migrated, rels_min_ts, rels_max_ts) = migrate_neo4j_relationships(
-        &graph,
-        surreal,
-        &sync_opts,
-        &ctx,
-        &from_opts.change_tracking_property,
-        &from_opts.id_property,
-        &from_opts.composite_constituent,
-    )
-    .await?;
+    let (rels_migrated, rels_min_ts, rels_max_ts) =
+        migrate_neo4j_relationships(&graph, surreal, &sync_opts, &ctx, &from_opts).await?;
     total_migrated += rels_migrated;
 
     // Compute overall min/max timestamps from both nodes and relationships
@@ -303,10 +286,7 @@ async fn migrate_neo4j_nodes<S: SurrealSink>(
     surreal: &S,
     sync_opts: &SyncOpts,
     ctx: &Neo4jConversionContext,
-    labels_filter: &[String],
-    tracking_property: &str,
-    id_property: &str,
-    composite_constituent: &Option<String>,
+    from_opts: &SourceOpts,
 ) -> anyhow::Result<(
     usize,
     Option<chrono::DateTime<chrono::Utc>>,
@@ -318,9 +298,12 @@ async fn migrate_neo4j_nodes<S: SurrealSink>(
     let mut max_timestamp: Option<chrono::DateTime<chrono::Utc>> = None;
 
     // Determine which labels to process
-    let labels_to_process: Vec<String> = if labels_filter.is_empty() {
+    let labels_to_process: Vec<String> = if from_opts.labels.is_empty() {
         // No filter - get all distinct labels from the database
-        let label_query = Query::new(with_use_clause("MATCH (n) RETURN DISTINCT labels(n) as labels", composite_constituent));
+        let label_query = Query::new(with_use_clause(
+            "MATCH (n) RETURN DISTINCT labels(n) as labels",
+            &from_opts.composite_constituent,
+        ));
         let mut result = graph.execute(label_query).await?;
 
         let mut all_labels = std::collections::HashSet::new();
@@ -337,10 +320,10 @@ async fn migrate_neo4j_nodes<S: SurrealSink>(
     } else {
         tracing::info!(
             "Filtering to {} specified labels: {:?}",
-            labels_filter.len(),
-            labels_filter
+            from_opts.labels.len(),
+            from_opts.labels
         );
-        labels_filter.to_vec()
+        from_opts.labels.to_vec()
     };
 
     let mut total_migrated = 0;
@@ -349,9 +332,10 @@ async fn migrate_neo4j_nodes<S: SurrealSink>(
     for label in labels_to_process {
         tracing::info!("Migrating nodes with label: {}", label);
 
-        let node_query = Query::new(
-            with_use_clause("MATCH (n) WHERE $label IN labels(n) RETURN n, id(n) as node_id", composite_constituent),
-        )
+        let node_query = Query::new(with_use_clause(
+            "MATCH (n) WHERE $label IN labels(n) RETURN n, id(n) as node_id",
+            &from_opts.composite_constituent,
+        ))
         .param("label", label.clone());
         let mut node_result = graph.execute(node_query).await?;
 
@@ -359,11 +343,12 @@ async fn migrate_neo4j_nodes<S: SurrealSink>(
         let mut processed = 0;
 
         while let Some(row) = node_result.next().await? {
-            let universal_row = convert_neo4j_row_to_universal_row(&row, &label, ctx, id_property)?;
+            let universal_row =
+                convert_neo4j_row_to_universal_row(&row, &label, ctx, &from_opts.id_property)?;
 
             // Extract tracking property timestamp if present
             if let Some(UniversalValue::LocalDateTime(ts)) =
-                universal_row.get_field(tracking_property)
+                universal_row.get_field(&from_opts.change_tracking_property)
             {
                 min_timestamp = Some(min_timestamp.map_or(*ts, |min| min.min(*ts)));
                 max_timestamp = Some(max_timestamp.map_or(*ts, |max| max.max(*ts)));
@@ -439,9 +424,7 @@ async fn migrate_neo4j_relationships<S: SurrealSink>(
     surreal: &S,
     sync_opts: &SyncOpts,
     ctx: &Neo4jConversionContext,
-    tracking_property: &str,
-    id_property: &str,
-    composite_constituent: &Option<String>,
+    from_opts: &SourceOpts,
 ) -> anyhow::Result<(
     usize,
     Option<chrono::DateTime<chrono::Utc>>,
@@ -453,7 +436,10 @@ async fn migrate_neo4j_relationships<S: SurrealSink>(
     let mut max_timestamp: Option<chrono::DateTime<chrono::Utc>> = None;
 
     // Get all distinct relationship types first
-    let type_query = Query::new(with_use_clause("MATCH ()-[r]->() RETURN DISTINCT type(r) as rel_type", composite_constituent));
+    let type_query = Query::new(with_use_clause(
+        "MATCH ()-[r]->() RETURN DISTINCT type(r) as rel_type",
+        &from_opts.composite_constituent,
+    ));
     let mut result = graph.execute(type_query).await?;
 
     let mut all_types = std::collections::HashSet::new();
@@ -471,12 +457,16 @@ async fn migrate_neo4j_relationships<S: SurrealSink>(
     for rel_type in all_types {
         tracing::info!("Migrating relationships of type: {}", rel_type);
 
-        let rel_query = Query::new(with_use_clause(&format!(
-            "MATCH (start_node)-[r]->(end_node) WHERE type(r) = $rel_type
+        let id_property = &from_opts.id_property;
+        let rel_query = Query::new(with_use_clause(
+            &format!(
+                "MATCH (start_node)-[r]->(end_node) WHERE type(r) = $rel_type
              RETURN r, id(r) as rel_id, id(start_node) as start_id, id(end_node) as end_id,
              labels(start_node) as start_labels, labels(end_node) as end_labels,
              start_node.{id_property} as start_prop_id, end_node.{id_property} as end_prop_id",
-        ), composite_constituent))
+            ),
+            &from_opts.composite_constituent,
+        ))
         .param("rel_type", rel_type.clone());
         let mut rel_result = graph.execute(rel_query).await?;
 
@@ -489,8 +479,9 @@ async fn migrate_neo4j_relationships<S: SurrealSink>(
             let universal_relation = r.to_universal_relation(ctx)?;
 
             // Extract tracking property timestamp if present
-            if let Some(UniversalValue::LocalDateTime(ts)) =
-                universal_relation.data.get(tracking_property)
+            if let Some(UniversalValue::LocalDateTime(ts)) = universal_relation
+                .data
+                .get(&from_opts.change_tracking_property)
             {
                 min_timestamp = Some(min_timestamp.map_or(*ts, |min| min.min(*ts)));
                 max_timestamp = Some(max_timestamp.map_or(*ts, |max| max.max(*ts)));
@@ -1270,5 +1261,18 @@ mod tests {
             err_msg.contains("unsupported"),
             "Error should mention unsupported type: {err_msg}"
         );
+    }
+
+    #[test]
+    fn test_with_use_clause_none() {
+        let result = with_use_clause("MATCH (n) RETURN n", &None);
+        assert_eq!(result, "MATCH (n) RETURN n");
+    }
+
+    #[test]
+    fn test_with_use_clause_some() {
+        let constituent = Some("composite.db1".to_string());
+        let result = with_use_clause("MATCH (n) RETURN n", &constituent);
+        assert_eq!(result, "USE composite.db1 MATCH (n) RETURN n");
     }
 }

--- a/crates/neo4j-source/src/full_sync.rs
+++ b/crates/neo4j-source/src/full_sync.rs
@@ -33,6 +33,8 @@ pub struct SourceOpts {
     /// Property name to use as SurrealDB record ID (default: "id").
     /// If a node does not have this property, the Neo4j internal node_id is used.
     pub id_property: String,
+    /// Optional composite database constituent to prefix queries with `USE <constituent>`
+    pub composite_constituent: Option<String>,
 }
 
 /// Sync options (non-connection related)
@@ -102,6 +104,14 @@ impl Neo4jConversionContext {
     }
 }
 
+/// Prefix a Cypher query with `USE <constituent>` for composite database access.
+pub fn with_use_clause(query: &str, constituent: &Option<String>) -> String {
+    match constituent {
+        Some(c) => format!("USE {c} {query}"),
+        None => query.to_string(),
+    }
+}
+
 /// Enhanced version that supports checkpoint emission for incremental sync coordination
 ///
 /// # Arguments
@@ -164,6 +174,7 @@ pub async fn run_full_sync<S: SurrealSink, CS: CheckpointStore>(
         &from_opts.labels,
         &from_opts.change_tracking_property,
         &from_opts.id_property,
+        &from_opts.composite_constituent,
     )
     .await?;
     total_migrated += nodes_migrated;
@@ -176,6 +187,7 @@ pub async fn run_full_sync<S: SurrealSink, CS: CheckpointStore>(
         &ctx,
         &from_opts.change_tracking_property,
         &from_opts.id_property,
+        &from_opts.composite_constituent,
     )
     .await?;
     total_migrated += rels_migrated;
@@ -294,6 +306,7 @@ async fn migrate_neo4j_nodes<S: SurrealSink>(
     labels_filter: &[String],
     tracking_property: &str,
     id_property: &str,
+    composite_constituent: &Option<String>,
 ) -> anyhow::Result<(
     usize,
     Option<chrono::DateTime<chrono::Utc>>,
@@ -307,7 +320,7 @@ async fn migrate_neo4j_nodes<S: SurrealSink>(
     // Determine which labels to process
     let labels_to_process: Vec<String> = if labels_filter.is_empty() {
         // No filter - get all distinct labels from the database
-        let label_query = Query::new("MATCH (n) RETURN DISTINCT labels(n) as labels".to_string());
+        let label_query = Query::new(with_use_clause("MATCH (n) RETURN DISTINCT labels(n) as labels", composite_constituent));
         let mut result = graph.execute(label_query).await?;
 
         let mut all_labels = std::collections::HashSet::new();
@@ -337,7 +350,7 @@ async fn migrate_neo4j_nodes<S: SurrealSink>(
         tracing::info!("Migrating nodes with label: {}", label);
 
         let node_query = Query::new(
-            "MATCH (n) WHERE $label IN labels(n) RETURN n, id(n) as node_id".to_string(),
+            with_use_clause("MATCH (n) WHERE $label IN labels(n) RETURN n, id(n) as node_id", composite_constituent),
         )
         .param("label", label.clone());
         let mut node_result = graph.execute(node_query).await?;
@@ -428,6 +441,7 @@ async fn migrate_neo4j_relationships<S: SurrealSink>(
     ctx: &Neo4jConversionContext,
     tracking_property: &str,
     id_property: &str,
+    composite_constituent: &Option<String>,
 ) -> anyhow::Result<(
     usize,
     Option<chrono::DateTime<chrono::Utc>>,
@@ -439,7 +453,7 @@ async fn migrate_neo4j_relationships<S: SurrealSink>(
     let mut max_timestamp: Option<chrono::DateTime<chrono::Utc>> = None;
 
     // Get all distinct relationship types first
-    let type_query = Query::new("MATCH ()-[r]->() RETURN DISTINCT type(r) as rel_type".to_string());
+    let type_query = Query::new(with_use_clause("MATCH ()-[r]->() RETURN DISTINCT type(r) as rel_type", composite_constituent));
     let mut result = graph.execute(type_query).await?;
 
     let mut all_types = std::collections::HashSet::new();
@@ -457,12 +471,12 @@ async fn migrate_neo4j_relationships<S: SurrealSink>(
     for rel_type in all_types {
         tracing::info!("Migrating relationships of type: {}", rel_type);
 
-        let rel_query = Query::new(format!(
+        let rel_query = Query::new(with_use_clause(&format!(
             "MATCH (start_node)-[r]->(end_node) WHERE type(r) = $rel_type
              RETURN r, id(r) as rel_id, id(start_node) as start_id, id(end_node) as end_id,
              labels(start_node) as start_labels, labels(end_node) as end_labels,
              start_node.{id_property} as start_prop_id, end_node.{id_property} as end_prop_id",
-        ))
+        ), composite_constituent))
         .param("rel_type", rel_type.clone());
         let mut rel_result = graph.execute(rel_query).await?;
 

--- a/crates/neo4j-source/src/incremental_sync.rs
+++ b/crates/neo4j-source/src/incremental_sync.rs
@@ -167,14 +167,17 @@ impl Neo4jChangeStream {
 
         let checkpoint_str = checkpoint_datetime.to_rfc3339();
 
-        let node_query = Query::new(with_use_clause(&format!(
-            "MATCH (n)
+        let node_query = Query::new(with_use_clause(
+            &format!(
+                "MATCH (n)
              WHERE n.{} > datetime($checkpoint)
              RETURN n, id(n) as node_id, labels(n) as labels
              ORDER BY n.{}
              LIMIT 100",
-            self.change_tracking_property, self.change_tracking_property
-        ), &self.composite_constituent))
+                self.change_tracking_property, self.change_tracking_property
+            ),
+            &self.composite_constituent,
+        ))
         .param("checkpoint", checkpoint_str.clone());
 
         let mut result = self.graph.execute(node_query).await?;
@@ -270,8 +273,9 @@ impl Neo4jChangeStream {
         }
 
         // Also query for relationship changes
-        let rel_query = Query::new(with_use_clause(&format!(
-            "MATCH (a)-[r]->(b)
+        let rel_query = Query::new(with_use_clause(
+            &format!(
+                "MATCH (a)-[r]->(b)
              WHERE r.{tracking} > datetime($checkpoint)
              RETURN r, id(r) as rel_id, type(r) as rel_type,
                     id(a) as start_id, id(b) as end_id,
@@ -280,9 +284,11 @@ impl Neo4jChangeStream {
                     'update' as operation
              ORDER BY r.{tracking}
              LIMIT 100",
-            tracking = self.change_tracking_property,
-            id_prop = self.id_property,
-        ), &self.composite_constituent))
+                tracking = self.change_tracking_property,
+                id_prop = self.id_property,
+            ),
+            &self.composite_constituent,
+        ))
         .param("checkpoint", checkpoint_str);
 
         let mut rel_result = self.graph.execute(rel_query).await?;

--- a/crates/neo4j-source/src/incremental_sync.rs
+++ b/crates/neo4j-source/src/incremental_sync.rs
@@ -14,6 +14,7 @@
 //! If you need to sync deletions, run periodic clean-ups and full syncs to ensure SurrealDB
 //! exactly matches Neo4j.
 
+use crate::full_sync::with_use_clause;
 use crate::neo4j_checkpoint::Neo4jCheckpoint;
 use crate::{Neo4jConversionContext, SourceOpts, SyncOpts};
 use async_trait::async_trait;
@@ -53,6 +54,8 @@ pub struct Neo4jIncrementalSource {
     id_property: String,
     /// Current timestamp position for incremental sync (as i64)
     current_timestamp: i64,
+    /// Optional composite database constituent for `USE` clause
+    composite_constituent: Option<String>,
 }
 
 impl Neo4jIncrementalSource {
@@ -64,6 +67,7 @@ impl Neo4jIncrementalSource {
         change_tracking_property: Option<String>,
         id_property: String,
         initial_timestamp: i64,
+        composite_constituent: Option<String>,
     ) -> anyhow::Result<Self> {
         let ctx = Neo4jConversionContext::new(neo4j_timezone, neo4j_json_properties)?;
         Ok(Neo4jIncrementalSource {
@@ -73,6 +77,7 @@ impl Neo4jIncrementalSource {
                 .unwrap_or_else(|| "updated_at".to_string()),
             id_property,
             current_timestamp: initial_timestamp,
+            composite_constituent,
         })
     }
 
@@ -90,6 +95,7 @@ impl Neo4jIncrementalSource {
             self.change_tracking_property.clone(),
             self.id_property.clone(),
             self.ctx.clone(),
+            self.composite_constituent.clone(),
         )))
     }
 
@@ -123,6 +129,8 @@ pub struct Neo4jChangeStream {
     change_buffer: Vec<IncrementalChange>,
     /// Whether we've finished reading all changes
     finished: bool,
+    /// Optional composite database constituent for `USE` clause
+    composite_constituent: Option<String>,
 }
 
 impl Neo4jChangeStream {
@@ -132,6 +140,7 @@ impl Neo4jChangeStream {
         change_tracking_property: String,
         id_property: String,
         ctx: Neo4jConversionContext,
+        composite_constituent: Option<String>,
     ) -> Self {
         Neo4jChangeStream {
             graph,
@@ -141,6 +150,7 @@ impl Neo4jChangeStream {
             ctx,
             change_buffer: Vec::new(),
             finished: false,
+            composite_constituent,
         }
     }
 
@@ -157,14 +167,14 @@ impl Neo4jChangeStream {
 
         let checkpoint_str = checkpoint_datetime.to_rfc3339();
 
-        let node_query = Query::new(format!(
+        let node_query = Query::new(with_use_clause(&format!(
             "MATCH (n)
              WHERE n.{} > datetime($checkpoint)
              RETURN n, id(n) as node_id, labels(n) as labels
              ORDER BY n.{}
              LIMIT 100",
             self.change_tracking_property, self.change_tracking_property
-        ))
+        ), &self.composite_constituent))
         .param("checkpoint", checkpoint_str.clone());
 
         let mut result = self.graph.execute(node_query).await?;
@@ -260,7 +270,7 @@ impl Neo4jChangeStream {
         }
 
         // Also query for relationship changes
-        let rel_query = Query::new(format!(
+        let rel_query = Query::new(with_use_clause(&format!(
             "MATCH (a)-[r]->(b)
              WHERE r.{tracking} > datetime($checkpoint)
              RETURN r, id(r) as rel_id, type(r) as rel_type,
@@ -272,7 +282,7 @@ impl Neo4jChangeStream {
              LIMIT 100",
             tracking = self.change_tracking_property,
             id_prop = self.id_property,
-        ))
+        ), &self.composite_constituent))
         .param("checkpoint", checkpoint_str);
 
         let mut rel_result = self.graph.execute(rel_query).await?;
@@ -400,6 +410,7 @@ pub async fn run_incremental_sync<S: SurrealSink>(
         None,
         from_opts.id_property.clone(),
         initial_timestamp,
+        from_opts.composite_constituent.clone(),
     )?;
 
     // Start reading changes

--- a/src/from/neo4j.rs
+++ b/src/from/neo4j.rs
@@ -89,6 +89,7 @@ async fn run_full_v2(args: Neo4jFullArgs) -> anyhow::Result<()> {
         assumed_start_timestamp,
         allow_empty_tracking_timestamp: args.allow_empty_tracking_timestamp,
         id_property: args.id_property.clone(),
+        composite_constituent: args.composite_constituent.clone(),
     };
 
     let sync_opts = surreal_sync_neo4j_source::SyncOpts {
@@ -210,6 +211,7 @@ async fn run_full_v3(args: Neo4jFullArgs) -> anyhow::Result<()> {
         assumed_start_timestamp,
         allow_empty_tracking_timestamp: args.allow_empty_tracking_timestamp,
         id_property: args.id_property.clone(),
+        composite_constituent: args.composite_constituent.clone(),
     };
 
     let sync_opts = surreal_sync_neo4j_source::SyncOpts {
@@ -391,6 +393,7 @@ async fn run_incremental_v2(args: Neo4jIncrementalArgs) -> anyhow::Result<()> {
         assumed_start_timestamp,
         allow_empty_tracking_timestamp: args.allow_empty_tracking_timestamp,
         id_property: args.id_property.clone(),
+        composite_constituent: args.composite_constituent.clone(),
     };
 
     // Connect to SurrealDB using v2 SDK
@@ -524,6 +527,7 @@ async fn run_incremental_v3(args: Neo4jIncrementalArgs) -> anyhow::Result<()> {
         assumed_start_timestamp,
         allow_empty_tracking_timestamp: args.allow_empty_tracking_timestamp,
         id_property: args.id_property.clone(),
+        composite_constituent: args.composite_constituent.clone(),
     };
 
     // Connect to SurrealDB using v3 SDK

--- a/src/from/neo4j.rs
+++ b/src/from/neo4j.rs
@@ -13,6 +13,20 @@ use super::{
 };
 use crate::{Neo4jFullArgs, Neo4jIncrementalArgs};
 
+/// Parse a database name that may be a composite constituent (e.g., "composite.db1").
+/// Returns (session_database, composite_constituent).
+/// If the name contains a dot, the part before the first dot is the session database
+/// and the full name is the composite constituent for the USE clause.
+fn parse_composite_database(database: &Option<String>) -> (Option<String>, Option<String>) {
+    match database {
+        Some(db) if db.contains('.') => {
+            let session_db = db.split('.').next().unwrap().to_string();
+            (Some(session_db), Some(db.clone()))
+        }
+        other => (other.clone(), None),
+    }
+}
+
 /// Run Neo4j full sync, dispatching to appropriate SDK version.
 pub async fn run_full(args: Neo4jFullArgs) -> anyhow::Result<()> {
     let sdk_version = get_sdk_version(
@@ -79,7 +93,7 @@ async fn run_full_v2(args: Neo4jFullArgs) -> anyhow::Result<()> {
 
     let source_opts = surreal_sync_neo4j_source::SourceOpts {
         source_uri: args.connection_string,
-        source_database: args.database,
+        source_database: parse_composite_database(&args.database).0,
         source_username: args.username,
         source_password: args.password,
         labels: args.tables,
@@ -89,7 +103,7 @@ async fn run_full_v2(args: Neo4jFullArgs) -> anyhow::Result<()> {
         assumed_start_timestamp,
         allow_empty_tracking_timestamp: args.allow_empty_tracking_timestamp,
         id_property: args.id_property.clone(),
-        composite_constituent: args.composite_constituent.clone(),
+        composite_constituent: parse_composite_database(&args.database).1,
     };
 
     let sync_opts = surreal_sync_neo4j_source::SyncOpts {
@@ -201,7 +215,7 @@ async fn run_full_v3(args: Neo4jFullArgs) -> anyhow::Result<()> {
 
     let source_opts = surreal_sync_neo4j_source::SourceOpts {
         source_uri: args.connection_string,
-        source_database: args.database,
+        source_database: parse_composite_database(&args.database).0,
         source_username: args.username,
         source_password: args.password,
         labels: args.tables,
@@ -211,7 +225,7 @@ async fn run_full_v3(args: Neo4jFullArgs) -> anyhow::Result<()> {
         assumed_start_timestamp,
         allow_empty_tracking_timestamp: args.allow_empty_tracking_timestamp,
         id_property: args.id_property.clone(),
-        composite_constituent: args.composite_constituent.clone(),
+        composite_constituent: parse_composite_database(&args.database).1,
     };
 
     let sync_opts = surreal_sync_neo4j_source::SyncOpts {
@@ -383,7 +397,7 @@ async fn run_incremental_v2(args: Neo4jIncrementalArgs) -> anyhow::Result<()> {
 
     let source_opts = surreal_sync_neo4j_source::SourceOpts {
         source_uri: args.connection_string,
-        source_database: args.database,
+        source_database: parse_composite_database(&args.database).0,
         source_username: args.username,
         source_password: args.password,
         labels: args.tables,
@@ -393,7 +407,7 @@ async fn run_incremental_v2(args: Neo4jIncrementalArgs) -> anyhow::Result<()> {
         assumed_start_timestamp,
         allow_empty_tracking_timestamp: args.allow_empty_tracking_timestamp,
         id_property: args.id_property.clone(),
-        composite_constituent: args.composite_constituent.clone(),
+        composite_constituent: parse_composite_database(&args.database).1,
     };
 
     // Connect to SurrealDB using v2 SDK
@@ -517,7 +531,7 @@ async fn run_incremental_v3(args: Neo4jIncrementalArgs) -> anyhow::Result<()> {
 
     let source_opts = surreal_sync_neo4j_source::SourceOpts {
         source_uri: args.connection_string,
-        source_database: args.database,
+        source_database: parse_composite_database(&args.database).0,
         source_username: args.username,
         source_password: args.password,
         labels: args.tables,
@@ -527,7 +541,7 @@ async fn run_incremental_v3(args: Neo4jIncrementalArgs) -> anyhow::Result<()> {
         assumed_start_timestamp,
         allow_empty_tracking_timestamp: args.allow_empty_tracking_timestamp,
         id_property: args.id_property.clone(),
-        composite_constituent: args.composite_constituent.clone(),
+        composite_constituent: parse_composite_database(&args.database).1,
     };
 
     // Connect to SurrealDB using v3 SDK
@@ -551,4 +565,30 @@ async fn run_incremental_v3(args: Neo4jIncrementalArgs) -> anyhow::Result<()> {
 
     tracing::info!("Incremental sync completed successfully");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_composite_database_none() {
+        let (db, constituent) = parse_composite_database(&None);
+        assert_eq!(db, None);
+        assert_eq!(constituent, None);
+    }
+
+    #[test]
+    fn test_parse_composite_database_standard() {
+        let (db, constituent) = parse_composite_database(&Some("neo4j".to_string()));
+        assert_eq!(db, Some("neo4j".to_string()));
+        assert_eq!(constituent, None);
+    }
+
+    #[test]
+    fn test_parse_composite_database_composite_constituent() {
+        let (db, constituent) = parse_composite_database(&Some("composite.db1".to_string()));
+        assert_eq!(db, Some("composite".to_string()));
+        assert_eq!(constituent, Some("composite.db1".to_string()));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -365,6 +365,10 @@ struct Neo4jFullArgs {
     #[arg(long, default_value = "id")]
     id_property: String,
 
+    /// Composite database constituent to query via USE clause (e.g., "gatewayro.c1o")
+    #[arg(long, env = "NEO4J_COMPOSITE_CONSTITUENT")]
+    composite_constituent: Option<String>,
+
     #[command(flatten)]
     surreal: SurrealOpts,
 }
@@ -452,6 +456,10 @@ struct Neo4jIncrementalArgs {
     /// If a node does not have this property, the Neo4j internal node ID is used as fallback.
     #[arg(long, default_value = "id")]
     id_property: String,
+
+    /// Composite database constituent to query via USE clause (e.g., "gatewayro.c1o")
+    #[arg(long, env = "NEO4J_COMPOSITE_CONSTITUENT")]
+    composite_constituent: Option<String>,
 
     #[command(flatten)]
     surreal: SurrealOpts,

--- a/src/main.rs
+++ b/src/main.rs
@@ -300,7 +300,9 @@ struct Neo4jFullArgs {
     #[arg(long, env = "NEO4J_URI")]
     connection_string: String,
 
-    /// Neo4j database name
+    /// Neo4j database name. For composite database constituents, use
+    /// "composite.constituent" (e.g., "composite.db1") to automatically
+    /// route queries via USE clause.
     #[arg(long, env = "NEO4J_DATABASE")]
     database: Option<String>,
 
@@ -365,10 +367,6 @@ struct Neo4jFullArgs {
     #[arg(long, default_value = "id")]
     id_property: String,
 
-    /// Composite database constituent to query via USE clause (e.g., "gatewayro.c1o")
-    #[arg(long, env = "NEO4J_COMPOSITE_CONSTITUENT")]
-    composite_constituent: Option<String>,
-
     #[command(flatten)]
     surreal: SurrealOpts,
 }
@@ -379,7 +377,9 @@ struct Neo4jIncrementalArgs {
     #[arg(long, env = "NEO4J_URI")]
     connection_string: String,
 
-    /// Neo4j database name
+    /// Neo4j database name. For composite database constituents, use
+    /// "composite.constituent" (e.g., "composite.db1") to automatically
+    /// route queries via USE clause.
     #[arg(long, env = "NEO4J_DATABASE")]
     database: Option<String>,
 
@@ -456,10 +456,6 @@ struct Neo4jIncrementalArgs {
     /// If a node does not have this property, the Neo4j internal node ID is used as fallback.
     #[arg(long, default_value = "id")]
     id_property: String,
-
-    /// Composite database constituent to query via USE clause (e.g., "gatewayro.c1o")
-    #[arg(long, env = "NEO4J_COMPOSITE_CONSTITUENT")]
-    composite_constituent: Option<String>,
 
     #[command(flatten)]
     surreal: SurrealOpts,

--- a/tests/loadtest/neo4j_loadtest.rs
+++ b/tests/loadtest/neo4j_loadtest.rs
@@ -130,6 +130,7 @@ async fn test_neo4j_loadtest_small_scale() -> Result<(), Box<dyn std::error::Err
         assumed_start_timestamp: None,
         allow_empty_tracking_timestamp: false,
         id_property: "id".to_string(),
+        composite_constituent: None,
     };
 
     let sync_opts = surreal_sync_neo4j_source::SyncOpts {

--- a/tests/neo4j/main.rs
+++ b/tests/neo4j/main.rs
@@ -1,3 +1,4 @@
+mod neo4j_composite_full_sync_lib;
 mod neo4j_full_sync_only_cli;
 mod neo4j_full_sync_only_lib;
 mod neo4j_incremental_sync_only_cli;

--- a/tests/neo4j/neo4j_composite_full_sync_lib.rs
+++ b/tests/neo4j/neo4j_composite_full_sync_lib.rs
@@ -1,0 +1,156 @@
+//! Neo4j composite database full sync test
+//!
+//! This test validates that full sync works through a composite database
+//! using the USE clause to route queries to a local constituent alias.
+//! Requires Neo4j Enterprise Edition (composite databases are Enterprise-only).
+//!
+//! Configure via environment variables:
+//!   NEO4J_ENTERPRISE_URI  - e.g., "neo4j://127.0.0.1:7687"
+//!   NEO4J_ENTERPRISE_USER - e.g., "neo4j" (default: "neo4j")
+//!   NEO4J_ENTERPRISE_PASS - e.g., "neo4jneo4j" (default: "neo4j")
+
+use surreal_sync::testing::surreal::{
+    assert_synced_auto, cleanup_surrealdb_auto, connect_auto, SurrealConnection,
+};
+use surreal_sync::testing::{
+    create_unified_full_dataset, generate_test_id, SourceDatabase, TestConfig,
+};
+
+#[tokio::test]
+#[ignore] // Requires Neo4j Enterprise Edition; run manually with --ignored
+async fn test_neo4j_composite_full_sync_lib() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter("surreal_sync=debug")
+        .try_init()
+        .ok();
+
+    let neo4j_uri = std::env::var("NEO4J_ENTERPRISE_URI")
+        .unwrap_or_else(|_| "neo4j://127.0.0.1:7687".to_string());
+    let neo4j_user = std::env::var("NEO4J_ENTERPRISE_USER").unwrap_or_else(|_| "neo4j".to_string());
+    let neo4j_pass = std::env::var("NEO4J_ENTERPRISE_PASS").unwrap_or_else(|_| "neo4j".to_string());
+
+    let surrealdb = surreal_sync::testing::shared_containers::shared_surrealdb();
+
+    let dataset = create_unified_full_dataset();
+    let test_id = generate_test_id();
+
+    // Connect to the default neo4j database to insert test data
+    let graph_config = neo4rs::ConfigBuilder::default()
+        .uri(&neo4j_uri)
+        .user(&neo4j_user)
+        .password(&neo4j_pass)
+        .db("neo4j")
+        .build()?;
+    let graph = neo4rs::Graph::connect(graph_config)?;
+
+    // Setup SurrealDB connection
+    let surreal_config = TestConfig::with_surreal_endpoint(test_id, &surrealdb.ws_endpoint());
+    let conn = connect_auto(&surreal_config).await?;
+
+    cleanup_surrealdb_auto(&conn, &dataset).await?;
+    surreal_sync::testing::neo4j::delete_nodes_and_relationships(&graph).await?;
+
+    // Create schema and insert all test data into the neo4j database
+    surreal_sync::testing::neo4j::create_constraints_and_indices(&graph, &dataset).await?;
+    surreal_sync::testing::neo4j::create_nodes(&graph, &dataset).await?;
+    surreal_sync::testing::neo4j::create_relationships(&graph, &dataset).await?;
+
+    // Create a composite database with a local alias pointing to the neo4j database
+    let system_config = neo4rs::ConfigBuilder::default()
+        .uri(&neo4j_uri)
+        .user(&neo4j_user)
+        .password(&neo4j_pass)
+        .db("system")
+        .build()?;
+    let system_graph = neo4rs::Graph::connect(system_config)?;
+
+    let composite_name = format!("comp{test_id}");
+    let alias_name = format!("{composite_name}.localdb");
+
+    system_graph
+        .run(neo4rs::query(&format!(
+            "CREATE COMPOSITE DATABASE {composite_name}"
+        )))
+        .await?;
+
+    // Wait for composite database to come online
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    system_graph
+        .run(neo4rs::query(&format!(
+            "CREATE ALIAS {alias_name} FOR DATABASE neo4j"
+        )))
+        .await?;
+
+    // Wait for the alias to be available
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    // Perform full sync using composite constituent notation (composite.alias)
+    // This tests that the dot in the database name triggers USE clause routing.
+    let source_opts = surreal_sync_neo4j_source::SourceOpts {
+        source_uri: neo4j_uri.clone(),
+        source_database: Some(composite_name.clone()),
+        source_username: Some(neo4j_user.clone()),
+        source_password: Some(neo4j_pass.clone()),
+        labels: vec![],
+        neo4j_timezone: "UTC".to_string(),
+        neo4j_json_properties: Some(vec![
+            "all_types_users.metadata".to_string(),
+            "all_types_posts.post_categories".to_string(),
+        ]),
+        change_tracking_property: "updated_at".to_string(),
+        assumed_start_timestamp: None,
+        allow_empty_tracking_timestamp: false,
+        id_property: "id".to_string(),
+        composite_constituent: Some(alias_name.clone()),
+    };
+
+    let sync_opts = surreal_sync_neo4j_source::SyncOpts {
+        batch_size: 1000,
+        dry_run: false,
+    };
+
+    match &conn {
+        SurrealConnection::V2(client) => {
+            let sink = surreal2_sink::Surreal2Sink::new(client.clone());
+            surreal_sync_neo4j_source::run_full_sync::<_, checkpoint::NullStore>(
+                &sink,
+                source_opts,
+                sync_opts,
+                None,
+            )
+            .await?;
+        }
+        SurrealConnection::V3(client) => {
+            let sink = surreal3_sink::Surreal3Sink::new(client.clone());
+            surreal_sync_neo4j_source::run_full_sync::<_, checkpoint::NullStore>(
+                &sink,
+                source_opts,
+                sync_opts,
+                None,
+            )
+            .await?;
+        }
+    }
+
+    assert_synced_auto(
+        &conn,
+        &dataset,
+        "Neo4j composite full sync",
+        SourceDatabase::Neo4j,
+    )
+    .await?;
+
+    // Cleanup
+    surreal_sync::testing::neo4j::delete_nodes_and_relationships(&graph).await?;
+    let _ = system_graph
+        .run(neo4rs::query(&format!("DROP ALIAS {alias_name}")))
+        .await;
+    let _ = system_graph
+        .run(neo4rs::query(&format!(
+            "DROP COMPOSITE DATABASE {composite_name}"
+        )))
+        .await;
+
+    Ok(())
+}

--- a/tests/neo4j/neo4j_full_sync_only_lib.rs
+++ b/tests/neo4j/neo4j_full_sync_only_lib.rs
@@ -66,6 +66,7 @@ async fn test_neo4j_full_sync_lib() -> Result<(), Box<dyn std::error::Error>> {
         assumed_start_timestamp: None,
         allow_empty_tracking_timestamp: false,
         id_property: "id".to_string(),
+        composite_constituent: None,
     };
 
     let sync_opts = surreal_sync_neo4j_source::SyncOpts {

--- a/tests/neo4j/neo4j_incremental_sync_only_lib.rs
+++ b/tests/neo4j/neo4j_incremental_sync_only_lib.rs
@@ -73,6 +73,7 @@ async fn test_neo4j_incremental_sync_lib() -> Result<(), Box<dyn std::error::Err
         assumed_start_timestamp: None,
         allow_empty_tracking_timestamp: false,
         id_property: "id".to_string(),
+        composite_constituent: None,
     };
 
     let sync_opts = surreal_sync_neo4j_source::SyncOpts {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Usage of Neo4j Enterprise edition composite DB; surreal downstream. 

## What does this change do?

Enables the ability to pass 'composite.db1' as the `--database` for a neo4j sync

## What is your testing strategy?

Added unit tests for expected cypher queries for unit testing. As neo4j composites require enterprise edition, tested against neo4j desktop && an enterprise edition to validate functionality.

## Is this related to any issues?

https://github.com/surrealdb/surreal-sync/issues/78

## Have you read the [Contributing Guidelines](/CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](/CONTRIBUTING.md)
