### PR TITLE
Further speed up CI with nextest sharding and parallel jobs

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -34,11 +34,11 @@ fail-fast = false
 slow-timeout = { period = "90s", terminate-after = 5 }
 failure-output = "immediate-final"
 
-# Emit a JUnit report so CI can surface per-test results / upload it as an artifact.
-[profile.ci.junit]
-path = "junit.xml"
-
 # Ship the CLI binary alongside test binaries so shard runners can set SURREAL_SYNC_BIN.
 archive.include = [
   { path = "ci/surreal-sync", relative-to = "target" },
 ]
+
+# Emit a JUnit report so CI can surface per-test results / upload it as an artifact.
+[profile.ci.junit]
+path = "junit.xml"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -37,3 +37,8 @@ failure-output = "immediate-final"
 # Emit a JUnit report so CI can surface per-test results / upload it as an artifact.
 [profile.ci.junit]
 path = "junit.xml"
+
+# Ship the CLI binary alongside test binaries so shard runners can set SURREAL_SYNC_BIN.
+archive.include = [
+  { path = "ci/surreal-sync", relative-to = "target" },
+]

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -45,12 +45,6 @@ jobs:
     permissions:
       contents: read
     steps:
-    - name: Free disk space
-      run: |
-        # The Rust build cache + Docker images need plenty of room.
-        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-        df -h
-
     - name: Checkout repository
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -14,7 +14,33 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  cargo-test:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+    - name: Install system build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          build-essential cmake libssl-dev libsasl2-dev pkg-config protobuf-compiler postgresql-client
+
+    - name: Install Rust toolchain (from rust-toolchain.toml) + cache
+      uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+      with:
+        components: rustfmt, clippy
+        cache: true
+
+    - name: Format check
+      run: cargo fmt --all -- --check
+
+    - name: Clippy
+      run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+  build:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -37,8 +63,6 @@ jobs:
     - name: Install Rust toolchain (from rust-toolchain.toml) + cache
       uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
       with:
-        components: rustfmt, clippy
-        # Persisted, automatically-pruned Rust cache (registry + target dir).
         cache: true
 
     - name: Install cargo-nextest
@@ -46,14 +70,46 @@ jobs:
       with:
         tool: nextest
 
-    - name: Format check
-      run: cargo fmt --all -- --check
+    - name: Build stripped CLI binary (used by CLI tests)
+      run: cargo build -p surreal-sync --profile ci
 
-    - name: Clippy
-      run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+    - name: Archive test binaries
+      run: cargo nextest archive --workspace --cargo-profile ci --archive-file nextest.tar.zst
 
-    - name: Build debug binary (used by CLI tests)
-      run: cargo build
+    - name: Upload nextest archive
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: nextest-archive
+        path: nextest.tar.zst
+        retention-days: 1
+
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    steps:
+    - name: Free disk space
+      run: |
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+        df -h
+
+    - name: Checkout repository
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+    - name: Download nextest archive
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: nextest-archive
+
+    - name: Install cargo-nextest
+      uses: taiki-e/install-action@9bcaee1dcae34154180f412e2fa69355a7cda9f6 # v2.82.6
+      with:
+        tool: nextest
 
     - name: Pre-build PostgreSQL (wal2json) test image
       run: |
@@ -61,13 +117,13 @@ jobs:
           -f crates/postgresql-wal2json-source/Dockerfile.postgres16.wal2json \
           crates/postgresql-wal2json-source
 
-    - name: Run unit + integration tests (nextest)
+    - name: Run unit + integration tests (nextest shard ${{ matrix.shard }}/3)
       env:
-        SURREAL_SYNC_BIN: ${{ github.workspace }}/target/debug/surreal-sync
-      run: cargo nextest run --workspace --profile ci
-
-    - name: Run documentation tests
-      run: cargo test --workspace --doc
+        SURREAL_SYNC_BIN: ${{ github.workspace }}/target/ci/surreal-sync
+        RUST_BACKTRACE: 1
+      run: |
+        cargo nextest run --archive-file nextest.tar.zst --profile ci \
+          --partition count:${{ matrix.shard }}/3
 
     - name: Clean up leftover test containers
       if: always()
@@ -77,9 +133,31 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: test-results
+        name: test-results-shard-${{ matrix.shard }}
         path: |
           target/nextest/ci/junit.xml
           logs/test/
         retention-days: 7
         if-no-files-found: ignore
+
+  doc:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+    - name: Install system build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          build-essential cmake libssl-dev libsasl2-dev pkg-config protobuf-compiler postgresql-client
+
+    - name: Install Rust toolchain (from rust-toolchain.toml) + cache
+      uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+      with:
+        cache: true
+
+    - name: Run documentation tests
+      run: cargo test --workspace --doc

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -123,6 +123,7 @@ jobs:
         RUST_BACKTRACE: 1
       run: |
         cargo nextest run --archive-file nextest.tar.zst --profile ci \
