### PR TITLE
Add Kafka TLS/mTLS certificate flags and secured-broker E2E test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7432,6 +7432,7 @@ dependencies = [
  "protobuf",
  "protobuf-codegen",
  "rdkafka",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/kafka-producer/Cargo.toml
+++ b/crates/kafka-producer/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Kafka client
-rdkafka = { version = "0.38", features = ["tokio"] }
+rdkafka = { version = "0.38", features = ["tokio", "sasl"] }
 
 # Protobuf support
 protobuf = "3.5"
@@ -28,6 +28,7 @@ anyhow = { version = "1.0.100", features = ["backtrace"] }
 
 # Utilities
 chrono = "0.4"
+tempfile = "3.27"
 
 # Logging
 tracing = "0.1"

--- a/crates/kafka-producer/src/certs.rs
+++ b/crates/kafka-producer/src/certs.rs
@@ -193,6 +193,8 @@ fn run_cert_generation_in_docker(work_dir: &Path) -> Result<()> {
         .args([
             "run",
             "--rm",
+            "--user",
+            "0",
             "-v",
             &mount,
             DOCKER_IMAGE,

--- a/crates/kafka-producer/src/certs.rs
+++ b/crates/kafka-producer/src/certs.rs
@@ -186,15 +186,40 @@ ssl.endpoint.identification.algorithm=
     Ok(())
 }
 
+fn docker_run_user_spec() -> Result<String> {
+    #[cfg(unix)]
+    {
+        let uid = Command::new("id")
+            .arg("-u")
+            .output()
+            .context("Failed to run id -u")?;
+        let gid = Command::new("id")
+            .arg("-g")
+            .output()
+            .context("Failed to run id -g")?;
+        if !uid.status.success() || !gid.status.success() {
+            anyhow::bail!("id command failed while resolving docker --user");
+        }
+        let uid = String::from_utf8(uid.stdout).context("id -u stdout")?;
+        let gid = String::from_utf8(gid.stdout).context("id -g stdout")?;
+        Ok(format!("{}:{}", uid.trim(), gid.trim()))
+    }
+    #[cfg(not(unix))]
+    {
+        Ok("0".into())
+    }
+}
+
 fn run_cert_generation_in_docker(work_dir: &Path) -> Result<()> {
     let mount = format!("{}:/work", work_dir.display());
+    let user = docker_run_user_spec()?;
 
     let output = Command::new("docker")
         .args([
             "run",
             "--rm",
             "--user",
-            "0",
+            &user,
             "-v",
             &mount,
             DOCKER_IMAGE,

--- a/crates/kafka-producer/src/certs.rs
+++ b/crates/kafka-producer/src/certs.rs
@@ -1,0 +1,251 @@
+//! Generate TLS certificates and broker JKS secrets for secured Kafka tests.
+//!
+//! Certificate generation runs inside a one-off `apache/kafka:latest` container so
+//! the host only needs Docker (openssl + keytool are bundled in the image).
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use tempfile::TempDir;
+
+const DOCKER_IMAGE: &str = "apache/kafka:latest";
+
+/// Fixed password for broker JKS/truststore files in tests.
+pub const TEST_JKS_PASSWORD: &str = "changeit";
+
+/// Default SCRAM username for client connections in secured test brokers.
+pub const DEFAULT_SASL_USERNAME: &str = "syncuser";
+
+/// Default SCRAM password for client connections in secured test brokers.
+pub const DEFAULT_SASL_PASSWORD: &str = "syncpass";
+
+/// Inter-broker SCRAM/PLAIN username baked into broker JAAS.
+pub const INTER_BROKER_USERNAME: &str = "admin";
+
+/// Inter-broker SCRAM/PLAIN password baked into broker JAAS.
+pub const INTER_BROKER_PASSWORD: &str = "admin-secret";
+
+/// Generated TLS/SASL secrets for a secured Kafka test broker.
+pub struct KafkaTestSecrets {
+    pub dir: TempDir,
+    pub ca_pem: PathBuf,
+    pub client_cert_pem: PathBuf,
+    pub client_key_pem: PathBuf,
+    pub sasl_username: String,
+    pub sasl_password: String,
+}
+
+impl KafkaTestSecrets {
+    /// Generate a fresh secrets directory with broker JKS files and client PEM files.
+    pub fn generate() -> Result<Self> {
+        Self::generate_with_credentials(DEFAULT_SASL_USERNAME, DEFAULT_SASL_PASSWORD)
+    }
+
+    /// Generate secrets using custom SCRAM credentials for client connections.
+    pub fn generate_with_credentials(username: &str, password: &str) -> Result<Self> {
+        let dir = tempfile::tempdir().context("Failed to create temp secrets directory")?;
+        let work_dir = dir.path();
+
+        write_generate_script(work_dir)?;
+        write_jaas_config(work_dir)?;
+
+        run_cert_generation_in_docker(work_dir)?;
+
+        write_client_properties(work_dir, username, password)?;
+
+        let ca_pem = work_dir.join("ca.pem");
+        let client_cert_pem = work_dir.join("client.pem");
+        let client_key_pem = work_dir.join("client.key");
+
+        for path in [&ca_pem, &client_cert_pem, &client_key_pem] {
+            if !path.exists() {
+                anyhow::bail!("Expected generated file missing: {}", path.display());
+            }
+        }
+
+        Ok(Self {
+            dir,
+            ca_pem,
+            client_cert_pem,
+            client_key_pem,
+            sasl_username: username.to_string(),
+            sasl_password: password.to_string(),
+        })
+    }
+
+    /// Directory containing all broker and client secret files (mount at `/etc/kafka/secrets`).
+    pub fn secrets_dir(&self) -> &Path {
+        self.dir.path()
+    }
+
+    /// Path to the broker JAAS configuration file.
+    pub fn jaas_config_path(&self) -> PathBuf {
+        self.dir.path().join("kafka_server_jaas.conf")
+    }
+
+    /// Path to a client properties file for health checks (SASL_SSL + mTLS + SCRAM).
+    pub fn client_properties_path(&self) -> PathBuf {
+        self.dir.path().join("client.properties")
+    }
+}
+
+fn write_jaas_config(work_dir: &Path) -> Result<()> {
+    // SCRAM login module for inter-broker authentication. Client SCRAM credentials are
+    // bootstrapped into KRaft metadata by the secure container entrypoint.
+    let jaas = format!(
+        r#"KafkaServer {{
+    org.apache.kafka.common.security.scram.ScramLoginModule required
+    username="{INTER_BROKER_USERNAME}"
+    password="{INTER_BROKER_PASSWORD}";
+}};
+"#
+    );
+    std::fs::write(work_dir.join("kafka_server_jaas.conf"), jaas)
+        .context("Failed to write kafka_server_jaas.conf")?;
+    Ok(())
+}
+
+fn write_generate_script(work_dir: &Path) -> Result<()> {
+    let script = r#"#!/bin/bash
+set -euo pipefail
+cd /work
+
+PASSWORD="changeit"
+
+# --- CA ---
+openssl req -new -x509 -keyout ca.key -out ca.pem -days 3650 -nodes \
+  -subj "/CN=KafkaTestCA"
+
+# --- Broker server certificate (SAN: localhost + 127.0.0.1) ---
+openssl req -new -newkey rsa:2048 -nodes -keyout server.key -out server.csr \
+  -subj "/CN=localhost"
+cat > server.ext <<'EOF'
+subjectAltName=DNS:localhost,IP:127.0.0.1
+EOF
+openssl x509 -req -in server.csr -CA ca.pem -CAkey ca.key -CAcreateserial \
+  -out server.crt -days 3650 -extfile server.ext
+
+# --- Client certificate for mTLS ---
+openssl req -new -newkey rsa:2048 -nodes -keyout client.key -out client.csr \
+  -subj "/CN=syncuser"
+openssl x509 -req -in client.csr -CA ca.pem -CAkey ca.key -CAcreateserial \
+  -out client.pem -days 3650
+
+# --- Broker keystore (PKCS12 -> JKS) ---
+openssl pkcs12 -export -in server.crt -inkey server.key -out server.p12 \
+  -name kafka -password pass:${PASSWORD} -CAfile ca.pem
+keytool -importkeystore -deststorepass "${PASSWORD}" -destkeypass "${PASSWORD}" \
+  -destkeystore kafka.keystore.jks -srckeystore server.p12 -srcstoretype PKCS12 \
+  -srcstorepass "${PASSWORD}" -alias kafka -noprompt
+
+# --- Broker truststore (CA) ---
+keytool -import -file ca.pem -alias CARoot -keystore kafka.truststore.jks \
+  -storepass "${PASSWORD}" -noprompt
+
+# --- Client keystore (PKCS12 -> JKS) for Java CLI health checks ---
+openssl pkcs12 -export -in client.pem -inkey client.key -out client.p12 \
+  -name client -password pass:${PASSWORD} -CAfile ca.pem
+keytool -importkeystore -deststorepass "${PASSWORD}" -destkeypass "${PASSWORD}" \
+  -destkeystore client.keystore.jks -srckeystore client.p12 -srcstoretype PKCS12 \
+  -srcstorepass "${PASSWORD}" -alias client -noprompt
+
+# --- Password credential files expected by apache/kafka docker image ---
+echo "${PASSWORD}" > kafka_keystore_creds
+echo "${PASSWORD}" > kafka_truststore_creds
+echo "${PASSWORD}" > kafka_ssl_key_creds
+"#;
+
+    let script_path = work_dir.join("generate-certs.sh");
+    std::fs::write(&script_path, script).context("Failed to write cert generation script")?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
+            .context("Failed to mark cert generation script executable")?;
+    }
+
+    Ok(())
+}
+
+fn write_client_properties(work_dir: &Path, username: &str, password: &str) -> Result<()> {
+    let contents = format!(
+        r#"security.protocol=SASL_SSL
+sasl.mechanism=SCRAM-SHA-256
+sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="{username}" password="{password}";
+ssl.truststore.location=/etc/kafka/secrets/kafka.truststore.jks
+ssl.truststore.password={TEST_JKS_PASSWORD}
+ssl.keystore.location=/etc/kafka/secrets/client.keystore.jks
+ssl.keystore.password={TEST_JKS_PASSWORD}
+ssl.key.password={TEST_JKS_PASSWORD}
+ssl.endpoint.identification.algorithm=
+"#
+    );
+    std::fs::write(work_dir.join("client.properties"), contents)
+        .context("Failed to write client.properties")?;
+    Ok(())
+}
+
+fn run_cert_generation_in_docker(work_dir: &Path) -> Result<()> {
+    let mount = format!("{}:/work", work_dir.display());
+
+    let output = Command::new("docker")
+        .args([
+            "run",
+            "--rm",
+            "-v",
+            &mount,
+            DOCKER_IMAGE,
+            "bash",
+            "/work/generate-certs.sh",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .context("Failed to run cert generation container")?;
+
+    if !output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "Cert generation failed (exit {}):\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}",
+            output.status
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Smoke test: cert generation completes and expected files exist.
+    /// Requires Docker; skipped when Docker is unavailable.
+    #[test]
+    fn generate_certs_smoke() {
+        if !docker_available() {
+            eprintln!("Skipping generate_certs_smoke: docker not available");
+            return;
+        }
+
+        let secrets = KafkaTestSecrets::generate().expect("cert generation should succeed");
+        assert!(secrets.ca_pem.exists());
+        assert!(secrets.client_cert_pem.exists());
+        assert!(secrets.client_key_pem.exists());
+        assert!(secrets.secrets_dir().join("kafka.keystore.jks").exists());
+        assert!(secrets.secrets_dir().join("kafka.truststore.jks").exists());
+        assert_eq!(secrets.sasl_username, DEFAULT_SASL_USERNAME);
+        assert_eq!(secrets.sasl_password, DEFAULT_SASL_PASSWORD);
+    }
+
+    fn docker_available() -> bool {
+        Command::new("docker")
+            .args(["info"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+}

--- a/crates/kafka-producer/src/lib.rs
+++ b/crates/kafka-producer/src/lib.rs
@@ -65,6 +65,12 @@ mod protos;
 // Docker container management for Kafka test instances
 pub mod container;
 
+// TLS certificate generation for secured Kafka tests
+pub mod certs;
+
+// SASL_SSL + mTLS Kafka test container
+pub mod secure_container;
+
 // Test data helpers module
 pub mod testdata;
 
@@ -75,33 +81,191 @@ pub use protos::user_post_relation::UserPostRelation;
 
 pub use testdata::{publish_test_posts, publish_test_relations, publish_test_users};
 
+pub use certs::{
+    KafkaTestSecrets, DEFAULT_SASL_PASSWORD, DEFAULT_SASL_USERNAME, INTER_BROKER_PASSWORD,
+    INTER_BROKER_USERNAME, TEST_JKS_PASSWORD,
+};
+pub use secure_container::SecureKafkaContainer;
+
+/// SASL authentication mechanism for test Kafka clients.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SaslMechanism {
+    ScramSha256,
+    ScramSha512,
+    Plain,
+}
+
+impl SaslMechanism {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SaslMechanism::ScramSha256 => "SCRAM-SHA-256",
+            SaslMechanism::ScramSha512 => "SCRAM-SHA-512",
+            SaslMechanism::Plain => "PLAIN",
+        }
+    }
+}
+
+/// Kafka security protocol for test Kafka clients.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SecurityProtocol {
+    Plaintext,
+    Ssl,
+    SaslPlaintext,
+    SaslSsl,
+}
+
+impl SecurityProtocol {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SecurityProtocol::Plaintext => "PLAINTEXT",
+            SecurityProtocol::Ssl => "SSL",
+            SecurityProtocol::SaslPlaintext => "SASL_PLAINTEXT",
+            SecurityProtocol::SaslSsl => "SASL_SSL",
+        }
+    }
+
+    pub fn requires_sasl(&self) -> bool {
+        matches!(
+            self,
+            SecurityProtocol::SaslPlaintext | SecurityProtocol::SaslSsl
+        )
+    }
+
+    pub fn uses_ssl(&self) -> bool {
+        matches!(self, SecurityProtocol::Ssl | SecurityProtocol::SaslSsl)
+    }
+}
+
+/// Connection and security options shared by producer and admin clients.
+#[derive(Debug, Clone, Default)]
+pub struct KafkaConnectionOptions {
+    pub brokers: String,
+    pub security_protocol: Option<SecurityProtocol>,
+    pub sasl_mechanism: Option<SaslMechanism>,
+    pub sasl_username: Option<String>,
+    pub sasl_password: Option<String>,
+    pub ssl_ca_location: Option<String>,
+    pub ssl_certificate_location: Option<String>,
+    pub ssl_key_location: Option<String>,
+    pub ssl_key_password: Option<String>,
+}
+
+impl KafkaConnectionOptions {
+    /// PLAINTEXT connection to the given broker address.
+    pub fn plaintext(brokers: impl Into<String>) -> Self {
+        Self {
+            brokers: brokers.into(),
+            ..Default::default()
+        }
+    }
+
+    fn validate(&self) -> Result<()> {
+        if let Some(protocol) = self.security_protocol {
+            if protocol.requires_sasl() {
+                if self.sasl_username.is_none() || self.sasl_password.is_none() {
+                    anyhow::bail!(
+                        "Security protocol '{}' requires both sasl_username and sasl_password",
+                        protocol.as_str()
+                    );
+                }
+                if self.sasl_mechanism.is_none() {
+                    anyhow::bail!(
+                        "Security protocol '{}' requires sasl_mechanism to be set",
+                        protocol.as_str()
+                    );
+                }
+            }
+        }
+
+        let has_cert = self.ssl_certificate_location.is_some();
+        let has_key = self.ssl_key_location.is_some();
+        if has_cert != has_key {
+            anyhow::bail!(
+                "ssl_certificate_location and ssl_key_location must both be set for mTLS client authentication"
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Apply security settings to an rdkafka client configuration.
+    pub fn apply_to_client_config(&self, config: &mut ClientConfig) -> Result<()> {
+        self.validate()?;
+
+        config
+            .set("bootstrap.servers", &self.brokers)
+            .set("message.timeout.ms", "5000");
+
+        if let Some(protocol) = self.security_protocol {
+            config.set("security.protocol", protocol.as_str());
+
+            if protocol.requires_sasl() {
+                config
+                    .set(
+                        "sasl.mechanism",
+                        self.sasl_mechanism.as_ref().unwrap().as_str(),
+                    )
+                    .set("sasl.username", self.sasl_username.as_deref().unwrap())
+                    .set("sasl.password", self.sasl_password.as_deref().unwrap());
+            }
+
+            if protocol.uses_ssl() {
+                if let Some(ca) = &self.ssl_ca_location {
+                    config.set("ssl.ca.location", ca);
+                }
+                if let Some(cert) = &self.ssl_certificate_location {
+                    config.set("ssl.certificate.location", cert);
+                }
+                if let Some(key) = &self.ssl_key_location {
+                    config.set("ssl.key.location", key);
+                }
+                if let Some(password) = &self.ssl_key_password {
+                    config.set("ssl.key.password", password);
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
 /// Kafka producer wrapper for testing
 pub struct KafkaTestProducer {
     producer: FutureProducer,
-    broker: String,
+    options: KafkaConnectionOptions,
 }
 
 impl KafkaTestProducer {
-    /// Create a new Kafka test producer
-    pub async fn new(broker: &str) -> Result<Self> {
-        let producer: FutureProducer = ClientConfig::new()
-            .set("bootstrap.servers", broker)
-            .set("message.timeout.ms", "5000")
-            .create()
-            .context("Failed to create Kafka producer")?;
+    /// Connect to Kafka with explicit security options.
+    pub async fn connect(options: &KafkaConnectionOptions) -> Result<Self> {
+        let mut config = ClientConfig::new();
+        options
+            .apply_to_client_config(&mut config)
+            .context("Invalid Kafka connection options")?;
+
+        let producer: FutureProducer =
+            config.create().context("Failed to create Kafka producer")?;
 
         Ok(Self {
             producer,
-            broker: broker.to_string(),
+            options: options.clone(),
         })
+    }
+
+    /// Create a PLAINTEXT Kafka test producer (backward-compatible wrapper).
+    pub async fn new(broker: &str) -> Result<Self> {
+        Self::connect(&KafkaConnectionOptions::plaintext(broker)).await
     }
 
     /// Create Kafka topic if it doesn't exist
     pub async fn create_topic_if_not_exists(&self, topic: &str, partitions: i32) -> Result<()> {
-        let admin_client: AdminClient<DefaultClientContext> = ClientConfig::new()
-            .set("bootstrap.servers", &self.broker)
-            .create()
-            .context("Failed to create admin client")?;
+        let mut config = ClientConfig::new();
+        self.options
+            .apply_to_client_config(&mut config)
+            .context("Invalid Kafka connection options")?;
+
+        let admin_client: AdminClient<DefaultClientContext> =
+            config.create().context("Failed to create admin client")?;
 
         let new_topic = NewTopic::new(topic, partitions, TopicReplication::Fixed(1));
         let opts = AdminOptions::new().operation_timeout(Some(Duration::from_secs(5)));

--- a/crates/kafka-producer/src/secure_container.rs
+++ b/crates/kafka-producer/src/secure_container.rs
@@ -1,0 +1,321 @@
+//! Docker container management for SASL_SSL + mTLS Kafka test instances.
+//!
+//! Starts an `apache/kafka:latest` broker with SCRAM-SHA-256 client authentication,
+//! required client TLS certificates, and a custom entrypoint that bootstraps SCRAM
+//! credentials into KRaft metadata at storage format time.
+
+use crate::certs::{
+    KafkaTestSecrets, DEFAULT_SASL_PASSWORD, DEFAULT_SASL_USERNAME, INTER_BROKER_PASSWORD,
+    INTER_BROKER_USERNAME,
+};
+use anyhow::{Context, Result};
+use std::net::TcpListener;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+use tracing::{debug, info};
+
+const DOCKER_IMAGE: &str = "apache/kafka:latest";
+const CLUSTER_ID: &str = "4L6g3nShT-eMCtK--X86sw";
+
+/// A secured test Kafka container (SASL_SSL + SCRAM-SHA-256 + required mTLS).
+pub struct SecureKafkaContainer {
+    pub container_name: String,
+    pub host_port: u16,
+    /// Broker address in `localhost:<port>` form for rdkafka clients.
+    pub broker_address: String,
+    secrets: KafkaTestSecrets,
+}
+
+impl SecureKafkaContainer {
+    /// Creates a new container configuration. Generates TLS/SASL secrets eagerly.
+    /// Call [`start`](Self::start) before using the broker.
+    pub fn new(container_name: &str) -> Result<Self> {
+        Ok(Self {
+            container_name: container_name.to_string(),
+            host_port: 0,
+            broker_address: String::new(),
+            secrets: KafkaTestSecrets::generate()?,
+        })
+    }
+
+    /// Reference to the generated TLS/SASL secrets (PEM paths, SCRAM credentials).
+    pub fn secrets(&self) -> &KafkaTestSecrets {
+        &self.secrets
+    }
+
+    /// Finds a free host port, starts the secured Kafka container, and sets
+    /// [`broker_address`](Self::broker_address).
+    pub fn start(&mut self) -> Result<()> {
+        info!("Starting secured Kafka container: {}", self.container_name);
+
+        let _ = Command::new("docker")
+            .args(["rm", "-f", &self.container_name])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+
+        let port = find_available_port()?;
+        let port_mapping = format!("{port}:9092");
+        let advertised = format!("SASL_SSL://localhost:{port}");
+
+        write_entrypoint_script(self.secrets.secrets_dir())?;
+
+        let secrets_mount = format!(
+            "{}:/etc/kafka/secrets",
+            self.secrets.secrets_dir().display()
+        );
+
+        let output = Command::new("docker")
+            .args([
+                "run",
+                "--name",
+                &self.container_name,
+                "-v",
+                &secrets_mount,
+                "--entrypoint",
+                "/etc/kafka/secrets/secure-entrypoint.sh",
+                "-e",
+                "KAFKA_NODE_ID=1",
+                "-e",
+                "KAFKA_PROCESS_ROLES=broker,controller",
+                "-e",
+                "KAFKA_LISTENERS=SASL_SSL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093",
+                "-e",
+                &format!("KAFKA_ADVERTISED_LISTENERS={advertised}"),
+                "-e",
+                "KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER",
+                "-e",
+                "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,SASL_SSL:SASL_SSL",
+                "-e",
+                "KAFKA_CONTROLLER_QUORUM_VOTERS=1@localhost:9093",
+                "-e",
+                "KAFKA_SASL_ENABLED_MECHANISMS=SCRAM-SHA-256",
+                "-e",
+                "KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL=SCRAM-SHA-256",
+                "-e",
+                "KAFKA_SECURITY_INTER_BROKER_PROTOCOL=SASL_SSL",
+                "-e",
+                "KAFKA_SSL_CLIENT_AUTH=required",
+                "-e",
+                "KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM=",
+                "-e",
+                "KAFKA_SSL_KEYSTORE_FILENAME=kafka.keystore.jks",
+                "-e",
+                "KAFKA_SSL_KEYSTORE_CREDENTIALS=kafka_keystore_creds",
+                "-e",
+                "KAFKA_SSL_KEY_CREDENTIALS=kafka_ssl_key_creds",
+                "-e",
+                "KAFKA_SSL_TRUSTSTORE_FILENAME=kafka.truststore.jks",
+                "-e",
+                "KAFKA_SSL_TRUSTSTORE_CREDENTIALS=kafka_truststore_creds",
+                "-e",
+                "KAFKA_OPTS=-Djava.security.auth.login.config=/etc/kafka/secrets/kafka_server_jaas.conf",
+                "-e",
+                &format!("CLUSTER_ID={CLUSTER_ID}"),
+                "-e",
+                "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1",
+                "-e",
+                "KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1",
+                "-e",
+                "KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1",
+                "-e",
+                "KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0",
+                "-e",
+                "KAFKA_NUM_PARTITIONS=3",
+                "-e",
+                "KAFKA_LOG_DIRS=/tmp/kraft-combined-logs",
+                "-e",
+                &format!("KAFKA_SCRAM_CLIENT_USER={DEFAULT_SASL_USERNAME}"),
+                "-e",
+                &format!("KAFKA_SCRAM_CLIENT_PASSWORD={DEFAULT_SASL_PASSWORD}"),
+                "-e",
+                &format!("KAFKA_SCRAM_BROKER_USER={INTER_BROKER_USERNAME}"),
+                "-e",
+                &format!("KAFKA_SCRAM_BROKER_PASSWORD={INTER_BROKER_PASSWORD}"),
+                "-p",
+                &port_mapping,
+                "-d",
+                DOCKER_IMAGE,
+            ])
+            .output()
+            .context("Failed to start secured Kafka Docker container")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("Failed to start secured Kafka container: {stderr}");
+        }
+
+        let container_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        info!("Started secured Kafka container: {}", container_id);
+
+        self.host_port = port;
+        self.broker_address = format!("localhost:{port}");
+
+        info!(
+            "Secured Kafka container bound to dynamic port {} (broker: {})",
+            self.host_port, self.broker_address
+        );
+
+        Ok(())
+    }
+
+    /// Polls until the broker accepts SASL_SSL + mTLS + SCRAM connections, up to `timeout_secs`.
+    pub async fn wait_until_ready(&self, timeout_secs: u64) -> Result<()> {
+        info!("Waiting for secured Kafka to be ready...");
+
+        let start = Instant::now();
+        let timeout = Duration::from_secs(timeout_secs);
+
+        while start.elapsed() < timeout {
+            let status = Command::new("docker")
+                .args([
+                    "exec",
+                    &self.container_name,
+                    "/opt/kafka/bin/kafka-broker-api-versions.sh",
+                    "--bootstrap-server",
+                    "localhost:9092",
+                    "--command-config",
+                    "/etc/kafka/secrets/client.properties",
+                ])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status();
+
+            match status {
+                Ok(s) if s.success() => {
+                    info!("Secured Kafka is ready!");
+                    return Ok(());
+                }
+                Ok(_) => {
+                    debug!("Secured Kafka not ready yet, retrying...");
+                }
+                Err(e) => {
+                    debug!("Secured Kafka health check command failed: {}", e);
+                }
+            }
+
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+
+        anyhow::bail!("Secured Kafka did not become ready within {timeout_secs} seconds")
+    }
+
+    pub fn stop(&self) -> Result<()> {
+        info!("Stopping secured Kafka container: {}", self.container_name);
+
+        let output = Command::new("docker")
+            .args(["stop", &self.container_name])
+            .output()
+            .context("Failed to stop container")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            debug!("Failed to stop container (may not exist): {}", stderr);
+        }
+
+        let output = Command::new("docker")
+            .args(["rm", &self.container_name])
+            .output()
+            .context("Failed to remove container")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            debug!("Failed to remove container (may not exist): {}", stderr);
+        }
+
+        info!("Secured Kafka container stopped and removed");
+        Ok(())
+    }
+
+    pub fn get_logs(&self) -> Result<String> {
+        let output = Command::new("docker")
+            .args(["logs", &self.container_name])
+            .output()
+            .context("Failed to get container logs")?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        Ok(format!("STDOUT:\n{stdout}\n\nSTDERR:\n{stderr}"))
+    }
+}
+
+impl Drop for SecureKafkaContainer {
+    fn drop(&mut self) {
+        let _ = self.stop();
+    }
+}
+
+/// Custom entrypoint: configure broker properties, bootstrap SCRAM credentials into
+/// KRaft metadata, then delegate to the image's normal startup script.
+///
+/// Inter-broker authentication uses SCRAM-SHA-256 over SASL_SSL (same listener as clients).
+/// If single-node KRaft inter-broker SCRAM proves flaky, fall back to PLAIN for
+/// `KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL` only while keeping SCRAM-SHA-256 for
+/// client connections — client-side SASL_SSL + mTLS + SCRAM remains unchanged.
+fn write_entrypoint_script(secrets_dir: &Path) -> Result<()> {
+    let script = r#"#!/usr/bin/env bash
+set -euo pipefail
+
+. /etc/kafka/docker/bash-config
+. /etc/kafka/docker/configureDefaults
+. /etc/kafka/docker/configure
+
+LOG_DIR="${KAFKA_LOG_DIRS:-/tmp/kraft-combined-logs}"
+CLUSTER_ID="${CLUSTER_ID:?CLUSTER_ID is required}"
+CLIENT_USER="${KAFKA_SCRAM_CLIENT_USER:?}"
+CLIENT_PASSWORD="${KAFKA_SCRAM_CLIENT_PASSWORD:?}"
+BROKER_USER="${KAFKA_SCRAM_BROKER_USER:?}"
+BROKER_PASSWORD="${KAFKA_SCRAM_BROKER_PASSWORD:?}"
+
+if [ ! -f "${LOG_DIR}/meta.properties" ]; then
+  echo "===> Formatting KRaft storage with SCRAM credentials ..."
+  /opt/kafka/bin/kafka-storage.sh format \
+    -t "${CLUSTER_ID}" \
+    -c /opt/kafka/config/server.properties \
+    --standalone \
+    --add-scram "SCRAM-SHA-256=[name=${CLIENT_USER},password=${CLIENT_PASSWORD}]" \
+    --add-scram "SCRAM-SHA-256=[name=${BROKER_USER},password=${BROKER_PASSWORD}]"
+fi
+
+exec /etc/kafka/docker/run
+"#;
+
+    let path = secrets_dir.join("secure-entrypoint.sh");
+    std::fs::write(&path, script).context("Failed to write secure entrypoint script")?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+            .context("Failed to mark secure entrypoint script executable")?;
+    }
+
+    Ok(())
+}
+
+fn find_available_port() -> Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0").context("Failed to bind to ephemeral port")?;
+    let port = listener.local_addr()?.port();
+    Ok(port)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Full broker boot smoke test (Docker required). Run with:
+    /// `cargo test -p surreal-sync-kafka-producer secure_boot -- --ignored --nocapture`
+    #[tokio::test]
+    #[ignore = "requires Docker and ~30-60s broker startup"]
+    async fn secure_boot_smoke() {
+        let mut container =
+            SecureKafkaContainer::new("surreal-sync-secure-kafka-boot-smoke").unwrap();
+        container.start().unwrap();
+        if let Err(err) = container.wait_until_ready(90).await {
+            let logs = container.get_logs().unwrap_or_default();
+            panic!("broker not ready: {err}\n{logs}");
+        }
+    }
+}

--- a/crates/kafka-source/src/consumer.rs
+++ b/crates/kafka-source/src/consumer.rs
@@ -66,6 +66,10 @@ impl SecurityProtocol {
             SecurityProtocol::SaslPlaintext | SecurityProtocol::SaslSsl
         )
     }
+
+    pub fn uses_ssl(&self) -> bool {
+        matches!(self, SecurityProtocol::Ssl | SecurityProtocol::SaslSsl)
+    }
 }
 
 /// Configuration for Kafka consumer
@@ -119,6 +123,14 @@ pub struct ConsumerConfig {
     pub sasl_mechanism: Option<SaslMechanism>,
     /// Security protocol. When None, rdkafka defaults to PLAINTEXT (no auth).
     pub security_protocol: Option<SecurityProtocol>,
+    /// Path to CA certificate file for broker verification (`ssl.ca.location`)
+    pub ssl_ca_location: Option<String>,
+    /// Path to client certificate file for mTLS (`ssl.certificate.location`)
+    pub ssl_certificate_location: Option<String>,
+    /// Path to client private key file for mTLS (`ssl.key.location`)
+    pub ssl_key_location: Option<String>,
+    /// Password for the client private key (`ssl.key.password`)
+    pub ssl_key_password: Option<String>,
 }
 
 impl Default for ConsumerConfig {
@@ -136,8 +148,47 @@ impl Default for ConsumerConfig {
             sasl_password: None,
             sasl_mechanism: None,
             security_protocol: None,
+            ssl_ca_location: None,
+            ssl_certificate_location: None,
+            ssl_key_location: None,
+            ssl_key_password: None,
         }
     }
+}
+
+fn validate_mtls_pairing(config: &ConsumerConfig) -> Result<()> {
+    let has_cert = config.ssl_certificate_location.is_some();
+    let has_key = config.ssl_key_location.is_some();
+    if has_cert != has_key {
+        return Err(Error::Consumer(
+            "ssl_certificate_location and ssl_key_location must both be set for mTLS client authentication"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn ssl_config_entries(config: &ConsumerConfig) -> Vec<(&'static str, &str)> {
+    let mut entries = Vec::new();
+    let Some(protocol) = config.security_protocol.as_ref() else {
+        return entries;
+    };
+    if !protocol.uses_ssl() {
+        return entries;
+    }
+    if let Some(ca) = config.ssl_ca_location.as_deref() {
+        entries.push(("ssl.ca.location", ca));
+    }
+    if let Some(cert) = config.ssl_certificate_location.as_deref() {
+        entries.push(("ssl.certificate.location", cert));
+    }
+    if let Some(key) = config.ssl_key_location.as_deref() {
+        entries.push(("ssl.key.location", key));
+    }
+    if let Some(password) = config.ssl_key_password.as_deref() {
+        entries.push(("ssl.key.password", password));
+    }
+    entries
 }
 
 /// Kafka consumer with peek buffer and manual offset management
@@ -168,6 +219,8 @@ impl Consumer {
             }
         }
 
+        validate_mtls_pairing(&config)?;
+
         let mut client_config = ClientConfig::new();
         client_config
             .set("bootstrap.servers", &config.brokers)
@@ -189,6 +242,10 @@ impl Consumer {
                     .set("sasl.username", config.sasl_username.as_deref().unwrap())
                     .set("sasl.password", config.sasl_password.as_deref().unwrap());
             }
+        }
+
+        for (key, value) in ssl_config_entries(&config) {
+            client_config.set(key, value);
         }
 
         let consumer: RdkafkaStreamConsumer = client_config
@@ -379,6 +436,18 @@ mod tests {
         assert!(!SecurityProtocol::Ssl.requires_sasl());
     }
 
+    #[test]
+    fn uses_ssl_for_ssl_protocols() {
+        assert!(SecurityProtocol::Ssl.uses_ssl());
+        assert!(SecurityProtocol::SaslSsl.uses_ssl());
+    }
+
+    #[test]
+    fn uses_ssl_false_for_non_ssl_protocols() {
+        assert!(!SecurityProtocol::Plaintext.uses_ssl());
+        assert!(!SecurityProtocol::SaslPlaintext.uses_ssl());
+    }
+
     fn config_with_sasl_protocol(protocol: SecurityProtocol) -> ConsumerConfig {
         ConsumerConfig {
             security_protocol: Some(protocol),
@@ -461,6 +530,76 @@ mod tests {
                 "unexpected SASL error when no protocol set: {e}"
             );
         }
+    }
+
+    #[test]
+    fn rejects_cert_without_key() {
+        let config = ConsumerConfig {
+            ssl_certificate_location: Some("/path/to/client.pem".into()),
+            ..Default::default()
+        };
+        let err = expect_err(Consumer::new(config, dummy_decoder()));
+        assert!(err.to_string().contains("ssl_certificate_location"));
+        assert!(err.to_string().contains("ssl_key_location"));
+    }
+
+    #[test]
+    fn rejects_key_without_cert() {
+        let config = ConsumerConfig {
+            ssl_key_location: Some("/path/to/client.key".into()),
+            ..Default::default()
+        };
+        let err = expect_err(Consumer::new(config, dummy_decoder()));
+        assert!(err.to_string().contains("ssl_certificate_location"));
+        assert!(err.to_string().contains("ssl_key_location"));
+    }
+
+    #[test]
+    fn ssl_config_skipped_for_plaintext_protocols() {
+        for protocol in [SecurityProtocol::Plaintext, SecurityProtocol::SaslPlaintext] {
+            let protocol_for_msg = format!("{protocol:?}");
+            let config = ConsumerConfig {
+                security_protocol: Some(protocol),
+                ssl_ca_location: Some("/ca.pem".into()),
+                ssl_certificate_location: Some("/client.pem".into()),
+                ssl_key_location: Some("/client.key".into()),
+                ssl_key_password: Some("secret".into()),
+                ..Default::default()
+            };
+            assert!(
+                ssl_config_entries(&config).is_empty(),
+                "SSL settings should not apply for {protocol_for_msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn ssl_config_applied_for_ssl_protocols() {
+        let config = ConsumerConfig {
+            security_protocol: Some(SecurityProtocol::SaslSsl),
+            ssl_ca_location: Some("/ca.pem".into()),
+            ssl_certificate_location: Some("/client.pem".into()),
+            ssl_key_location: Some("/client.key".into()),
+            ssl_key_password: Some("secret".into()),
+            ..Default::default()
+        };
+        let entries = ssl_config_entries(&config);
+        assert_eq!(entries.len(), 4);
+        assert!(entries.contains(&("ssl.ca.location", "/ca.pem")));
+        assert!(entries.contains(&("ssl.certificate.location", "/client.pem")));
+        assert!(entries.contains(&("ssl.key.location", "/client.key")));
+        assert!(entries.contains(&("ssl.key.password", "secret")));
+    }
+
+    #[test]
+    fn ssl_config_ca_only_without_mtls() {
+        let config = ConsumerConfig {
+            security_protocol: Some(SecurityProtocol::Ssl),
+            ssl_ca_location: Some("/ca.pem".into()),
+            ..Default::default()
+        };
+        let entries = ssl_config_entries(&config);
+        assert_eq!(entries, vec![("ssl.ca.location", "/ca.pem")]);
     }
 
     /// Minimal decoder — validation tests fail before decoding is ever attempted.

--- a/crates/kafka-source/src/sync/incremental.rs
+++ b/crates/kafka-source/src/sync/incremental.rs
@@ -83,6 +83,18 @@ pub struct Config {
     /// Security protocol. Omit for plain Kafka with no auth.
     #[clap(long, value_enum)]
     pub security_protocol: Option<SecurityProtocol>,
+    /// Path to CA certificate file for broker verification
+    #[clap(long, env = "KAFKA_SSL_CA_LOCATION")]
+    pub ssl_ca_location: Option<String>,
+    /// Path to client certificate file for mTLS
+    #[clap(long, env = "KAFKA_SSL_CERTIFICATE_LOCATION")]
+    pub ssl_certificate_location: Option<String>,
+    /// Path to client private key file for mTLS
+    #[clap(long, env = "KAFKA_SSL_KEY_LOCATION")]
+    pub ssl_key_location: Option<String>,
+    /// Password for the client private key
+    #[clap(long, env = "KAFKA_SSL_KEY_PASSWORD")]
+    pub ssl_key_password: Option<String>,
 }
 
 /// Run incremental sync from Kafka to SurrealDB.
@@ -120,6 +132,10 @@ pub async fn run_incremental_sync<S: SurrealSink + Send + Sync + 'static>(
         sasl_password: config.sasl_password,
         sasl_mechanism: config.sasl_mechanism,
         security_protocol: config.security_protocol,
+        ssl_ca_location: config.ssl_ca_location,
+        ssl_certificate_location: config.ssl_certificate_location,
+        ssl_key_location: config.ssl_key_location,
+        ssl_key_password: config.ssl_key_password,
         ..Default::default()
     };
 

--- a/docs/kafka.md
+++ b/docs/kafka.md
@@ -80,6 +80,37 @@ For secured Kafka clusters, set `--security-protocol` to `SASL_PLAINTEXT` or `SA
 | `--sasl-password <PASS>` | `KAFKA_SASL_PASSWORD` | SASL password |
 | `--sasl-mechanism <MECH>` | — | `SCRAM-SHA-256`, `SCRAM-SHA-512`, or `PLAIN` |
 
+### TLS / mTLS
+
+When `--security-protocol` is `SSL` or `SASL_SSL`, you can configure TLS trust and optional mutual TLS (mTLS) client authentication. These flags map to librdkafka `ssl.*` settings and are ignored for `PLAINTEXT` and `SASL_PLAINTEXT`.
+
+| Flag | Env var | Description |
+|------|---------|-------------|
+| `--ssl-ca-location <PATH>` | `KAFKA_SSL_CA_LOCATION` | Custom CA certificate for broker verification (omit to use the system trust store) |
+| `--ssl-certificate-location <PATH>` | `KAFKA_SSL_CERTIFICATE_LOCATION` | Client certificate for mTLS (must be paired with `--ssl-key-location`) |
+| `--ssl-key-location <PATH>` | `KAFKA_SSL_KEY_LOCATION` | Client private key for mTLS (must be paired with `--ssl-certificate-location`) |
+| `--ssl-key-password <PASS>` | `KAFKA_SSL_KEY_PASSWORD` | Password for an encrypted client private key (optional) |
+
+Example combining SASL, a custom CA, and mTLS client credentials:
+
+```bash
+surreal-sync from kafka \
+  --proto-path ./schemas/user.proto \
+  --brokers kafka.example.com:9093 \
+  --group-id user-sync \
+  --topic users \
+  --message-type User \
+  --security-protocol SASL_SSL \
+  --sasl-mechanism SCRAM-SHA-256 \
+  --sasl-username "$KAFKA_SASL_USERNAME" \
+  --sasl-password "$KAFKA_SASL_PASSWORD" \
+  --ssl-ca-location /etc/kafka/secrets/ca.pem \
+  --ssl-certificate-location /etc/kafka/secrets/client.pem \
+  --ssl-key-location /etc/kafka/secrets/client.key \
+  --to-namespace production \
+  --to-database users
+```
+
 Run `surreal-sync from kafka --help` for full flag details.
 
 ### SurrealDB Connection Settings
@@ -495,7 +526,7 @@ For production deployments that need continuous consumption:
 
 ### Kafka Client Settings Flexibility
 
-surreal-sync uses the Kafka client library (librdkafka) with a fixed set of settings (brokers, consumer group, session timeout, and optional SASL authentication). All other librdkafka settings use their defaults.
+surreal-sync uses the Kafka client library (librdkafka) with a fixed set of settings (brokers, consumer group, session timeout, optional SASL authentication, and optional TLS/mTLS certificate paths). All other librdkafka settings use their defaults.
 
 See [librdkafka Configuration Documentation](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md) for complete details on all settings and their defaults.
 

--- a/tests/kafka/incremental_sync_lib.rs
+++ b/tests/kafka/incremental_sync_lib.rs
@@ -131,6 +131,10 @@ async fn test_kafka_incremental_sync_lib() -> Result<(), Box<dyn std::error::Err
         sasl_password: None,
         sasl_mechanism: None,
         security_protocol: None,
+        ssl_ca_location: None,
+        ssl_certificate_location: None,
+        ssl_key_location: None,
+        ssl_key_password: None,
     };
 
     // Run sync with a short deadline (just enough to consume existing messages)
@@ -187,6 +191,10 @@ async fn test_kafka_incremental_sync_lib() -> Result<(), Box<dyn std::error::Err
                 sasl_password: None,
                 sasl_mechanism: None,
                 security_protocol: None,
+                ssl_ca_location: None,
+                ssl_certificate_location: None,
+                ssl_key_location: None,
+                ssl_key_password: None,
             };
 
             let deadline = Utc::now() + chrono::Duration::seconds(5);
@@ -235,6 +243,10 @@ async fn test_kafka_incremental_sync_lib() -> Result<(), Box<dyn std::error::Err
                 sasl_password: None,
                 sasl_mechanism: None,
                 security_protocol: None,
+                ssl_ca_location: None,
+                ssl_certificate_location: None,
+                ssl_key_location: None,
+                ssl_key_password: None,
             };
 
             let deadline = Utc::now() + chrono::Duration::seconds(5);
@@ -306,6 +318,10 @@ async fn test_kafka_incremental_sync_lib() -> Result<(), Box<dyn std::error::Err
                 sasl_password: None,
                 sasl_mechanism: None,
                 security_protocol: None,
+                ssl_ca_location: None,
+                ssl_certificate_location: None,
+                ssl_key_location: None,
+                ssl_key_password: None,
             };
 
             let deadline = Utc::now() + chrono::Duration::seconds(5);
@@ -354,6 +370,10 @@ async fn test_kafka_incremental_sync_lib() -> Result<(), Box<dyn std::error::Err
                 sasl_password: None,
                 sasl_mechanism: None,
                 security_protocol: None,
+                ssl_ca_location: None,
+                ssl_certificate_location: None,
+                ssl_key_location: None,
+                ssl_key_password: None,
             };
 
             let deadline = Utc::now() + chrono::Duration::seconds(5);

--- a/tests/kafka/main.rs
+++ b/tests/kafka/main.rs
@@ -4,3 +4,4 @@
 //! that does not require full sync or checkpoint management.
 
 mod incremental_sync_lib;
+mod sasl_ssl_mtls_sync;

--- a/tests/kafka/sasl_ssl_mtls_sync.rs
+++ b/tests/kafka/sasl_ssl_mtls_sync.rs
@@ -1,0 +1,146 @@
+//! E2E test for Kafka incremental sync over SASL_SSL + SCRAM-SHA-256 + mTLS.
+
+use chrono::Utc;
+use std::{sync::Arc, time::Duration};
+use surreal_sync::testing::surreal::{
+    assert_synced_auto, cleanup_surrealdb_auto, connect_auto, SurrealConnection,
+};
+use surreal_sync::testing::{
+    generate_test_id, table::TestDataSet, users::create_users_table, SourceDatabase, TestConfig,
+};
+use surreal_sync_kafka_producer::secure_container::SecureKafkaContainer;
+use surreal_sync_kafka_producer::{
+    publish_test_users, KafkaConnectionOptions, KafkaTestProducer, SaslMechanism, SecurityProtocol,
+};
+use surreal_sync_kafka_source::{
+    Config as KafkaConfig, SaslMechanism as ConsumerSaslMechanism,
+    SecurityProtocol as ConsumerSecurityProtocol,
+};
+use tokio::time::sleep;
+
+#[tokio::test]
+async fn test_kafka_sasl_ssl_mtls_sync() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter("surreal_sync=debug,surreal_sync_kafka_source=debug")
+        .try_init()
+        .ok();
+
+    let surrealdb = surreal_sync::testing::shared_containers::shared_surrealdb();
+
+    let mut kafka = SecureKafkaContainer::new("test-kafka-sasl-ssl-mtls")?;
+    kafka.start()?;
+    kafka.wait_until_ready(60).await?;
+
+    let secrets = kafka.secrets();
+    let kafka_broker = kafka.broker_address.clone();
+
+    let test_id = generate_test_id();
+    let dataset = TestDataSet::new().add_table(create_users_table());
+    let users_topic = format!("test-users-sasl-ssl-{test_id}");
+
+    tracing::info!("Using secured Kafka topic: {users_topic}");
+
+    let surreal_config = TestConfig::with_surreal_endpoint(test_id, &surrealdb.ws_endpoint());
+    let conn = connect_auto(&surreal_config).await?;
+    cleanup_surrealdb_auto(&conn, &dataset).await?;
+
+    let connection_options = KafkaConnectionOptions {
+        brokers: kafka_broker.clone(),
+        security_protocol: Some(SecurityProtocol::SaslSsl),
+        sasl_mechanism: Some(SaslMechanism::ScramSha256),
+        sasl_username: Some(secrets.sasl_username.clone()),
+        sasl_password: Some(secrets.sasl_password.clone()),
+        ssl_ca_location: Some(secrets.ca_pem.to_string_lossy().into_owned()),
+        ssl_certificate_location: Some(secrets.client_cert_pem.to_string_lossy().into_owned()),
+        ssl_key_location: Some(secrets.client_key_pem.to_string_lossy().into_owned()),
+        ssl_key_password: None,
+    };
+
+    tracing::info!("Connecting secured Kafka producer...");
+    let producer = KafkaTestProducer::connect(&connection_options).await?;
+    producer.create_topic_if_not_exists(&users_topic, 3).await?;
+    sleep(Duration::from_millis(500)).await;
+
+    tracing::info!("Publishing users to secured Kafka topic...");
+    publish_test_users(&producer, &users_topic).await?;
+    sleep(Duration::from_millis(200)).await;
+
+    let proto_dir = tempfile::tempdir()?;
+    let user_proto_path = proto_dir.path().join("user.proto");
+    std::fs::write(
+        &user_proto_path,
+        include_str!("../../crates/kafka-producer/proto/user.proto"),
+    )?;
+
+    let user_config = KafkaConfig {
+        proto_path: user_proto_path.to_string_lossy().to_string(),
+        brokers: vec![kafka_broker],
+        group_id: format!("test-group-sasl-ssl-{test_id}"),
+        topic: users_topic,
+        message_type: "User".to_string(),
+        buffer_size: 1000,
+        session_timeout_ms: "6000".to_string(),
+        num_consumers: 1,
+        kafka_batch_size: 100,
+        table_name: Some("all_types_users".to_string()),
+        use_message_key_as_id: false,
+        id_field: "id".to_string(),
+        max_messages: None,
+        sasl_username: Some(secrets.sasl_username.clone()),
+        sasl_password: Some(secrets.sasl_password.clone()),
+        sasl_mechanism: Some(ConsumerSaslMechanism::ScramSha256),
+        security_protocol: Some(ConsumerSecurityProtocol::SaslSsl),
+        ssl_ca_location: Some(secrets.ca_pem.to_string_lossy().into_owned()),
+        ssl_certificate_location: Some(secrets.client_cert_pem.to_string_lossy().into_owned()),
+        ssl_key_location: Some(secrets.client_key_pem.to_string_lossy().into_owned()),
+        ssl_key_password: None,
+    };
+
+    let deadline = Utc::now() + chrono::Duration::seconds(5);
+
+    tracing::info!("Running secured Kafka incremental sync for users...");
+    match &conn {
+        SurrealConnection::V2(client) => {
+            let sink = Arc::new(surreal2_sink::Surreal2Sink::new(client.clone()));
+            let sync_handle = tokio::spawn(async move {
+                surreal_sync_kafka_source::run_incremental_sync(sink, user_config, deadline, None)
+                    .await
+            });
+
+            let sync_result = tokio::time::timeout(Duration::from_secs(10), sync_handle).await;
+            match sync_result {
+                Ok(Ok(Ok(()))) => tracing::info!("User sync completed successfully"),
+                Ok(Ok(Err(e))) => tracing::warn!("User sync error (may be expected): {e}"),
+                Ok(Err(e)) => tracing::warn!("User sync task error: {e}"),
+                Err(_) => tracing::info!("User sync timeout (expected for test)"),
+            }
+        }
+        SurrealConnection::V3(client) => {
+            let sink = Arc::new(surreal3_sink::Surreal3Sink::new(client.clone()));
+            let sync_handle = tokio::spawn(async move {
+                surreal_sync_kafka_source::run_incremental_sync(sink, user_config, deadline, None)
+                    .await
+            });
+
+            let sync_result = tokio::time::timeout(Duration::from_secs(10), sync_handle).await;
+            match sync_result {
+                Ok(Ok(Ok(()))) => tracing::info!("User sync completed successfully"),
+                Ok(Ok(Err(e))) => tracing::warn!("User sync error (may be expected): {e}"),
+                Ok(Err(e)) => tracing::warn!("User sync task error: {e}"),
+                Err(_) => tracing::info!("User sync timeout (expected for test)"),
+            }
+        }
+    }
+
+    tracing::info!("Verifying synced users in SurrealDB...");
+    assert_synced_auto(
+        &conn,
+        &dataset,
+        "Kafka SASL_SSL mTLS sync",
+        SourceDatabase::Kafka,
+    )
+    .await?;
+
+    tracing::info!("Kafka SASL_SSL mTLS sync test completed successfully");
+    Ok(())
+}

--- a/tests/loadtest/kafka_loadtest.rs
+++ b/tests/loadtest/kafka_loadtest.rs
@@ -186,6 +186,10 @@ async fn test_kafka_loadtest_small_scale() -> Result<(), Box<dyn std::error::Err
                     sasl_password: None,
                     sasl_mechanism: None,
                     security_protocol: None,
+                    ssl_ca_location: None,
+                    ssl_certificate_location: None,
+                    ssl_key_location: None,
+                    ssl_key_password: None,
                 };
 
                 // Run sync with a deadline
@@ -315,6 +319,10 @@ async fn test_kafka_loadtest_small_scale() -> Result<(), Box<dyn std::error::Err
                     sasl_password: None,
                     sasl_mechanism: None,
                     security_protocol: None,
+                    ssl_ca_location: None,
+                    ssl_certificate_location: None,
+                    ssl_key_location: None,
+                    ssl_key_password: None,
                 };
 
                 // Run sync with a deadline


### PR DESCRIPTION
## What is the motivation?

Production Kafka clusters often require TLS and mTLS with custom CAs; #70 called out missing certificate CLI support and we still have no integration test against a secured broker after #77 and #89.

## What does this change do?

Adds `--ssl-*` flags for the Kafka source, test harness support for a TLS/SASL broker, and documents TLS usage in `docs/kafka.md`.

## What is your testing strategy?

- Unit tests for SSL config mapping in `kafka-source`
- Integration test `test_kafka_sasl_ssl_mtls_sync` against `SecureKafkaContainer`
- Pre-push `cargo clippy` on push; CI `make test` expected to cover the suite

## Is this related to any issues?

Closes #70

## Have you read the [Contributing Guidelines](/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](/CONTRIBUTING.md)