### PR TITLE
Clarify MySQL connection refused errors

### DIFF
--- a/crates/mysql-binlog-source/src/client.rs
+++ b/crates/mysql-binlog-source/src/client.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use binlog_protocol::{
     BinlogClient, Flavor, MariaDbDumpFlags, MariaDbGtidList, ReplicaOptions, ResumePosition,
 };
@@ -41,6 +41,26 @@ pub fn new_mysql_pool(connection_string: &str) -> Result<Pool> {
     Ok(Pool::from_url(connection_string)?)
 }
 
+/// Short, actionable message when a MySQL TCP/connect attempt fails.
+fn mysql_connect_context(connection_string: &str) -> String {
+    match parse_mysql_uri(connection_string) {
+        Ok((host, port, ..)) => format!(
+            "failed to connect to MySQL at {host}:{port}; check the server is running and `--connection-string` is correct"
+        ),
+        Err(_) => {
+            "failed to connect to MySQL; check the server is running and `--connection-string` is correct"
+                .to_string()
+        }
+    }
+}
+
+/// Get a pool connection, wrapping TCP/connect failures with a clear next action.
+pub async fn get_pool_conn(pool: &Pool, connection_string: &str) -> Result<mysql_async::Conn> {
+    pool.get_conn()
+        .await
+        .with_context(|| mysql_connect_context(connection_string))
+}
+
 pub async fn connect_binlog_client(from_opts: &SourceOpts) -> Result<BinlogClient> {
     connect_binlog_client_with_poll(from_opts, DEFAULT_BINLOG_POLL_TIMEOUT).await
 }
@@ -68,7 +88,7 @@ pub async fn connect_binlog_client_with_poll(
     };
     BinlogClient::connect(opts)
         .await
-        .map_err(|e| anyhow::anyhow!("binlog connect failed: {e}"))
+        .with_context(|| mysql_connect_context(&connection_string))
 }
 
 pub async fn resolve_database(pool: &Pool, from_opts: &SourceOpts) -> Result<String> {
@@ -79,7 +99,7 @@ pub async fn resolve_database(pool: &Pool, from_opts: &SourceOpts) -> Result<Str
     if let Some(db) = db_from_uri {
         return Ok(db);
     }
-    let mut conn = pool.get_conn().await?;
+    let mut conn = get_pool_conn(pool, &from_opts.connection_string).await?;
     let db: Option<String> = conn.query_first("SELECT DATABASE()").await?;
     db.ok_or_else(|| anyhow::anyhow!("no database selected"))
 }
@@ -206,6 +226,24 @@ mod tests {
         assert!(
             format!("{err}").contains("gtid_binlog_pos"),
             "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn mysql_connect_context_includes_host_port() {
+        let msg = mysql_connect_context("mysql://db:db@127.0.0.1:32793/db");
+        assert_eq!(
+            msg,
+            "failed to connect to MySQL at 127.0.0.1:32793; check the server is running and `--connection-string` is correct"
+        );
+    }
+
+    #[test]
+    fn mysql_connect_context_fallback_on_bad_uri() {
+        let msg = mysql_connect_context("not-a-uri");
+        assert_eq!(
+            msg,
+            "failed to connect to MySQL; check the server is running and `--connection-string` is correct"
         );
     }
 }

--- a/crates/mysql-binlog-source/src/full_sync.rs
+++ b/crates/mysql-binlog-source/src/full_sync.rs
@@ -16,7 +16,8 @@ use crate::catch_up::{
 };
 use crate::checkpoint::BinlogCheckpoint;
 use crate::client::{
-    connect_binlog_client, new_mysql_pool, resolve_database, show_master_status, use_database,
+    connect_binlog_client, get_pool_conn, new_mysql_pool, resolve_database, show_master_status,
+    use_database,
 };
 use crate::schema::collect_mysql_database_schema;
 use crate::signal::SIGNAL_TABLE;
@@ -61,7 +62,7 @@ pub async fn run_full_sync_cancellable<S: SurrealSink, CS: CheckpointStore>(
 
     let pool = new_mysql_pool(&from_opts.connection_string)?;
     let database = resolve_database(&pool, from_opts).await?;
-    let mut conn = pool.get_conn().await?;
+    let mut conn = get_pool_conn(&pool, &from_opts.connection_string).await?;
     use_database(&mut conn, &database).await?;
 
     // Detect the server flavor via a short-lived binlog handshake so the captured

--- a/crates/mysql-binlog-source/src/incremental_sync.rs
+++ b/crates/mysql-binlog-source/src/incremental_sync.rs
@@ -18,7 +18,7 @@ use crate::catch_up::{
 use crate::change::cdc_change_to_universal;
 use crate::checkpoint::BinlogCheckpoint;
 use crate::client::{
-    connect_binlog_client_with_poll, new_mysql_pool, resolve_database,
+    connect_binlog_client_with_poll, get_pool_conn, new_mysql_pool, resolve_database,
     start_binlog_from_checkpoint, use_database, DEFAULT_BINLOG_POLL_TIMEOUT,
 };
 use crate::schema::{collect_mysql_database_schema, get_table_column_names_ordinal};
@@ -116,7 +116,7 @@ where
 
     let pool = new_mysql_pool(&from_opts.connection_string)?;
     let database = resolve_database(&pool, &from_opts).await?;
-    let mut conn = pool.get_conn().await?;
+    let mut conn = get_pool_conn(&pool, &from_opts.connection_string).await?;
     use_database(&mut conn, &database).await?;
     conn.query_drop(create_signal_table_sql()).await?;
 

--- a/crates/mysql-binlog-source/src/watermark_source.rs
+++ b/crates/mysql-binlog-source/src/watermark_source.rs
@@ -25,7 +25,7 @@ use crate::catch_up::{
 use crate::change::cdc_change_to_universal;
 use crate::checkpoint::{get_current_checkpoint, BinlogCheckpoint, BinlogReconciliationPos};
 use crate::client::{
-    connect_binlog_client, new_mysql_pool, resolve_database, start_binlog_at_end,
+    connect_binlog_client, get_pool_conn, new_mysql_pool, resolve_database, start_binlog_at_end,
     start_binlog_from_checkpoint, use_database,
 };
 use crate::full_sync::{get_primary_key_columns, read_table_chunk};
@@ -109,7 +109,7 @@ impl BinlogWatermarkSource {
     ) -> Result<Self> {
         let pool = new_mysql_pool(&from_opts.connection_string)?;
         let database = resolve_database(&pool, from_opts).await?;
-        let mut conn = pool.get_conn().await?;
+        let mut conn = get_pool_conn(&pool, &from_opts.connection_string).await?;
         use_database(&mut conn, &database).await?;
         conn.query_drop(create_signal_table_sql()).await?;
 
@@ -174,7 +174,7 @@ impl BinlogWatermarkSource {
     pub async fn resolve_snapshot_table_names(from_opts: &SourceOpts) -> Result<Vec<String>> {
         let pool = new_mysql_pool(&from_opts.connection_string)?;
         let database = resolve_database(&pool, from_opts).await?;
-        let mut conn = pool.get_conn().await?;
+        let mut conn = get_pool_conn(&pool, &from_opts.connection_string).await?;
         use_database(&mut conn, &database).await?;
         get_snapshot_tables(&mut conn, &database, from_opts).await
     }


### PR DESCRIPTION
When MySQL is unreachable, surreal-sync now leads with a short, actionable message that includes the host and port and points users at the server or `--connection-string`, instead of only surfacing the nested `mysql_async` “Connection refused” I/O error that looked like a SurrealDB failure after the WebSocket handshake.

Fixes #119