### PR TITLE
Update SurrealDB SDKs to latest 2.x (2.6.5) and 3.x (3.1.5)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,18 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  ignore:
+    # surreal-sync depends on both SurrealDB SDK 2.x and 3.x simultaneously via
+    # Cargo package aliasing (surrealdb2 / surrealdb3). Never cross-upgrade one
+    # major line into the other (e.g. 2.x -> 3.x); each line should only receive
+    # within-major updates. See https://github.com/surrealdb/surreal-sync/pull/88.
+    #
+    # Known limitation: Dependabot can under-update when Cargo.lock holds two
+    # versions of the same crate (https://github.com/dependabot/dependabot-core/issues/8050).
+    # If the 3.x line stops getting PRs, bump it manually with
+    # `cargo update -p surrealdb@3.x`.
+    - dependency-name: "surrealdb"
+      update-types: ["version-update:semver-major"]
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:

--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -21,7 +21,7 @@ on:
       surrealdb_images:
         type: string
         description: 'Comma-separated list of SurrealDB images to test'
-        default: 'surrealdb/surrealdb:v2.3.7,surrealdb/surrealdb:v3.0.1'
+        default: 'surrealdb/surrealdb:v2.6.5,surrealdb/surrealdb:v3.1.5'
       timeout:
         type: string
         description: 'Timeout in seconds per source'
@@ -74,7 +74,7 @@ jobs:
             echo "preset=small" >> $GITHUB_OUTPUT
             echo "timeout=600" >> $GITHUB_OUTPUT
             SOURCES="mysql,mysql-trigger-incremental,postgresql,postgresql-trigger-incremental,postgresql-wal2json-incremental,mongodb,mongodb-incremental,neo4j,neo4j-incremental,kafka"
-            SURREALDB_IMAGES="surrealdb/surrealdb:v2.3.7,surrealdb/surrealdb:v3.0.1"
+            SURREALDB_IMAGES="surrealdb/surrealdb:v2.6.5,surrealdb/surrealdb:v3.1.5"
           fi
           echo "sources=$SOURCES" >> $GITHUB_OUTPUT
           echo "surrealdb_images=$SURREALDB_IMAGES" >> $GITHUB_OUTPUT

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,15 +22,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,16 +41,18 @@ dependencies = [
 
 [[package]]
 name = "affinitypool"
-version = "0.4.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a58b64a64aecad4ba7f2ccf0f79115f5d2d184b1e55307f78c20be07adc6633"
+checksum = "c4a46f56d354df11b6bcd8ca4f84fa03ac816cc41c72568a1b337d8f7e5af90e"
 dependencies = [
- "crossbeam",
+ "arc-swap",
+ "async-task",
+ "crossbeam-deque",
+ "crossbeam-utils",
  "libc",
  "num_cpus",
  "parking_lot",
  "thiserror 2.0.18",
- "tokio",
  "winapi",
 ]
 
@@ -182,12 +175,9 @@ checksum = "ea50b14b7a4b9343f8c627a7a53c52076482bd4bdad0a24fd3ec533ed616cc2c"
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
-dependencies = [
- "backtrace",
-]
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -200,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.8.0"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d03449bb8ca2cc2ef70869af31463d1ae5ccc8fa3e334b307203fbf815207e"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -215,7 +205,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -295,7 +285,7 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "mime",
  "multer",
  "num-traits",
@@ -344,7 +334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ecdaff7c9cffa3614a9f9999bf9ee4c3078fe3ce4d6a6e161736b56febf2de"
 dependencies = [
  "bytes",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_json",
 ]
@@ -723,7 +713,7 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "rustls-native-certs 0.8.2",
  "rustls-pki-types",
  "tokio",
@@ -958,21 +948,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "backtrace"
-version = "0.3.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,16 +1098,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -1202,10 +1177,10 @@ dependencies = [
  "getrandom 0.2.16",
  "getrandom 0.3.4",
  "hex",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "js-sys",
  "once_cell",
- "rand 0.9.1",
+ "rand 0.9.4",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -1255,6 +1230,20 @@ name = "bytemuck"
 version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
+]
 
 [[package]]
 name = "byteorder"
@@ -1283,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "castaway"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
 ]
@@ -1387,8 +1376,8 @@ dependencies = [
  "serde",
  "serde_json",
  "surreal-version",
- "surrealdb 2.3.7",
- "surrealdb 3.0.1",
+ "surrealdb 2.6.5",
+ "surrealdb 3.1.5",
  "tempfile",
  "tokio",
  "tracing",
@@ -1404,15 +1393,15 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
- "surrealdb 3.0.1",
+ "surrealdb 3.1.5",
  "tracing",
 ]
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1497,7 +1486,7 @@ version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.103",
@@ -1628,6 +1617,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1651,7 +1649,7 @@ dependencies = [
  "crc",
  "digest",
  "libc",
- "rand 0.9.1",
+ "rand 0.9.4",
  "regex",
 ]
 
@@ -1669,28 +1667,6 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
 
 [[package]]
 name = "crossbeam-deque"
