### PR TITLE
Unify GHA build job into single cargo build

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -64,8 +64,8 @@ jobs:
       with:
         tool: nextest
 
-    - name: Build stripped CLI binary (used by CLI tests)
-      run: cargo build -p surreal-sync --profile ci
+    - name: Build CLI + all test binaries
+      run: cargo build --workspace --profile ci --bins --tests
 
     - name: Archive test binaries
       run: cargo nextest archive --workspace --cargo-profile ci --profile ci --archive-file nextest.tar.zst

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,8 +64,8 @@ jobs:
       with:
         tool: nextest
 
-    - name: Build stripped CLI binary (used by CLI tests)
-      run: cargo build -p surreal-sync --profile ci
+    - name: Build CLI + all test binaries
+      run: cargo build --workspace --profile ci --bins --tests
 
     - name: Archive test binaries
       run: cargo nextest archive --workspace --cargo-profile ci --profile ci --archive-file nextest.tar.zst


### PR DESCRIPTION
- Replace the sequential CLI build and nextest archive compile passes with a single `cargo build --workspace --profile ci --bins --tests`
- `cargo nextest archive` then becomes mostly packaging (~24s residual recompile instead of ~3m)
- Removes redundant dependency compilation in the GHA build job

## Test plan
- [x] `workflow_dispatch` run on `ci/unified-build` passed (lint, build, doc, all 3 test shards)
- [x] Build job archive step dropped from ~3m compile to ~32s (24s recompile + 7s packaging)
- [ ] Confirm cold-cache build job lands around ~5–5.5m after merge