### PR TITLE
Fix release builds by installing libsasl2-dev

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,13 @@ jobs:
           rustup toolchain install
           rustup target add ${{ matrix.target }}
 
+      - name: Install system build dependencies
+        if: contains(matrix.target, 'linux')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential cmake libssl-dev libsasl2-dev pkg-config protobuf-compiler
+
       - name: Install cross-compilation tools
         if: matrix.os == 'ubuntu-latest'
         run: |


### PR DESCRIPTION
- Release Linux builds fail because rdkafka's SASL feature needs libsasl2-dev.
- Install the same build deps used by test CI and the Dockerfile.