@@ -1865,7 +1841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -2087,6 +2063,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "diskann"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "376186e025eb294c22f06236b23417608f1867def159c3a61a5c57788a3e889e"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "diskann-utils",
+ "diskann-vector",
+ "diskann-wide",
+ "futures-util",
+ "half",
+ "hashbrown 0.16.1",
+ "num-traits",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "diskann-utils"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b70289db1b66826fa1ef2b4113bf2f9d0dedc8df983b2b804c38dc1e519e15e"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "diskann-vector",
+ "diskann-wide",
+ "half",
+ "rand 0.9.4",
+ "rand_distr",
+ "rayon",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "diskann-vector"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f62c9d81aad6e3df6a026b1bb693dbbcfbee5ea93d9e7a5ff15c31576263bc29"
+dependencies = [
+ "cfg-if",
+ "diskann-wide",
+ "half",
+]
+
+[[package]]
+name = "diskann-wide"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46fcacef8ea9274969f98499456718f3dcaa5d3d7392b3171079653370fa0b20"
+dependencies = [
+ "cfg-if",
+ "half",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2304,7 +2338,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.103",
@@ -2456,6 +2490,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2509,9 +2549,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2524,9 +2564,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2534,15 +2574,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2551,9 +2591,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-lite"
@@ -2570,9 +2610,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2581,15 +2621,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
@@ -2599,9 +2639,9 @@ checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2611,7 +2651,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -2686,7 +2725,6 @@ dependencies = [
  "num-traits",
  "robust",
  "rstar 0.12.2",
- "serde",
  "spade",
 ]
 
@@ -2713,9 +2751,9 @@ dependencies = [
 
 [[package]]
 name = "geo-types"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f8647af4005fa11da47cd56252c6ef030be8fa97bdbf355e7dfb6348f0a82c"
+checksum = "94776032c45f950d30a13af6113c2ad5625316c9abfbccee4dd5a6695f8fe0f5"
 dependencies = [
  "approx",
  "num-traits",
@@ -2759,22 +2797,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
+name = "getrandom"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
-name = "glob"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+]
 
 [[package]]
 name = "group"
@@ -2810,7 +2847,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2829,7 +2866,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2838,12 +2875,17 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_distr",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2887,6 +2929,10 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash 0.8.12",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2896,7 +2942,7 @@ checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -2904,6 +2950,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "headers"
@@ -2963,6 +3018,12 @@ dependencies = [
  "hash32 0.3.1",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -3219,7 +3280,7 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.6.0",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "rustls-native-certs 0.8.2",
  "rustls-pki-types",
  "tokio",
@@ -3458,12 +3519,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -3491,9 +3552,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
@@ -3672,7 +3733,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee7893dab2e44ae5f9d0173f26ff4aa327c10b01b06a72b52dd9405b628640d"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -3735,9 +3796,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -3837,7 +3898,7 @@ name = "loadtest-generator"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "rand 0.9.1",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -4015,7 +4076,7 @@ dependencies = [
  "serde",
  "serde_json",
  "surreal2-types",
- "surrealdb 2.3.7",
+ "surrealdb 2.6.5",
  "sync-core",
  "thiserror 2.0.18",
  "tokio",
@@ -4037,7 +4098,7 @@ dependencies = [
  "serde",
  "serde_json",
  "surreal3-types",
- "surrealdb 3.0.1",
+ "surrealdb 3.1.5",
  "sync-core",
  "thiserror 2.0.18",
  "tokio",
@@ -4238,9 +4299,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "miette"
@@ -4292,13 +4353,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4400,7 +4461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66f62cad7623a9cb6f8f64037f0c4f69c8db8e82914334a83c9788201c2c1bfa"
 dependencies = [
  "darling",
- "heck",
+ "heck 0.5.0",
  "num-bigint",
  "proc-macro-crate",
  "proc-macro-error2",
@@ -4444,7 +4505,7 @@ dependencies = [
  "mysql_common",
  "pem",
  "percent-encoding",
- "rand 0.9.1",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "socket2 0.5.10",
@@ -4480,15 +4541,6 @@ dependencies = [
  "sha2",
  "thiserror 2.0.18",
  "uuid",
-]
-
-[[package]]
-name = "nanoid"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
-dependencies = [
- "rand 0.8.5",
 ]
 
 [[package]]
@@ -4541,7 +4593,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6e54a8b65764f71827a90ca1d56965ec0c67f069f996477bd493402a901d1f"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.13.0",
  "ndarray 0.17.2",
  "noisy_float",
@@ -4584,7 +4636,7 @@ dependencies = [
  "neo4rs-macros",
  "pastey",
  "pin-project-lite",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "rustls-native-certs 0.7.3",
  "rustls-pemfile 2.2.0",
  "serde",
@@ -4781,15 +4833,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "object_store"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4815,14 +4858,16 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2858065e55c148d294a9f3aae3b0fa9458edadb41a108397094566f4e3c0dfb"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
 dependencies = [
  "async-trait",
  "bytes",
  "chrono",
- "futures",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
  "http 1.4.0",
  "humantime",
  "itertools 0.14.0",
@@ -4955,9 +5000,9 @@ dependencies = [
 
 [[package]]
 name = "papaya"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92dd0b07c53a0a0c764db2ace8c541dc47320dad97c2200c2a637ab9dd2328f"
+checksum = "997ee03cd38c01469a7046643714f0ad28880bcb9e6679ff0666e24817ca19b7"
 dependencies = [
  "equivalent",
  "seize",
@@ -5091,7 +5136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -5249,9 +5294,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -5317,7 +5362,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56df96f5394370d1b20e49de146f9e6c25aa9ae750f449c9d665eafecb3ccae6"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.103",
@@ -5336,7 +5381,7 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand 0.9.1",
+ "rand 0.9.4",
  "sha2",
  "stringprep",
 ]
@@ -5519,7 +5564,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4aeaa1f2460f1d348eeaeed86aea999ce98c1bded6f089ff8514c9d9dbdc973"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "protobuf",
  "protobuf-support",
@@ -5586,9 +5631,9 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.6.18"
+version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ada44a88ef953a3294f6eb55d2007ba44646015e18613d2f213016379203ef3"
+checksum = "b9c6658afe513a3b484e3abfdaa0d03ef3c0bbf017542c178dd55f94eb3051f9"
 dependencies = [
  "ahash 0.8.12",
  "equivalent",
@@ -5608,7 +5653,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
@@ -5626,10 +5671,10 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.1",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -5666,6 +5711,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -5708,9 +5759,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -5755,6 +5806,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand 0.9.4",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5762,9 +5823,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -5860,9 +5921,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5889,15 +5950,9 @@ checksum = "8d942b98df5e658f56f20d592c7f868833fe38115e65c33003d8cd224b0155da"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
-
-[[package]]
-name = "relative-path"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rend"
@@ -5930,7 +5985,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -5972,7 +6027,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -6023,16 +6078,16 @@ dependencies = [
 
 [[package]]
 name = "revision"
-version = "0.17.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c3c8ec8b2be254beb5f8acdd80cdd57b7b5d40988c2ec3d0b7cdb6f7c2829b"
+checksum = "e735a8c2864f0b0fd48a55d0a71c081c7cbef8c8958a4665d8de423f20f2d0cf"
 dependencies = [
  "bytes",
  "chrono",
- "geo 0.31.0",
+ "geo 0.32.0",
  "regex",
- "revision-derive 0.17.0",
- "roaring 0.11.3",
+ "revision-derive 0.28.0",
+ "roaring 0.11.4",
  "rust_decimal",
  "uuid",
 ]
@@ -6061,9 +6116,9 @@ dependencies = [
 
 [[package]]
 name = "revision-derive"
-version = "0.17.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76be63634a8b1809e663bc0b975d78f6883c0fadbcce9c52e19b9e421f423357"
+checksum = "f446f8c55ba240992330b09f69fe9e5ec8a2e1ba266843cb9f59d7bc6037c821"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6179,9 +6234,9 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -6276,35 +6331,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rstest"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
-dependencies = [
- "futures-timer",
- "futures-util",
- "rstest_macros",
-]
-
-[[package]]
-name = "rstest_macros"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
-dependencies = [
- "cfg-if",
- "glob",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "regex",
- "relative-path",
- "rustc_version",
- "syn 2.0.103",
- "unicode-ident",
-]
-
-[[package]]
 name = "rust-stemmers"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6316,9 +6342,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.40.0"
+version = "1.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -6329,13 +6355,8 @@ dependencies = [
  "rkyv",
  "serde",
  "serde_json",
+ "wasm-bindgen",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustc-hash"
@@ -6411,9 +6432,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -6501,7 +6522,7 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "rustls-native-certs 0.8.2",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.7",
@@ -6718,9 +6739,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -6786,7 +6807,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -6836,7 +6857,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars",
  "serde",
  "serde_derive",
@@ -6863,7 +6884,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -6877,7 +6898,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -6888,7 +6909,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -7040,12 +7061,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7205,7 +7226,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -7276,9 +7297,9 @@ dependencies = [
  "neo4rs",
  "openssl",
  "postgresql-types",
- "rand 0.9.1",
+ "rand 0.9.4",
  "rust_decimal",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -7299,8 +7320,8 @@ dependencies = [
  "surreal2-types",
  "surreal3-sink",
  "surreal3-types",
- "surrealdb 2.3.7",
- "surrealdb 3.0.1",
+ "surrealdb 2.6.5",
+ "surrealdb 3.1.5",
  "sync-core",
  "tempfile",
  "tokio",
@@ -7333,8 +7354,8 @@ dependencies = [
  "surreal-version",
  "surreal2-sink",
  "surreal3-sink",
- "surrealdb 2.3.7",
- "surrealdb 3.0.1",
+ "surrealdb 2.6.5",
+ "surrealdb 3.1.5",
  "sync-core",
  "tempfile",
  "tokio",
@@ -7392,8 +7413,8 @@ dependencies = [
  "surreal-version",
  "surreal2-sink",
  "surreal3-sink",
- "surrealdb 2.3.7",
- "surrealdb 3.0.1",
+ "surrealdb 2.6.5",
+ "surrealdb 3.1.5",
  "sync-core",
  "tokio",
  "tokio-test",
@@ -7460,7 +7481,7 @@ dependencies = [
  "serde_json",
  "surreal-sink",
  "surreal2-types",
- "surrealdb 2.3.7",
+ "surrealdb 2.6.5",
  "sync-core",
  "tempfile",
  "tokio",
@@ -7481,12 +7502,12 @@ dependencies = [
  "log",
  "mysql-types",
  "mysql_async",
- "rand 0.9.1",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "surreal-sink",
  "surreal-sync-interleaved-snapshot",
- "surrealdb 2.3.7",
+ "surrealdb 2.6.5",
  "sync-core",
  "tempfile",
  "tokio",
@@ -7515,7 +7536,7 @@ dependencies = [
  "serde",
  "serde_json",
  "surreal-sink",
- "surrealdb 2.3.7",
+ "surrealdb 2.6.5",
  "sync-core",
  "tempfile",
  "tokio",
@@ -7567,7 +7588,7 @@ dependencies = [
  "surreal-sink",
  "surreal-sync-interleaved-snapshot",
  "surreal-sync-postgresql",
- "surrealdb 2.3.7",
+ "surrealdb 2.6.5",
  "sync-core",
  "tempfile",
  "tokio",
@@ -7596,7 +7617,7 @@ dependencies = [
  "surreal-sync-interleaved-snapshot",
  "surreal-sync-postgresql",
  "surreal2-sink",
- "surrealdb 2.3.7",
+ "surrealdb 2.6.5",
  "sync-core",
  "tempfile",
  "tokio",
@@ -7625,7 +7646,7 @@ dependencies = [
  "async-trait",
  "serde_json",
  "surreal-client",
- "surrealdb 2.3.7",
+ "surrealdb 2.6.5",
  "tracing",
 ]
 
@@ -7638,7 +7659,7 @@ dependencies = [
  "log",
  "surreal-sink",
  "surreal2-types",
- "surrealdb 2.3.7",
+ "surrealdb 2.6.5",
  "sync-core",
  "tokio",
  "tracing",
@@ -7657,7 +7678,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
- "surrealdb 2.3.7",
+ "surrealdb 2.6.5",
  "sync-core",
  "thiserror 2.0.18",
  "tokio",
@@ -7674,7 +7695,7 @@ dependencies = [
  "async-trait",
  "serde_json",
  "surreal-client",
- "surrealdb 3.0.1",
+ "surrealdb 3.1.5",
  "tracing",
 ]
 
@@ -7687,7 +7708,7 @@ dependencies = [
  "log",
  "surreal-sink",
  "surreal3-types",
- "surrealdb 3.0.1",
+ "surrealdb 3.1.5",
  "sync-core",
  "tokio",
  "tracing",
@@ -7706,7 +7727,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
- "surrealdb 3.0.1",
+ "surrealdb 3.1.5",
  "sync-core",
  "thiserror 2.0.18",
  "tokio",
@@ -7717,9 +7738,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb"
-version = "2.3.7"
+version = "2.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5545940eb21920f4eb3fbdd4a805c68c9917e9ee95b805d7702c0a6cf61ed4d0"
+checksum = "3429154a8b5a98ca39100ba45ef49ae046fb1d0869dff78d78a2670b1b278982"
 dependencies = [
  "arrayvec",
  "async-channel",
@@ -7729,7 +7750,7 @@ dependencies = [
  "futures",
  "geo 0.28.0",
  "getrandom 0.3.4",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "path-clean",
  "pharos",
  "reblessive",
@@ -7737,13 +7758,13 @@ dependencies = [
  "revision 0.11.0",
  "ring",
  "rust_decimal",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "semver",
  "serde",
  "serde-content",
  "serde_json",
- "surrealdb-core 2.3.7",
+ "surrealdb-core 2.6.5",
  "thiserror 1.0.69",
  "tokio",
  "tokio-tungstenite 0.23.1",
@@ -7759,9 +7780,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb"
-version = "3.0.1"
+version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18997a4c20c9559461846bff0dad185854c32639407904e2bb97567b4fa6a63"
+checksum = "81ee3110fe3ab8172eb8c135c96ed2d57c7470cdf1ad732d176db95a92c9faab"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -7769,18 +7790,19 @@ dependencies = [
  "chrono",
  "futures",
  "getrandom 0.3.4",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "js-sys",
  "path-clean",
  "reqwest 0.13.2",
  "ring",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "semver",
  "serde",
  "serde_json",
- "surrealdb-core 3.0.1",
+ "surrealdb-core 3.1.5",
  "surrealdb-types",
+ "surrealdb-types-derive",
  "tokio",
  "tokio-tungstenite 0.28.0",
  "tokio-tungstenite-wasm",
@@ -7795,10 +7817,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "surrealdb-core"
-version = "2.3.7"
+name = "surrealdb-collections"
+version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c0c3d3e8e8156a1f15e3f146b8e40d7a0197e89abea6c4aa0178d06d11e6d1"
+checksum = "069e0c90dad71cf8f17475f75118a56ad3047f2f46fac24643e562b415b3f11a"
+dependencies = [
+ "revision 0.28.0",
+ "storekey 0.11.0",
+]
+
+[[package]]
+name = "surrealdb-core"
+version = "2.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba423d9e7e665e4c735a1d4669c3a067135e4a574edf88af215f7f2b815e70ed"
 dependencies = [
  "addr",
  "affinitypool 0.3.1",
@@ -7828,6 +7860,7 @@ dependencies = [
  "geo 0.28.0",
  "geo-types",
  "getrandom 0.3.4",
+ "hashbrown 0.14.5",
  "hex",
  "http 1.4.0",
  "ipnet",
@@ -7835,7 +7868,6 @@ dependencies = [
  "lexicmp 0.1.0",
  "linfa-linalg",
  "md-5",
- "nanoid",
  "ndarray 0.15.6",
  "ndarray-stats 0.5.1",
  "num-traits",
@@ -7888,19 +7920,18 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-core"
-version = "3.0.1"
+version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470a61158ca8b4e774f8be3a8fbe1393bd33c026d9025a3db8f5ada0a06adf6a"
+checksum = "9780c2f3dd6a3cb1cce8ca7c866b5e82ac4377b826a09bf718ca441bfd2bd747"
 dependencies = [
  "addr",
- "affinitypool 0.4.0",
+ "affinitypool 0.7.0",
  "ahash 0.8.12",
  "ammonia",
  "anyhow",
  "argon2",
  "async-channel",
  "async-stream",
- "async-trait",
  "base64 0.22.1",
  "bcrypt 0.18.0",
  "blake3",
@@ -7909,6 +7940,9 @@ dependencies = [
  "ciborium",
  "dashmap 6.1.0",
  "deunicode",
+ "diskann",
+ "diskann-utils",
+ "diskann-vector",
  "dmp",
  "ext-sort",
  "fastnum",
@@ -7918,6 +7952,7 @@ dependencies = [
  "geo 0.32.0",
  "geo-types",
  "getrandom 0.3.4",
+ "half",
  "headers",
  "hex",
  "http 1.4.0",
@@ -7926,26 +7961,28 @@ dependencies = [
  "jsonwebtoken 10.3.0",
  "lexicmp 0.2.0",
  "md-5",
+ "memchr",
  "mime",
  "ndarray 0.17.2",
  "ndarray-stats 0.7.0",
  "num-traits",
  "num_cpus",
- "object_store 0.13.1",
+ "object_store 0.13.2",
  "parking_lot",
  "path-clean",
  "pbkdf2 0.12.2",
  "phf 0.13.1",
  "pin-project-lite",
- "quick_cache 0.6.18",
+ "quick_cache 0.6.24",
  "radix_trie 0.3.0",
- "rand 0.8.5",
+ "rand 0.9.4",
+ "rand_core 0.6.4",
  "rayon",
  "reblessive",
  "regex",
- "revision 0.17.0",
+ "revision 0.28.0",
  "ring",
- "roaring 0.11.3",
+ "roaring 0.11.4",
  "rust-stemmers",
  "rust_decimal",
  "scrypt",
@@ -7957,7 +7994,9 @@ dependencies = [
  "storekey 0.11.0",
  "strsim",
  "subtle",
+ "surrealdb-collections",
  "surrealdb-protocol",
+ "surrealdb-strand",
  "surrealdb-types",
  "surrealmx",
  "sysinfo 0.37.2",
@@ -7986,8 +8025,8 @@ dependencies = [
  "serde",
  "serde_json",
  "surreal-version",
- "surrealdb 2.3.7",
- "surrealdb 3.0.1",
+ "surrealdb 2.6.5",
+ "surrealdb 3.1.5",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -7995,9 +8034,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-protocol"
-version = "0.8.3"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb37698e0493bcfac3229ecb6ec6894a3ad705a3a2087b1562eeb881b3db19d4"
+checksum = "3f4e06f586c9179a02349b88b0c18e3a0850c55431aa513e0cd66529c00da1af"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8018,37 +8057,53 @@ dependencies = [
 ]
 
 [[package]]
-name = "surrealdb-types"
-version = "3.0.1"
+name = "surrealdb-strand"
+version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58db59440236ec593dbbb2487c4db11e4452ee636f9a1da3e3672c1cc1f42259"
+checksum = "4af300a172983b23c05e692cacba462ca023e3e9404812b6783d09a8af487865"
+dependencies = [
+ "revision 0.28.0",
+ "serde",
+ "storekey 0.11.0",
+]
+
+[[package]]
+name = "surrealdb-types"
+version = "3.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd434d643c040c2872c9cfc88c90e9910e9a55456d2df7e68e92725225d3e20"
 dependencies = [
  "anyhow",
+ "async-channel",
  "bytes",
+ "castaway",
  "chrono",
  "flatbuffers",
  "geo 0.32.0",
  "hex",
  "http 1.4.0",
  "papaya",
- "rand 0.8.5",
+ "rand 0.9.4",
  "regex",
- "rstest",
  "rust_decimal",
+ "semver",
  "serde",
  "serde_json",
  "surrealdb-protocol",
  "surrealdb-types-derive",
+ "tracing",
  "ulid",
+ "url",
  "uuid",
 ]
 
 [[package]]
 name = "surrealdb-types-derive"
-version = "3.0.1"
+version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617a808c9b3a2cd688c98027f4781c522507df73b42b1c56820ae72407eda016"
+checksum = "16d385184f3b727c58c4d099a877a4c54ffe879dd190396cc80b1676146b8b2b"
 dependencies = [
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.103",
@@ -8068,16 +8123,16 @@ dependencies = [
  "getrandom 0.2.16",
  "lru 0.12.5",
  "parking_lot",
- "quick_cache 0.6.18",
+ "quick_cache 0.6.24",
  "revision 0.10.0",
  "vart 0.9.3",
 ]
 
 [[package]]
 name = "surrealmx"
-version = "0.18.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6508449a7d1379a92a51ba49391b48ccab0b60dd11a4277c0dda965d8c99dbff"
+checksum = "9e8a87f050a4860832ccf4a53e43ea264e98d27618983602b5c575e6df296054"
 dependencies = [
  "arc-swap",
  "bincode 2.0.1",
@@ -8351,9 +8406,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -8361,16 +8416,16 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.0",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8396,8 +8451,8 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.9.1",
- "socket2 0.6.0",
+ "rand 0.9.4",
+ "socket2 0.6.4",
  "tokio",
  "tokio-util",
  "whoami",
@@ -8419,7 +8474,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "tokio",
 ]
 
@@ -8455,7 +8510,7 @@ checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -8471,7 +8526,7 @@ checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -8539,7 +8594,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -8572,7 +8627,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.0",
+ "socket2 0.6.4",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
@@ -8601,7 +8656,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -8734,7 +8789,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "sha1",
  "thiserror 1.0.69",
@@ -8753,8 +8808,8 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "rand 0.9.1",
- "rustls 0.23.37",
+ "rand 0.9.4",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
@@ -8797,7 +8852,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand 0.9.1",
+ "rand 0.9.4",
  "serde",
  "web-time",
 ]
@@ -8937,11 +8992,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.20.0"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -9056,6 +9111,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Database clients
 # SurrealDB SDK v2 (aliased for coexistence with v3)
-surrealdb2 = { version = "2.3.7", package = "surrealdb", features = ["protocol-ws", "kv-mem"] }
+surrealdb2 = { version = "2.6.5", package = "surrealdb", features = ["protocol-ws", "kv-mem"] }
 # SurrealDB SDK v3 (aliased for coexistence with v2)
-surrealdb3 = { version = "=3.0.1", package = "surrealdb", features = ["protocol-ws", "kv-mem"] }
+surrealdb3 = { version = "3.1.5", package = "surrealdb", features = ["protocol-ws", "kv-mem"] }
 mongodb = "3.2.4"
 bson = { version = "2.15.0", features = ["chrono-0_4"] }
 chrono = "0.4.41"

--- a/crates/checkpoint-surreal3/Cargo.toml
+++ b/crates/checkpoint-surreal3/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [dependencies]
 checkpoint = { path = "../checkpoint" }
-surrealdb = "=3.0.1"
+surrealdb = { version = "3.1.5", features = ["protocol-ws", "kv-mem"] }
 async-trait = "0.1"
 anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/checkpoint/Cargo.toml
+++ b/crates/checkpoint/Cargo.toml
@@ -21,11 +21,11 @@ tracing = "0.1"
 async-trait = "0.1"
 
 # SurrealDB for checkpoint storage
-surrealdb = { version = "2.3.7", features = ["protocol-ws", "kv-mem"] }
+surrealdb = { version = "2.6.5", features = ["protocol-ws", "kv-mem"] }
 
 [dev-dependencies]
 tokio = { version = "1.49", features = ["full", "test-util"] }
 tempfile = "3.27"
 surreal-version = { path = "../surreal-version" }
-surrealdb3 = { version = "=3.0.1", package = "surrealdb", features = ["protocol-ws", "kv-mem"] }
+surrealdb3 = { version = "3.1.5", package = "surrealdb", features = ["protocol-ws", "kv-mem"] }
 checkpoint-surreal3 = { path = "../checkpoint-surreal3" }

--- a/crates/csv-source/Cargo.toml
+++ b/crates/csv-source/Cargo.toml
@@ -53,8 +53,8 @@ surreal3-sink = { path = "../surreal3-sink" }
 surreal-version = { path = "../surreal-version" }
 
 # SurrealDB for tests
-surrealdb = { version = "2.3.7", features = ["protocol-ws", "kv-mem"] }
-surrealdb3 = { version = "=3.0.1", package = "surrealdb", features = ["protocol-ws", "kv-mem"] }
+surrealdb = { version = "2.6.5", features = ["protocol-ws", "kv-mem"] }
+surrealdb3 = { version = "3.1.5", package = "surrealdb", features = ["protocol-ws", "kv-mem"] }
 
 # HTTP test server
 axum = "0.7"

--- a/crates/jsonl-source/Cargo.toml
+++ b/crates/jsonl-source/Cargo.toml
@@ -25,8 +25,8 @@ surreal-sink = { path = "../surreal-sink" }
 tokio-test = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-surrealdb = { version = "2.3.7", features = ["protocol-ws", "kv-mem"] }
-surrealdb3 = { version = "=3.0.1", package = "surrealdb", features = ["protocol-ws", "kv-mem"] }
+surrealdb = { version = "2.6.5", features = ["protocol-ws", "kv-mem"] }
+surrealdb3 = { version = "3.1.5", package = "surrealdb", features = ["protocol-ws", "kv-mem"] }
 surreal2-sink = { path = "../surreal2-sink" }
 surreal3-sink = { path = "../surreal3-sink" }
 surreal-version = { path = "../surreal-version" }

--- a/crates/loadtest-verify-surreal2/Cargo.toml
+++ b/crates/loadtest-verify-surreal2/Cargo.toml
@@ -11,7 +11,7 @@ loadtest-generator = { path = "../loadtest-generator" }
 surreal2-types = { path = "../surreal2-types" }
 
 clap = { version = "4.5", features = ["derive", "env"] }
-surrealdb2 = { version = "2.3.7", package = "surrealdb", features = ["protocol-ws", "kv-mem"] }
+surrealdb2 = { version = "2.6.5", package = "surrealdb", features = ["protocol-ws", "kv-mem"] }
 tokio = { version = "1.49", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/loadtest-verify-surreal3/Cargo.toml
+++ b/crates/loadtest-verify-surreal3/Cargo.toml
@@ -11,7 +11,7 @@ loadtest-generator = { path = "../loadtest-generator" }
 surreal3-types = { path = "../surreal3-types" }
 
 clap = { version = "4.5", features = ["derive", "env"] }
-surrealdb3 = { version = "=3.0.1", package = "surrealdb", features = ["protocol-ws", "kv-mem"] }
+surrealdb3 = { version = "3.1.5", package = "surrealdb", features = ["protocol-ws", "kv-mem"] }
 tokio = { version = "1.49", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/mongodb-changestream-source/Cargo.toml
+++ b/crates/mongodb-changestream-source/Cargo.toml
@@ -39,5 +39,5 @@ base64 = "0.22"
 
 [dev-dependencies]
 tempfile = "3.27"
-surrealdb = { version = "2.3.7", features = ["protocol-ws", "kv-mem"] }
+surrealdb = { version = "2.6.5", features = ["protocol-ws", "kv-mem"] }
 surreal2-types = { path = "../surreal2-types" }

--- a/crates/mysql-trigger-source/Cargo.toml
+++ b/crates/mysql-trigger-source/Cargo.toml
@@ -27,5 +27,5 @@ log = "0.4"
 
 [dev-dependencies]
 tempfile = "3.27"
-surrealdb = { version = "2.3.7", features = ["protocol-ws", "kv-mem"] }
+surrealdb = { version = "2.6.5", features = ["protocol-ws", "kv-mem"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/neo4j-source/Cargo.toml
+++ b/crates/neo4j-source/Cargo.toml
@@ -42,4 +42,4 @@ serde_json = "1.0.145"
 [dev-dependencies]
 tokio-test = "0.4"
 tempfile = "3.27"
-surrealdb = { version = "2.3.7", features = ["protocol-ws", "kv-mem"] }
+surrealdb = { version = "2.6.5", features = ["protocol-ws", "kv-mem"] }

--- a/crates/postgresql-trigger-source/Cargo.toml
+++ b/crates/postgresql-trigger-source/Cargo.toml
@@ -36,4 +36,4 @@ libc = "0.2.183"
 
 [dev-dependencies]
 tempfile = "3.27"
-surrealdb = { version = "2.3.7", features = ["protocol-ws", "kv-mem"] }
+surrealdb = { version = "2.6.5", features = ["protocol-ws", "kv-mem"] }

--- a/crates/postgresql-wal2json-source/Cargo.toml
+++ b/crates/postgresql-wal2json-source/Cargo.toml
@@ -25,7 +25,7 @@ async-trait = "0.1"
 surreal-sink = { path = "../surreal-sink" }
 surreal2-sink = { path = "../surreal2-sink" }
 sync-core = { path = "../sync-core" }
-surrealdb = { version = "2.3.7", features = ["protocol-ws", "kv-mem"] }
+surrealdb = { version = "2.6.5", features = ["protocol-ws", "kv-mem"] }
 clap = { version = "4.5", features = ["derive", "env"] }
 rust_decimal = { version = "^1.23", features = ["db-tokio-postgres"] }
 libc = "0.2.183"

--- a/crates/surreal-version/src/testing/container.rs
+++ b/crates/surreal-version/src/testing/container.rs
@@ -2,7 +2,7 @@
 //!
 //! Provides a `SurrealDbContainer` that runs SurrealDB in-memory via Docker
 //! with dynamic port binding. The Docker image defaults to
-//! `surrealdb/surrealdb:v2.3.7` and can be overridden with the
+//! `surrealdb/surrealdb:v2.6.5` and can be overridden with the
 //! `SURREALDB_IMAGE` environment variable.
 
 use anyhow::{Context, Result};
@@ -12,7 +12,7 @@ use tracing::{debug, info};
 
 use crate::SurrealMajorVersion;
 
-const DEFAULT_IMAGE: &str = "surrealdb/surrealdb:v2.3.7";
+const DEFAULT_IMAGE: &str = "surrealdb/surrealdb:v2.6.5";
 
 /// A test SurrealDB container backed by Docker with dynamic port binding.
 pub struct SurrealDbContainer {
@@ -27,7 +27,7 @@ impl SurrealDbContainer {
     /// Creates a new container configuration.
     ///
     /// The Docker image is read from `SURREALDB_IMAGE` env var, falling back
-    /// to `surrealdb/surrealdb:v2.3.7`.
+    /// to `surrealdb/surrealdb:v2.6.5`.
     pub fn new(container_name: &str) -> Self {
         let image = std::env::var("SURREALDB_IMAGE").unwrap_or_else(|_| DEFAULT_IMAGE.to_string());
         Self {

--- a/crates/surreal2-client/Cargo.toml
+++ b/crates/surreal2-client/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [dependencies]
 surreal-client = { path = "../surreal-client" }
-surrealdb = { version = "2.3.7", features = ["protocol-ws", "kv-mem"] }
+surrealdb = { version = "2.6.5", features = ["protocol-ws", "kv-mem"] }
 anyhow = "1.0.100"
 async-trait = "0.1"
 tracing = "0.1"

--- a/crates/surreal2-sink/Cargo.toml
+++ b/crates/surreal2-sink/Cargo.toml
@@ -6,7 +6,7 @@ description = "SurrealDB connection and write utilities"
 license = "MIT"
 
 [dependencies]
-surrealdb = { version = "2.3.7", features = ["protocol-ws", "kv-mem"] }
+surrealdb = { version = "2.6.5", features = ["protocol-ws", "kv-mem"] }
 surreal2-types = { path = "../surreal2-types" }
 surreal-sink = { path = "../surreal-sink" }
 sync-core = { path = "../sync-core" }

--- a/crates/surreal2-types/Cargo.toml
+++ b/crates/surreal2-types/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [dependencies]
 sync-core = { path = "../sync-core" }
-surrealdb = { version = "2.3.7", features = ["protocol-ws", "kv-mem"] }
+surrealdb = { version = "2.6.5", features = ["protocol-ws", "kv-mem"] }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.0", features = ["v4", "serde"] }
 ulid = { version = "1.1", features = ["serde"] }

--- a/crates/surreal3-client/Cargo.toml
+++ b/crates/surreal3-client/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [dependencies]
 surreal-client = { path = "../surreal-client" }
-surrealdb = { version = "=3.0.1", features = ["protocol-ws", "kv-mem"] }
+surrealdb = { version = "3.1.5", features = ["protocol-ws", "kv-mem"] }
 anyhow = "1.0.100"
 async-trait = "0.1"
 tracing = "0.1"

--- a/crates/surreal3-sink/Cargo.toml
+++ b/crates/surreal3-sink/Cargo.toml
@@ -6,7 +6,7 @@ description = "SurrealDB v3 connection and write utilities"
 license = "MIT"
 
 [dependencies]
-surrealdb = { version = "=3.0.1", features = ["protocol-ws", "kv-mem"] }
+surrealdb = { version = "3.1.5", features = ["protocol-ws", "kv-mem"] }
 surreal3-types = { path = "../surreal3-types" }
 surreal-sink = { path = "../surreal-sink" }
 sync-core = { path = "../sync-core" }

--- a/crates/surreal3-types/Cargo.toml
+++ b/crates/surreal3-types/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [dependencies]
 sync-core = { path = "../sync-core" }
-surrealdb = { version = "=3.0.1", features = ["protocol-ws", "kv-mem"] }
+surrealdb = { version = "3.1.5", features = ["protocol-ws", "kv-mem"] }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.0", features = ["v4", "serde"] }
 ulid = { version = "1.1", features = ["serde"] }

--- a/crates/surrealdb-multi-sdk-demo/Cargo.toml
+++ b/crates/surrealdb-multi-sdk-demo/Cargo.toml
@@ -8,10 +8,10 @@ publish = false
 
 [dependencies]
 # SurrealDB SDK v2 (aliased as surrealdb2)
-surrealdb2 = { version = "2.3.7", package = "surrealdb", features = ["protocol-ws", "kv-mem"] }
+surrealdb2 = { version = "2.6.5", package = "surrealdb", features = ["protocol-ws", "kv-mem"] }
 
 # SurrealDB SDK v3 (aliased as surrealdb3)
-surrealdb3 = { version = "=3.0.1", package = "surrealdb", features = ["protocol-ws", "kv-mem"] }
+surrealdb3 = { version = "3.1.5", package = "surrealdb", features = ["protocol-ws", "kv-mem"] }
 
 # Common dependencies
 tokio = { version = "1", features = ["full"] }

--- a/crates/surrealdb-multi-sdk-demo/src/lib.rs
+++ b/crates/surrealdb-multi-sdk-demo/src/lib.rs
@@ -3,8 +3,8 @@
 //! Demo crate verifying that SurrealDB SDK v2 and v3 can coexist in the same crate.
 //!
 //! This crate uses Cargo's package aliasing feature to import both SDK versions:
-//! - `surrealdb2` = SurrealDB SDK 2.3.7
-//! - `surrealdb3` = SurrealDB SDK 3.0.1
+//! - `surrealdb2` = SurrealDB SDK 2.6.5
+//! - `surrealdb3` = SurrealDB SDK 3.1.5
 //!
 //! ## Key Findings
 //!
@@ -191,8 +191,8 @@ mod tests {
     use std::sync::{Mutex, OnceLock};
     use surreal_version::testing::SurrealDbContainer;
 
-    const V2_IMAGE: &str = "surrealdb/surrealdb:v2.3.7";
-    const V3_IMAGE: &str = "surrealdb/surrealdb:v3.0.1";
+    const V2_IMAGE: &str = "surrealdb/surrealdb:v2.6.5";
+    const V3_IMAGE: &str = "surrealdb/surrealdb:v3.1.5";
 
     static CONTAINER_NAMES: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
 


### PR DESCRIPTION
## What is the motivation?

surreal-sync supports SurrealDB 2.x and 3.x at the same time, so both SDK lines should track their own latest stable release. Dependabot instead tried to collapse 2.x onto 3.x (#88), which breaks that dual-SDK support.

## What does this change do?

- Bumps the v2 SDK to 2.6.5 and the v3 SDK to 3.1.5 across the workspace.
- Aligns test/loadtest SurrealDB Docker image tags with the new versions.
- Configures Dependabot to ignore cross-major `surrealdb` upgrades.

## What is your testing strategy?

`make clippy` and `make test` (unit, integration against live 2.6.5/3.1.5 containers, and doctests) pass locally.

## Is this related to any issues?

#88

## Have you read the Contributing Guidelines?

- [x] I have read the Contributing Guidelines