+          --extract-to . --extract-overwrite \
           --partition count:${{ matrix.shard }}/3
 
     - name: Clean up leftover test containers

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -74,7 +74,7 @@ jobs:
       run: cargo build -p surreal-sync --profile ci
 
     - name: Archive test binaries
-      run: cargo nextest archive --workspace --cargo-profile ci --archive-file nextest.tar.zst
+      run: cargo nextest archive --workspace --cargo-profile ci --profile ci --archive-file nextest.tar.zst
 
     - name: Upload nextest archive
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -93,11 +93,6 @@ jobs:
       matrix:
         shard: [1, 2, 3]
     steps:
-    - name: Free disk space
-      run: |
-        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-        df -h
-
     - name: Checkout repository
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,33 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  cargo-test:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+    - name: Install system build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          build-essential cmake libssl-dev libsasl2-dev pkg-config protobuf-compiler postgresql-client
+
+    - name: Install Rust toolchain (from rust-toolchain.toml) + cache
+      uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+      with:
+        components: rustfmt, clippy
+        cache: true
+
+    - name: Format check
+      run: cargo fmt --all -- --check
+
+    - name: Clippy
+      run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+  build:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -37,7 +63,6 @@ jobs:
     - name: Install Rust toolchain (from rust-toolchain.toml) + cache
       uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
       with:
-        components: rustfmt, clippy
         cache: true
 
     - name: Install cargo-nextest
@@ -45,14 +70,46 @@ jobs:
       with:
         tool: nextest
 
-    - name: Format check
-      run: cargo fmt --all -- --check
+    - name: Build stripped CLI binary (used by CLI tests)
+      run: cargo build -p surreal-sync --profile ci
 
-    - name: Clippy
-      run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+    - name: Archive test binaries
+      run: cargo nextest archive --workspace --cargo-profile ci --archive-file nextest.tar.zst
 
-    - name: Build debug binary (used by CLI tests)
-      run: cargo build
+    - name: Upload nextest archive
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: nextest-archive
+        path: nextest.tar.zst
+        retention-days: 1
+
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    steps:
+    - name: Free disk space
+      run: |
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+        df -h
+
+    - name: Checkout repository
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+    - name: Download nextest archive
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: nextest-archive
+
+    - name: Install cargo-nextest
+      uses: taiki-e/install-action@9bcaee1dcae34154180f412e2fa69355a7cda9f6 # v2.82.6
+      with:
+        tool: nextest
 
     - name: Pre-build PostgreSQL (wal2json) test image
       run: |
@@ -60,13 +117,13 @@ jobs:
           -f crates/postgresql-wal2json-source/Dockerfile.postgres16.wal2json \
           crates/postgresql-wal2json-source
 
-    - name: Run unit + integration tests (nextest)
+    - name: Run unit + integration tests (nextest shard ${{ matrix.shard }}/3)
       env:
-        SURREAL_SYNC_BIN: ${{ github.workspace }}/target/debug/surreal-sync
-      run: cargo nextest run --workspace --profile ci
-
-    - name: Run documentation tests
-      run: cargo test --workspace --doc
+        SURREAL_SYNC_BIN: ${{ github.workspace }}/target/ci/surreal-sync
+        RUST_BACKTRACE: 1
+      run: |
+        cargo nextest run --archive-file nextest.tar.zst --profile ci \
+          --partition count:${{ matrix.shard }}/3
 
     - name: Clean up leftover test containers
       if: always()
@@ -76,9 +133,31 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: test-results
+        name: test-results-shard-${{ matrix.shard }}
         path: |
           target/nextest/ci/junit.xml
           logs/test/
         retention-days: 7
         if-no-files-found: ignore
+
+  doc:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+    - name: Install system build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          build-essential cmake libssl-dev libsasl2-dev pkg-config protobuf-compiler postgresql-client
+
+    - name: Install Rust toolchain (from rust-toolchain.toml) + cache
+      uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+      with:
+        cache: true
+
+    - name: Run documentation tests
+      run: cargo test --workspace --doc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,12 +45,6 @@ jobs:
     permissions:
       contents: read
     steps:
-    - name: Free disk space
-      run: |
-        # The Rust build cache + Docker images need plenty of room.
-        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-        df -h
-
     - name: Checkout repository
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,6 +123,7 @@ jobs:
         RUST_BACKTRACE: 1
       run: |
         cargo nextest run --archive-file nextest.tar.zst --profile ci \
+          --extract-to . --extract-overwrite \
           --partition count:${{ matrix.shard }}/3
 
     - name: Clean up leftover test containers

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
       run: cargo build -p surreal-sync --profile ci
 
     - name: Archive test binaries
-      run: cargo nextest archive --workspace --cargo-profile ci --archive-file nextest.tar.zst
+      run: cargo nextest archive --workspace --cargo-profile ci --profile ci --archive-file nextest.tar.zst
 
     - name: Upload nextest archive
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,11 +93,6 @@ jobs:
       matrix:
         shard: [1, 2, 3]
     steps:
-    - name: Free disk space
-      run: |
-        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-        df -h
-
     - name: Checkout repository
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,3 +148,10 @@ loadtest-generator = { path = "crates/loadtest-generator" }
 
 [profile.dev]
 debug = 1
+
+# CI build profile: stripped binaries for faster linking and smaller nextest archives.
+[profile.ci]
+inherits = "dev"
+debug = 0
+strip = "symbols"
+incremental = false

--- a/src/testing/cli.rs
+++ b/src/testing/cli.rs
@@ -4,9 +4,10 @@ use tempfile::TempDir;
 /// Execute surreal-sync CLI command and return the output.
 ///
 /// The binary location is resolved in this order:
-/// 1. `SURREAL_SYNC_BIN` environment variable
-/// 2. `./target/release/surreal-sync` relative to cwd
-/// 3. `/workspace/target/release/surreal-sync` (devcontainer fallback)
+/// 1. `SURREAL_SYNC_BIN` environment variable (if the path exists)
+/// 2. `NEXTEST_BIN_EXE_surreal_sync` / `CARGO_BIN_EXE_surreal-sync` (nextest archive runs)
+/// 3. `./target/ci/surreal-sync`, `./target/release/surreal-sync`, or `./target/debug/surreal-sync`
+/// 4. `/workspace/target/release/surreal-sync` (devcontainer fallback)
 pub fn execute_surreal_sync(args: &[&str]) -> Result<Output, Box<dyn std::error::Error>> {
     let binary = resolve_binary_path();
     let output = Command::new(binary)
@@ -17,28 +18,38 @@ pub fn execute_surreal_sync(args: &[&str]) -> Result<Output, Box<dyn std::error:
 }
 
 fn resolve_binary_path() -> String {
-    if let Ok(bin) = std::env::var("SURREAL_SYNC_BIN") {
-        return bin;
+    for key in [
+        "SURREAL_SYNC_BIN",
+        "NEXTEST_BIN_EXE_surreal_sync",
+        "CARGO_BIN_EXE_surreal-sync",
+    ] {
+        if let Ok(bin) = std::env::var(key) {
+            if std::path::Path::new(&bin).exists() {
+                return bin;
+            }
+        }
     }
     if let Ok(cwd) = std::env::current_dir() {
-        let release = cwd.join("target/release/surreal-sync");
-        let debug = cwd.join("target/debug/surreal-sync");
-        match (release.exists(), debug.exists()) {
-            (true, true) => {
-                // Pick whichever was compiled more recently so that
-                // `cargo test` (debug) and `make test` (release-then-test)
-                // both use the binary that matches the code under test.
-                let r_mtime = std::fs::metadata(&release).and_then(|m| m.modified()).ok();
-                let d_mtime = std::fs::metadata(&debug).and_then(|m| m.modified()).ok();
-                return match (r_mtime, d_mtime) {
-                    (Some(r), Some(d)) if r >= d => release.to_string_lossy().to_string(),
-                    (Some(_), Some(_)) => debug.to_string_lossy().to_string(),
-                    _ => release.to_string_lossy().to_string(),
-                };
+        let candidates = [
+            cwd.join("target/ci/surreal-sync"),
+            cwd.join("target/release/surreal-sync"),
+            cwd.join("target/debug/surreal-sync"),
+        ];
+        let existing: Vec<_> = candidates.iter().filter(|path| path.exists()).collect();
+        if existing.len() == 1 {
+            return existing[0].to_string_lossy().to_string();
+        }
+        if existing.len() > 1 {
+            // Pick whichever was compiled most recently so that `cargo test` (debug),
+            // `make test` (release-then-test), and CI (`ci` profile) all use the right binary.
+            let newest = existing.into_iter().max_by_key(|path| {
+                std::fs::metadata(path)
+                    .and_then(|m| m.modified())
+                    .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+            });
+            if let Some(path) = newest {
+                return path.to_string_lossy().to_string();
             }
-            (true, false) => return release.to_string_lossy().to_string(),
-            (false, true) => return debug.to_string_lossy().to_string(),
-            (false, false) => {}
         }
     }
     "/workspace/target/release/surreal-sync".to_string()


### PR DESCRIPTION
## What is the motivation?

Follow-up to #90.

We want faster feedback on PRs and main.

## What does this change do?

- Split `test-pr.yml` and `test.yml` into parallel lint/build/test and doc jobs so fmt/clippy and doc tests are off the critical path.
- Add a Cargo profile for faster links and smaller artifacts on CI
- Build and reuse nextest archive to eliminate build times

## What is your testing strategy?

- [x] Open this PR and confirm all workflow jobs pass (lint, build, three test shards, doc).
- [x] Compare total wall time vs. the post-#90 single job on a warm cache run.

## Have you read the [Contributing Guidelines](/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](/CONTRIBUTING.md)