### PR TITLE
Enhance Snowflake source with transform pipeline and partition streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8063,6 +8063,7 @@ name = "surreal-sync-snowflake-source"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "reqwest 0.12.20",
  "serde",
  "serde_json",
@@ -8070,6 +8071,7 @@ dependencies = [
  "snowflake-types",
  "surreal-sink",
  "sync-core",
+ "sync-transform",
  "tokio",
  "tracing",
 ]

--- a/crates/snowflake-source/Cargo.toml
+++ b/crates/snowflake-source/Cargo.toml
@@ -11,6 +11,10 @@ sync-core = { path = "../sync-core" }
 surreal-sink = { path = "../surreal-sink" }
 snowflake-types = { path = "../snowflake-types" }
 
+# Shared apply / transform pipeline
+sync-transform = { path = "../sync-transform" }
+async-trait = "0.1"
+
 # HTTP client (rustls to match the process-wide aws-lc-rs provider; no OpenSSL)
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
@@ -27,3 +31,8 @@ serde_json = "1.0"
 # Error handling / logging
 anyhow = "1.0"
 tracing = "0.1"
+
+[dev-dependencies]
+tokio = { version = "1.49", features = ["rt-multi-thread", "macros", "time"] }
+sync-transform = { path = "../sync-transform" }
+async-trait = "0.1"

--- a/crates/snowflake-source/src/client.rs
+++ b/crates/snowflake-source/src/client.rs
@@ -4,6 +4,10 @@
 //! and result-partition pagination. Result decoding into `UniversalValue`s is
 //! the job of the `snowflake-types` crate; this module only produces the raw
 //! `(rowType, data)` pair.
+//!
+//! Large results are exposed via [`QueryStream`], which keeps **one partition**
+//! in memory at a time and yields bounded [`QueryStream::next_batch`] slices for
+//! the apply path.
 
 use std::time::{Duration, Instant};
 
@@ -16,12 +20,101 @@ use crate::SourceOpts;
 
 /// A decoded (but not yet type-converted) result set: column metadata plus every
 /// data row across all partitions.
+///
+/// Prefer [`SnowflakeClient::execute_query_stream`] for large tables — this type
+/// materializes the full result and is mainly for small queries (DDL, discovery).
 #[derive(Debug, Clone)]
 pub struct QueryResult {
     /// Per-column metadata (`resultSetMetaData.rowType`).
     pub columns: Vec<ColumnType>,
     /// Rows, each a vector of raw JSON cells aligned with `columns`.
     pub rows: Vec<Vec<JsonValue>>,
+}
+
+/// Streaming view of a statement result: one Snowflake partition buffered at a
+/// time, sliced into caller-sized batches.
+pub struct QueryStream<'a> {
+    client: &'a SnowflakeClient,
+    columns: Vec<ColumnType>,
+    /// Statement handle used to fetch partitions `1..partition_count`.
+    handle: Option<String>,
+    /// Total partitions reported by Snowflake (or `1` when data arrived without
+    /// `partitionInfo`).
+    partition_count: usize,
+    /// Next partition index to fetch after the current buffer is exhausted.
+    next_partition: usize,
+    /// Rows for the partition currently being drained.
+    current: Vec<Vec<JsonValue>>,
+    /// Offset within [`Self::current`].
+    current_offset: usize,
+}
+
+impl<'a> QueryStream<'a> {
+    /// Column metadata for the statement (stable for the life of the stream).
+    pub fn columns(&self) -> &[ColumnType] {
+        &self.columns
+    }
+
+    /// Yield up to `max_rows` raw cells from the current partition, fetching the
+    /// next partition only when the buffer is empty.
+    ///
+    /// Returns `Ok(None)` when the result is fully consumed. A returned batch may
+    /// be smaller than `max_rows` when a partition ends mid-batch (callers should
+    /// treat that as a normal, final partial batch for that partition).
+    pub async fn next_batch(&mut self, max_rows: usize) -> Result<Option<Vec<Vec<JsonValue>>>> {
+        let max_rows = max_rows.max(1);
+        loop {
+            if self.current_offset >= self.current.len() {
+                self.current.clear();
+                self.current_offset = 0;
+                if !self.fetch_next_partition_if_needed().await? {
+                    return Ok(None);
+                }
+                // Empty partitions are skipped by continuing the loop.
+                continue;
+            }
+
+            let end = (self.current_offset + max_rows).min(self.current.len());
+            let batch = self.current[self.current_offset..end].to_vec();
+            self.current_offset = end;
+
+            // Drop the partition buffer once fully drained so peak memory stays
+            // near one partition (+ the in-flight apply window).
+            if self.current_offset >= self.current.len() {
+                self.current.clear();
+                self.current.shrink_to_fit();
+                self.current_offset = 0;
+            }
+
+            if batch.is_empty() {
+                continue;
+            }
+            return Ok(Some(batch));
+        }
+    }
+
+    async fn fetch_next_partition_if_needed(&mut self) -> Result<bool> {
+        if self.next_partition >= self.partition_count {
+            return Ok(false);
+        }
+
+        // Partition 0 is always loaded into `current` at stream open. Subsequent
+        // partitions are fetched by index (`next_partition` starts at 1).
+        let handle = self
+            .handle
+            .as_deref()
+            .ok_or_else(|| anyhow!("multi-partition result missing statementHandle"))?;
+        let partition = self.next_partition;
+        tracing::debug!(
+            partition,
+            partition_count = self.partition_count,
+            "Fetching Snowflake result partition"
+        );
+        self.current = self.client.fetch_partition(handle, partition).await?;
+        self.next_partition += 1;
+        self.current_offset = 0;
+        Ok(true)
+    }
 }
 
 /// Client for a single Snowflake account, bound to one warehouse/database/schema.
@@ -119,9 +212,12 @@ impl SnowflakeClient {
             .map_err(|e| anyhow!("failed to generate Snowflake JWT: {e}"))
     }
 
-    /// Execute a SQL statement and return the fully-paginated result set.
-    pub async fn execute_query(&self, sql: &str) -> Result<QueryResult> {
-        tracing::debug!("Snowflake execute: {sql}");
+    /// Execute a SQL statement and stream partitions one at a time.
+    ///
+    /// Peak source-side memory is roughly one Snowflake result partition (plus
+    /// whatever the caller retains from [`QueryStream::next_batch`]).
+    pub async fn execute_query_stream(&self, sql: &str) -> Result<QueryStream<'_>> {
+        tracing::debug!("Snowflake execute (stream): {sql}");
 
         let mut body = serde_json::Map::new();
         body.insert("statement".into(), JsonValue::String(sql.to_string()));
@@ -142,28 +238,51 @@ impl SnowflakeClient {
 
         let url = format!("{}/api/v2/statements", self.base_url);
         let (status, resp) = self.send_post(&url, &body).await?;
-
-        // Drive an async (202) statement to completion.
         let resp = self.await_completion(status, resp).await?;
 
         let meta = resp
             .result_set_meta_data
             .ok_or_else(|| anyhow!("Snowflake response missing resultSetMetaData"))?;
         let columns = meta.row_type;
+        let current = resp.data.unwrap_or_default();
 
-        // Partition 0 arrives inline; fetch the rest by index.
-        let mut rows = resp.data.unwrap_or_default();
-        let partition_count = meta.partition_info.len();
-        if partition_count > 1 {
-            let handle = resp
-                .statement_handle
-                .ok_or_else(|| anyhow!("multi-partition result missing statementHandle"))?;
-            for partition in 1..partition_count {
-                let mut more = self.fetch_partition(&handle, partition).await?;
-                rows.append(&mut more);
+        // Snowflake normally reports partitionInfo; when it is absent but rows
+        // arrived inline, treat that as a single already-buffered partition.
+        let partition_count = if meta.partition_info.is_empty() {
+            if current.is_empty() {
+                0
+            } else {
+                1
             }
-        }
+        } else {
+            meta.partition_info.len()
+        };
 
+        Ok(QueryStream {
+            client: self,
+            columns,
+            handle: resp.statement_handle,
+            partition_count,
+            // Partition 0 is already in `current`; the next fetch (if any) is 1.
+            next_partition: 1,
+            current,
+            current_offset: 0,
+        })
+    }
+
+    /// Execute a SQL statement and return the fully-paginated result set.
+    ///
+    /// Convenience for small results (DDL, `INFORMATION_SCHEMA`, tests). Prefer
+    /// [`Self::execute_query_stream`] for table ingestion.
+    pub async fn execute_query(&self, sql: &str) -> Result<QueryResult> {
+        let mut stream = self.execute_query_stream(sql).await?;
+        let columns = stream.columns().to_vec();
+        let mut rows = Vec::new();
+        // Drain with a large batch size; partitions still arrive one at a time,
+        // then are appended here (intentional full materialization).
+        while let Some(mut batch) = stream.next_batch(10_000).await? {
+            rows.append(&mut batch);
+        }
         Ok(QueryResult { columns, rows })
     }
 

--- a/crates/snowflake-source/src/full_sync.rs
+++ b/crates/snowflake-source/src/full_sync.rs
@@ -1,31 +1,67 @@
 //! Full (one-shot) snapshot ingestion from Snowflake into SurrealDB.
 //!
-//! Modeled on `crates/postgresql/src/full_sync.rs`, but — like the CSV source —
-//! it does not require a primary key, because Snowflake primary keys are not
-//! enforced and are frequently absent.
+//! Modeled on MongoDB/Neo4j full sync: rows stream through
+//! [`RowChunkDriver`] / [`run_source_runtime_with`] so transform batching and
+//! `max_in_flight` overlap apply within each table. Snowflake primary keys are
+//! not enforced (and are frequently absent), so ID columns are optional — like
+//! CSV, sequential ids are generated when omitted.
+//!
+//! There is no CDC and no durable source cursor: watermarks advance
+//! in-memory through the shared apply path (`CheckpointPolicy::AdvanceOnly`),
+//! but there is nothing to resume after a process restart.
 
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
+use async_trait::async_trait;
 use serde_json::Value as JsonValue;
 use snowflake_types::convert_cell;
 use surreal_sink::SurrealSink;
 use sync_core::{UniversalRow, UniversalValue};
+use sync_transform::{
+    run_source_runtime_with, ApplyOpts, Pipeline, RowChunkDriver, RowChunkSource, SourceRuntimeOpts,
+};
 
 use crate::client::{QueryResult, SnowflakeClient};
 use crate::{autoconf, SourceOpts, SyncOpts};
 
-/// Ingest every selected table. Returns the total number of rows written.
+/// Ingest every selected table with an identity transform pipeline.
 ///
-/// When `opts.tables` is empty, all base tables in the schema are discovered and
-/// ingested; otherwise the listed tables are used verbatim (upper-cased to match
-/// Snowflake's unquoted-identifier casing).
+/// Returns the total number of rows sunk (0 in dry-run).
 pub async fn run_full_sync<S: SurrealSink>(
     client: &SnowflakeClient,
     sink: &S,
     opts: &SourceOpts,
     sync_opts: &SyncOpts,
 ) -> Result<usize> {
+    let pipeline = Pipeline::new();
+    let apply_opts = ApplyOpts::identity();
+    run_full_sync_with_transforms(client, sink, opts, sync_opts, &pipeline, &apply_opts).await
+}
+
+/// Ingest every selected table through the shared transform/apply path.
+///
+/// When `opts.tables` is empty, all base tables in the schema are discovered and
+/// ingested; otherwise the listed tables are used verbatim (upper-cased to match
+/// Snowflake's unquoted-identifier casing).
+pub async fn run_full_sync_with_transforms<S: SurrealSink>(
+    client: &SnowflakeClient,
+    sink: &S,
+    opts: &SourceOpts,
+    sync_opts: &SyncOpts,
+    pipeline: &Pipeline,
+    apply_opts: &ApplyOpts,
+) -> Result<usize> {
+    if pipeline.is_identity() {
+        tracing::debug!("Snowflake full sync using identity transform pipeline");
+    } else {
+        tracing::info!(
+            stages = pipeline.len(),
+            "Snowflake full sync using transform pipeline"
+        );
+    }
+
     let tables: Vec<String> = if opts.tables.is_empty() {
         autoconf::list_tables(client, &opts.database, &opts.schema).await?
     } else {
@@ -48,7 +84,10 @@ pub async fn run_full_sync<S: SurrealSink>(
 
     let mut total = 0;
     for table in &tables {
-        let count = migrate_table(client, sink, table, opts, sync_opts).await?;
+        let count = migrate_table_with_transforms(
+            client, sink, table, opts, sync_opts, pipeline, apply_opts,
+        )
+        .await?;
         tracing::info!("Ingested {count} row(s) from table '{table}'");
         total += count;
     }
@@ -57,13 +96,29 @@ pub async fn run_full_sync<S: SurrealSink>(
     Ok(total)
 }
 
-/// Ingest a single table. Returns the number of rows written.
+/// Ingest a single table with an identity pipeline.
 pub async fn migrate_table<S: SurrealSink>(
     client: &SnowflakeClient,
     sink: &S,
     table: &str,
     opts: &SourceOpts,
     sync_opts: &SyncOpts,
+) -> Result<usize> {
+    let pipeline = Pipeline::new();
+    let apply_opts = ApplyOpts::identity();
+    migrate_table_with_transforms(client, sink, table, opts, sync_opts, &pipeline, &apply_opts)
+        .await
+}
+
+/// Ingest a single table through [`RowChunkDriver`].
+pub async fn migrate_table_with_transforms<S: SurrealSink>(
+    client: &SnowflakeClient,
+    sink: &S,
+    table: &str,
+    opts: &SourceOpts,
+    sync_opts: &SyncOpts,
+    pipeline: &Pipeline,
+    apply_opts: &ApplyOpts,
 ) -> Result<usize> {
     let db = opts.database.to_ascii_uppercase();
     let schema = opts.schema.to_ascii_uppercase();
@@ -77,66 +132,125 @@ pub async fn migrate_table<S: SurrealSink>(
         return Ok(0);
     }
 
-    // Resolve the (optional) ID columns once; empty means auto-generate.
-    let id_indices = resolve_id_columns(&result, &opts.id_columns)?;
-    let id_index_set: HashSet<usize> = id_indices.iter().copied().collect();
-
-    let mut batch: Vec<UniversalRow> = Vec::new();
-    let mut written = 0;
-
-    for (row_index, row) in result.rows.iter().enumerate() {
-        if row.len() != result.columns.len() {
-            return Err(anyhow!(
-                "row {row_index} of table '{table}' has {} cells but {} columns were declared",
-                row.len(),
-                result.columns.len()
-            ));
-        }
-
-        let mut fields: HashMap<String, UniversalValue> = HashMap::new();
-        for (i, col) in result.columns.iter().enumerate() {
-            // When ID columns are explicit, keep them out of the field map so the
-            // record ID is not duplicated as a field (matches the PostgreSQL PK behavior).
-            if id_index_set.contains(&i) {
-                continue;
-            }
-            let value = convert_cell(&row[i], col)?;
-            fields.insert(col.name.clone(), value);
-        }
-
-        let id = build_record_id(row, row_index, &id_indices);
-        batch.push(UniversalRow::new(
-            table_upper.clone(),
-            row_index as u64,
-            id,
-            fields,
-        ));
-
-        if batch.len() >= sync_opts.batch_size {
-            written += flush(sink, &mut batch, sync_opts.dry_run).await?;
-        }
-    }
-
-    written += flush(sink, &mut batch, sync_opts.dry_run).await?;
-    Ok(written)
+    apply_query_result_with_transforms(
+        sink,
+        &table_upper,
+        &result,
+        opts,
+        sync_opts,
+        pipeline,
+        apply_opts,
+    )
+    .await
 }
 
-async fn flush<S: SurrealSink>(
+/// Convert a fetched [`QueryResult`] and push it through the shared apply path.
+///
+/// Exposed for tests that build result sets without talking to Snowflake.
+pub async fn apply_query_result_with_transforms<S: SurrealSink>(
     sink: &S,
-    batch: &mut Vec<UniversalRow>,
-    dry_run: bool,
+    table: &str,
+    result: &QueryResult,
+    opts: &SourceOpts,
+    sync_opts: &SyncOpts,
+    pipeline: &Pipeline,
+    apply_opts: &ApplyOpts,
 ) -> Result<usize> {
-    if batch.is_empty() {
-        return Ok(0);
+    let id_indices = resolve_id_columns(result, &opts.id_columns)?;
+    let id_index_set: HashSet<usize> = id_indices.iter().copied().collect();
+
+    if sync_opts.dry_run {
+        let mut converted = 0usize;
+        for (row_index, row) in result.rows.iter().enumerate() {
+            convert_row(table, row_index, row, result, &id_indices, &id_index_set)?;
+            converted += 1;
+        }
+        tracing::info!("Dry-run scanned table '{table}': {converted} row(s)");
+        return Ok(converted);
     }
-    let n = batch.len();
-    if dry_run {
-        tracing::debug!("Dry-run: would write {n} row(s)");
-    } else {
-        sink.write_universal_rows(batch).await?;
+
+    struct SnowflakeRowChunks<'a> {
+        result: &'a QueryResult,
+        table: String,
+        id_indices: Vec<usize>,
+        id_index_set: HashSet<usize>,
+        batch_size: usize,
+        next_index: usize,
     }
-    batch.clear();
-    Ok(n)
+
+    #[async_trait]
+    impl RowChunkSource for SnowflakeRowChunks<'_> {
+        async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<UniversalRow>>> {
+            if self.next_index >= self.result.rows.len() {
+                return Ok(None);
+            }
+            let end = (self.next_index + self.batch_size).min(self.result.rows.len());
+            let mut batch = Vec::with_capacity(end - self.next_index);
+            for row_index in self.next_index..end {
+                let row = &self.result.rows[row_index];
+                batch.push(convert_row(
+                    &self.table,
+                    row_index,
+                    row,
+                    self.result,
+                    &self.id_indices,
+                    &self.id_index_set,
+                )?);
+            }
+            self.next_index = end;
+            Ok(Some(batch))
+        }
+    }
+
+    let chunks = SnowflakeRowChunks {
+        result,
+        table: table.to_string(),
+        id_indices,
+        id_index_set,
+        batch_size: sync_opts.batch_size.max(1),
+        next_index: 0,
+    };
+    let mut driver = RowChunkDriver::new(chunks);
+    let transformer = Arc::new(pipeline.clone());
+    let runtime_opts = SourceRuntimeOpts::new();
+    run_source_runtime_with(&mut driver, sink, transformer, apply_opts, &runtime_opts).await?;
+    Ok(driver.sunk_count() as usize)
+}
+
+fn convert_row(
+    table: &str,
+    row_index: usize,
+    row: &[JsonValue],
+    result: &QueryResult,
+    id_indices: &[usize],
+    id_index_set: &HashSet<usize>,
+) -> Result<UniversalRow> {
+    if row.len() != result.columns.len() {
+        return Err(anyhow!(
+            "row {row_index} of table '{table}' has {} cells but {} columns were declared",
+            row.len(),
+            result.columns.len()
+        ));
+    }
+
+    let mut fields: HashMap<String, UniversalValue> = HashMap::new();
+    for (i, col) in result.columns.iter().enumerate() {
+        // When ID columns are explicit, keep them out of the field map so the
+        // record ID is not duplicated as a field (matches the PostgreSQL PK behavior).
+        if id_index_set.contains(&i) {
+            continue;
+        }
+        let value = convert_cell(&row[i], col)?;
+        fields.insert(col.name.clone(), value);
+    }
+
+    let id = build_record_id(row, row_index, id_indices);
+    Ok(UniversalRow::new(
+        table.to_string(),
+        row_index as u64,
+        id,
+        fields,
+    ))
 }
 
 /// Map the configured ID column names to their positions in the result set.

--- a/crates/snowflake-source/src/full_sync.rs
+++ b/crates/snowflake-source/src/full_sync.rs
@@ -6,9 +6,13 @@
 //! not enforced (and are frequently absent), so ID columns are optional — like
 //! CSV, sequential ids are generated when omitted.
 //!
-//! There is no CDC and no durable source cursor: watermarks advance
-//! in-memory through the shared apply path (`CheckpointPolicy::AdvanceOnly`),
-//! but there is nothing to resume after a process restart.
+//! Source reads are **partition-bounded**: the SQL REST API returns result
+//! partitions; we keep one partition buffered and slice it into
+//! `sync_opts.batch_size` apply chunks (a trailing chunk may be smaller when
+//! `partition_len % batch_size != 0`). There is no CDC and no durable source
+//! cursor — watermarks advance in-memory through the shared apply path
+//! (`CheckpointPolicy::AdvanceOnly`), but there is nothing to resume after a
+//! process restart.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -16,19 +20,19 @@ use std::sync::Arc;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use serde_json::Value as JsonValue;
-use snowflake_types::convert_cell;
+use snowflake_types::{convert_cell, ColumnType};
 use surreal_sink::SurrealSink;
 use sync_core::{UniversalRow, UniversalValue};
 use sync_transform::{
     run_source_runtime_with, ApplyOpts, Pipeline, RowChunkDriver, RowChunkSource, SourceRuntimeOpts,
 };
 
-use crate::client::{QueryResult, SnowflakeClient};
+use crate::client::{QueryResult, QueryStream, SnowflakeClient};
 use crate::{autoconf, SourceOpts, SyncOpts};
 
 /// Ingest every selected table with an identity transform pipeline.
 ///
-/// Returns the total number of rows sunk (0 in dry-run).
+/// Returns the total number of rows sunk (0 in dry-run after a scan).
 pub async fn run_full_sync<S: SurrealSink>(
     client: &SnowflakeClient,
     sink: &S,
@@ -110,7 +114,8 @@ pub async fn migrate_table<S: SurrealSink>(
         .await
 }
 
-/// Ingest a single table through [`RowChunkDriver`].
+/// Ingest a single table through [`RowChunkDriver`], streaming Snowflake
+/// partitions and slicing each into `sync_opts.batch_size` apply chunks.
 pub async fn migrate_table_with_transforms<S: SurrealSink>(
     client: &SnowflakeClient,
     sink: &S,
@@ -125,17 +130,11 @@ pub async fn migrate_table_with_transforms<S: SurrealSink>(
     let table_upper = table.to_ascii_uppercase();
     let sql = format!("SELECT * FROM \"{db}\".\"{schema}\".\"{table_upper}\"");
 
-    let result = client.execute_query(&sql).await?;
-
-    if result.rows.is_empty() {
-        tracing::info!("Table '{table}' is empty, skipping");
-        return Ok(0);
-    }
-
-    apply_query_result_with_transforms(
+    let stream = client.execute_query_stream(&sql).await?;
+    apply_query_stream_with_transforms(
         sink,
         &table_upper,
-        &result,
+        stream,
         opts,
         sync_opts,
         pipeline,
@@ -144,7 +143,83 @@ pub async fn migrate_table_with_transforms<S: SurrealSink>(
     .await
 }
 
-/// Convert a fetched [`QueryResult`] and push it through the shared apply path.
+/// Push a live [`QueryStream`] through the shared apply path (production path).
+pub async fn apply_query_stream_with_transforms<S: SurrealSink>(
+    sink: &S,
+    table: &str,
+    mut stream: QueryStream<'_>,
+    opts: &SourceOpts,
+    sync_opts: &SyncOpts,
+    pipeline: &Pipeline,
+    apply_opts: &ApplyOpts,
+) -> Result<usize> {
+    let columns = stream.columns().to_vec();
+    let id_indices = resolve_id_columns(&columns, &opts.id_columns)?;
+    let id_index_set: HashSet<usize> = id_indices.iter().copied().collect();
+    let batch_size = sync_opts.batch_size.max(1);
+
+    if sync_opts.dry_run {
+        let mut converted = 0usize;
+        while let Some(raw_batch) = stream.next_batch(batch_size).await? {
+            for row in raw_batch {
+                convert_row(table, converted, &row, &columns, &id_indices, &id_index_set)?;
+                converted += 1;
+            }
+        }
+        tracing::info!("Dry-run scanned table '{table}': {converted} row(s)");
+        return Ok(converted);
+    }
+
+    struct SnowflakePartitionChunks<'a> {
+        stream: QueryStream<'a>,
+        columns: Vec<ColumnType>,
+        table: String,
+        id_indices: Vec<usize>,
+        id_index_set: HashSet<usize>,
+        batch_size: usize,
+        next_row_index: usize,
+    }
+
+    #[async_trait]
+    impl RowChunkSource for SnowflakePartitionChunks<'_> {
+        async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<UniversalRow>>> {
+            let Some(raw_batch) = self.stream.next_batch(self.batch_size).await? else {
+                return Ok(None);
+            };
+            let mut batch = Vec::with_capacity(raw_batch.len());
+            for row in raw_batch {
+                let row_index = self.next_row_index;
+                batch.push(convert_row(
+                    &self.table,
+                    row_index,
+                    &row,
+                    &self.columns,
+                    &self.id_indices,
+                    &self.id_index_set,
+                )?);
+                self.next_row_index = self.next_row_index.saturating_add(1);
+            }
+            Ok(Some(batch))
+        }
+    }
+
+    let chunks = SnowflakePartitionChunks {
+        stream,
+        columns,
+        table: table.to_string(),
+        id_indices,
+        id_index_set,
+        batch_size,
+        next_row_index: 0,
+    };
+    let mut driver = RowChunkDriver::new(chunks);
+    let transformer = Arc::new(pipeline.clone());
+    let runtime_opts = SourceRuntimeOpts::new();
+    run_source_runtime_with(&mut driver, sink, transformer, apply_opts, &runtime_opts).await?;
+    Ok(driver.sunk_count() as usize)
+}
+
+/// Convert an in-memory [`QueryResult`] and push it through the shared apply path.
 ///
 /// Exposed for tests that build result sets without talking to Snowflake.
 pub async fn apply_query_result_with_transforms<S: SurrealSink>(
@@ -156,21 +231,30 @@ pub async fn apply_query_result_with_transforms<S: SurrealSink>(
     pipeline: &Pipeline,
     apply_opts: &ApplyOpts,
 ) -> Result<usize> {
-    let id_indices = resolve_id_columns(result, &opts.id_columns)?;
+    let id_indices = resolve_id_columns(&result.columns, &opts.id_columns)?;
     let id_index_set: HashSet<usize> = id_indices.iter().copied().collect();
+    let batch_size = sync_opts.batch_size.max(1);
 
     if sync_opts.dry_run {
         let mut converted = 0usize;
         for (row_index, row) in result.rows.iter().enumerate() {
-            convert_row(table, row_index, row, result, &id_indices, &id_index_set)?;
+            convert_row(
+                table,
+                row_index,
+                row,
+                &result.columns,
+                &id_indices,
+                &id_index_set,
+            )?;
             converted += 1;
         }
         tracing::info!("Dry-run scanned table '{table}': {converted} row(s)");
         return Ok(converted);
     }
 
-    struct SnowflakeRowChunks<'a> {
-        result: &'a QueryResult,
+    struct InMemoryRowChunks<'a> {
+        rows: &'a [Vec<JsonValue>],
+        columns: &'a [ColumnType],
         table: String,
         id_indices: Vec<usize>,
         id_index_set: HashSet<usize>,
@@ -179,20 +263,19 @@ pub async fn apply_query_result_with_transforms<S: SurrealSink>(
     }
 
     #[async_trait]
-    impl RowChunkSource for SnowflakeRowChunks<'_> {
+    impl RowChunkSource for InMemoryRowChunks<'_> {
         async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<UniversalRow>>> {
-            if self.next_index >= self.result.rows.len() {
+            if self.next_index >= self.rows.len() {
                 return Ok(None);
             }
-            let end = (self.next_index + self.batch_size).min(self.result.rows.len());
+            let end = (self.next_index + self.batch_size).min(self.rows.len());
             let mut batch = Vec::with_capacity(end - self.next_index);
             for row_index in self.next_index..end {
-                let row = &self.result.rows[row_index];
                 batch.push(convert_row(
                     &self.table,
                     row_index,
-                    row,
-                    self.result,
+                    &self.rows[row_index],
+                    self.columns,
                     &self.id_indices,
                     &self.id_index_set,
                 )?);
@@ -202,12 +285,13 @@ pub async fn apply_query_result_with_transforms<S: SurrealSink>(
         }
     }
 
-    let chunks = SnowflakeRowChunks {
-        result,
+    let chunks = InMemoryRowChunks {
+        rows: &result.rows,
+        columns: &result.columns,
         table: table.to_string(),
         id_indices,
         id_index_set,
-        batch_size: sync_opts.batch_size.max(1),
+        batch_size,
         next_index: 0,
     };
     let mut driver = RowChunkDriver::new(chunks);
@@ -221,20 +305,20 @@ fn convert_row(
     table: &str,
     row_index: usize,
     row: &[JsonValue],
-    result: &QueryResult,
+    columns: &[ColumnType],
     id_indices: &[usize],
     id_index_set: &HashSet<usize>,
 ) -> Result<UniversalRow> {
-    if row.len() != result.columns.len() {
+    if row.len() != columns.len() {
         return Err(anyhow!(
             "row {row_index} of table '{table}' has {} cells but {} columns were declared",
             row.len(),
-            result.columns.len()
+            columns.len()
         ));
     }
 
     let mut fields: HashMap<String, UniversalValue> = HashMap::new();
-    for (i, col) in result.columns.iter().enumerate() {
+    for (i, col) in columns.iter().enumerate() {
         // When ID columns are explicit, keep them out of the field map so the
         // record ID is not duplicated as a field (matches the PostgreSQL PK behavior).
         if id_index_set.contains(&i) {
@@ -255,12 +339,11 @@ fn convert_row(
 
 /// Map the configured ID column names to their positions in the result set.
 /// Names are matched case-insensitively (Snowflake upper-cases identifiers).
-fn resolve_id_columns(result: &QueryResult, id_columns: &[String]) -> Result<Vec<usize>> {
+fn resolve_id_columns(columns: &[ColumnType], id_columns: &[String]) -> Result<Vec<usize>> {
     let mut indices = Vec::with_capacity(id_columns.len());
     for name in id_columns {
         let wanted = name.trim().to_ascii_uppercase();
-        let idx = result
-            .columns
+        let idx = columns
             .iter()
             .position(|c| c.name.to_ascii_uppercase() == wanted)
             .ok_or_else(|| anyhow!("id column '{name}' not found in result set"))?;

--- a/crates/snowflake-source/src/lib.rs
+++ b/crates/snowflake-source/src/lib.rs
@@ -5,7 +5,8 @@
 //! There is no CDC/incremental support and no durable source cursor — this is an
 //! ingestion-only source. Rows still go through the shared transform/apply path
 //! ([`run_full_sync_with_transforms`]) so `--transforms-config` batching and
-//! `max_in_flight` apply within each table.
+//! `max_in_flight` apply within each table. Source reads stream **one Snowflake
+//! result partition at a time**, sliced into `batch_size` apply chunks.
 //!
 //! # Usage
 //! ```ignore
@@ -20,10 +21,10 @@ pub mod autoconf;
 pub mod client;
 pub mod full_sync;
 
-pub use client::{QueryResult, SnowflakeClient};
+pub use client::{QueryResult, QueryStream, SnowflakeClient};
 pub use full_sync::{
-    apply_query_result_with_transforms, migrate_table, migrate_table_with_transforms,
-    run_full_sync, run_full_sync_with_transforms,
+    apply_query_result_with_transforms, apply_query_stream_with_transforms, migrate_table,
+    migrate_table_with_transforms, run_full_sync, run_full_sync_with_transforms,
 };
 
 /// Connection + selection options for the Snowflake source (no clap types).

--- a/crates/snowflake-source/src/lib.rs
+++ b/crates/snowflake-source/src/lib.rs
@@ -2,8 +2,10 @@
 //!
 //! Performs a full, one-shot batch snapshot of selected Snowflake tables into
 //! SurrealDB via the documented [SQL REST API v2] using key-pair (JWT) auth.
-//! There is no CDC/incremental support and no checkpointing — this is an
-//! ingestion-only source.
+//! There is no CDC/incremental support and no durable source cursor — this is an
+//! ingestion-only source. Rows still go through the shared transform/apply path
+//! ([`run_full_sync_with_transforms`]) so `--transforms-config` batching and
+//! `max_in_flight` apply within each table.
 //!
 //! # Usage
 //! ```ignore
@@ -19,7 +21,10 @@ pub mod client;
 pub mod full_sync;
 
 pub use client::{QueryResult, SnowflakeClient};
-pub use full_sync::{migrate_table, run_full_sync};
+pub use full_sync::{
+    apply_query_result_with_transforms, migrate_table, migrate_table_with_transforms,
+    run_full_sync, run_full_sync_with_transforms,
+};
 
 /// Connection + selection options for the Snowflake source (no clap types).
 #[derive(Clone, Debug)]
@@ -51,7 +56,7 @@ pub struct SourceOpts {
 /// Non-connection sync options.
 #[derive(Clone, Debug)]
 pub struct SyncOpts {
-    /// Number of rows per write batch to the sink.
+    /// Number of rows per read chunk fed into the apply window.
     pub batch_size: usize,
     /// When true, read and convert but do not write to SurrealDB.
     pub dry_run: bool,

--- a/crates/snowflake-source/tests/transforms.rs
+++ b/crates/snowflake-source/tests/transforms.rs
@@ -1,0 +1,208 @@
+//! Transform pipeline tests for Snowflake full sync (identity + external mutate).
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use serde_json::json;
+use snowflake_types::ColumnType;
+use surreal_sink::SurrealSink;
+use surreal_sync_snowflake_source::{
+    apply_query_result_with_transforms, QueryResult, SourceOpts, SyncOpts,
+};
+use sync_core::{UniversalChange, UniversalRelation, UniversalRow, UniversalValue};
+use sync_transform::{ApplyOpts, ChildStdioMode, ExternalTransform, FramerKind, Pipeline};
+
+struct CaptureSink {
+    rows: Mutex<Vec<UniversalRow>>,
+    rows_written: Arc<AtomicUsize>,
+}
+
+impl CaptureSink {
+    fn new() -> Self {
+        Self {
+            rows: Mutex::new(Vec::new()),
+            rows_written: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+}
+
+fn change_to_row(change: &UniversalChange, index: u64) -> UniversalRow {
+    UniversalRow::new(
+        change.table.clone(),
+        index,
+        change.id.clone(),
+        change.data.clone().unwrap_or_default(),
+    )
+}
+
+#[async_trait::async_trait]
+impl SurrealSink for CaptureSink {
+    async fn write_universal_rows(&self, rows: &[UniversalRow]) -> anyhow::Result<()> {
+        self.rows_written.fetch_add(rows.len(), Ordering::SeqCst);
+        self.rows.lock().expect("lock").extend(rows.iter().cloned());
+        Ok(())
+    }
+
+    async fn write_universal_relations(
+        &self,
+        _relations: &[UniversalRelation],
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn apply_universal_change(&self, change: &UniversalChange) -> anyhow::Result<()> {
+        let mut rows = self.rows.lock().expect("lock");
+        let index = rows.len() as u64;
+        rows.push(change_to_row(change, index));
+        self.rows_written.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn apply_universal_relation_change(
+        &self,
+        _change: &sync_core::UniversalRelationChange,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+fn fixture_worker_path() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.pop();
+    p.pop();
+    p.push("target/debug/sync-transform-fixture-worker");
+    p
+}
+
+fn ensure_fixture_worker() -> PathBuf {
+    let path = fixture_worker_path();
+    if !path.is_file() {
+        let status = Command::new("cargo")
+            .args([
+                "build",
+                "-p",
+                "sync-transform",
+                "--bin",
+                "sync-transform-fixture-worker",
+            ])
+            .current_dir({
+                let mut root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+                root.pop();
+                root.pop();
+                root
+            })
+            .status()
+            .expect("spawn cargo build");
+        assert!(status.success());
+    }
+    path
+}
+
+fn sample_result() -> QueryResult {
+    // Lowercase `name` matches the fixture mutate worker's field key.
+    QueryResult {
+        columns: vec![
+            ColumnType::new("id", "fixed"),
+            ColumnType::new("name", "text"),
+        ],
+        rows: vec![
+            vec![json!("1"), json!("Alice")],
+            vec![json!("2"), json!("Bob")],
+        ],
+    }
+}
+
+fn sample_opts() -> (SourceOpts, SyncOpts) {
+    let source = SourceOpts {
+        account: "unused".into(),
+        user: "unused".into(),
+        private_key_pem: String::new(),
+        private_key_passphrase: None,
+        warehouse: "unused".into(),
+        database: "DB".into(),
+        schema: "PUBLIC".into(),
+        role: None,
+        tables: vec!["PEOPLE".into()],
+        id_columns: vec!["id".into()],
+    };
+    let sync = SyncOpts {
+        batch_size: 10,
+        dry_run: false,
+    };
+    (source, sync)
+}
+
+fn row_name(row: &UniversalRow) -> Option<String> {
+    match row.fields.get("name")? {
+        UniversalValue::Text(value) => Some(value.clone()),
+        other => panic!("unexpected name: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn identity_apply_writes_rows() {
+    let (source_opts, sync_opts) = sample_opts();
+    let result = sample_result();
+    let pipeline = Pipeline::new();
+    let apply_opts = ApplyOpts::identity();
+    let sink = CaptureSink::new();
+
+    let written = apply_query_result_with_transforms(
+        &sink,
+        "PEOPLE",
+        &result,
+        &source_opts,
+        &sync_opts,
+        &pipeline,
+        &apply_opts,
+    )
+    .await
+    .expect("identity apply");
+
+    assert_eq!(written, 2);
+    assert_eq!(sink.rows_written.load(Ordering::SeqCst), 2);
+    let rows = sink.rows.lock().expect("lock").clone();
+    assert_eq!(row_name(&rows[0]).as_deref(), Some("Alice"));
+    assert_eq!(row_name(&rows[1]).as_deref(), Some("Bob"));
+}
+
+#[tokio::test]
+async fn external_mutate_rewrites_name_through_row_chunk_driver() {
+    let worker = ensure_fixture_worker();
+    let (source_opts, sync_opts) = sample_opts();
+    let result = sample_result();
+
+    let mut pipeline = Pipeline::new();
+    pipeline.push_external(
+        ExternalTransform::child_stdio(
+            ChildStdioMode::Persistent,
+            vec![worker.to_string_lossy().to_string(), "mutate".to_string()],
+            FramerKind::Ndjson,
+        )
+        .expect("spawn mutate worker"),
+    );
+    let apply_opts = ApplyOpts::identity()
+        .with_batch_size(10)
+        .with_max_in_flight(2);
+
+    let sink = CaptureSink::new();
+    apply_query_result_with_transforms(
+        &sink,
+        "PEOPLE",
+        &result,
+        &source_opts,
+        &sync_opts,
+        &pipeline,
+        &apply_opts,
+    )
+    .await
+    .expect("mutate apply");
+
+    let rows = sink.rows.lock().expect("lock").clone();
+    assert_eq!(rows.len(), 2);
+    for row in &rows {
+        assert_eq!(row_name(row).as_deref(), Some("mutated"));
+    }
+}

--- a/docs/source-ports.md
+++ b/docs/source-ports.md
@@ -39,7 +39,7 @@ spawn coverage is in `sync-transform` config tests).
 | kafka | SourceDriver + `run_source_runtime` | Yes (shared loader + CLI e2e) | N/A | `commit_batch` all sunk msgs; `note_sunk_events` counts |
 | csv | Long-lived SourceDriver stream | Yes (shared loader + CLI e2e) | N/A | File read polls into window (no per-batch runtime restart); **one runtime per file** (no cross-file read/transform/write overlap) |
 | jsonl | Long-lived SourceDriver stream | Yes (shared loader + CLI e2e) | N/A | `conversion_rules` before Pipeline; **one runtime per file** (same as CSV) |
-| snowflake | RowChunkDriver full (per table) | Yes (shared loader) | N/A | Ingestion-only SQL REST snapshot; no durable source cursor / checkpoint resume |
+| snowflake | RowChunkDriver full (per table) | Yes (shared loader) | N/A | Ingestion-only SQL REST snapshot; streams one result partition at a time into `batch_size` apply chunks; no durable source cursor / checkpoint resume |
 
 ## Porting checklist
 

--- a/docs/source-ports.md
+++ b/docs/source-ports.md
@@ -39,6 +39,7 @@ spawn coverage is in `sync-transform` config tests).
 | kafka | SourceDriver + `run_source_runtime` | Yes (shared loader + CLI e2e) | N/A | `commit_batch` all sunk msgs; `note_sunk_events` counts |
 | csv | Long-lived SourceDriver stream | Yes (shared loader + CLI e2e) | N/A | File read polls into window (no per-batch runtime restart); **one runtime per file** (no cross-file read/transform/write overlap) |
 | jsonl | Long-lived SourceDriver stream | Yes (shared loader + CLI e2e) | N/A | `conversion_rules` before Pipeline; **one runtime per file** (same as CSV) |
+| snowflake | RowChunkDriver full (per table) | Yes (shared loader) | N/A | Ingestion-only SQL REST snapshot; no durable source cursor / checkpoint resume |
 
 ## Porting checklist
 

--- a/docs/sync-pipeline.md
+++ b/docs/sync-pipeline.md
@@ -96,7 +96,7 @@ For every incremental batch on sources with a real post-sink durability hook, su
 | PostgreSQL wal2json | Slot `advance` only after emitted events are sunk (peeks may continue under window capacity via non-consuming peek + prefix skip) |
 | Kafka | Consumer-group `commit_batch` of **all** messages in the sunk batch (not only the last position) |
 | CSV / JSONL | No source cursor (file import) |
-| Snowflake | No source cursor (one-shot ingestion) |
+| Snowflake | No source cursor (one-shot ingestion; streams result partitions) |
 | MySQL/PostgreSQL trigger, MongoDB change stream, Neo4j | After SurrealDB write succeeds, `advance_watermark(position)` marks an **in-memory sink-safe cursor**. Fetch/read-ahead may be ahead of that cursor; `checkpoint()` / resume-token handles report the sunk watermark, not the read head. There is still **no mid-run durable store write** on these ports — process restart resumes from the last **persisted** sync checkpoint (phase markers / `--from`), so long incremental runs may reprocess after a crash (at-least-once). |
 
 | Hop | What “ack” means |

--- a/docs/sync-pipeline.md
+++ b/docs/sync-pipeline.md
@@ -96,6 +96,7 @@ For every incremental batch on sources with a real post-sink durability hook, su
 | PostgreSQL wal2json | Slot `advance` only after emitted events are sunk (peeks may continue under window capacity via non-consuming peek + prefix skip) |
 | Kafka | Consumer-group `commit_batch` of **all** messages in the sunk batch (not only the last position) |
 | CSV / JSONL | No source cursor (file import) |
+| Snowflake | No source cursor (one-shot ingestion) |
 | MySQL/PostgreSQL trigger, MongoDB change stream, Neo4j | After SurrealDB write succeeds, `advance_watermark(position)` marks an **in-memory sink-safe cursor**. Fetch/read-ahead may be ahead of that cursor; `checkpoint()` / resume-token handles report the sunk watermark, not the read head. There is still **no mid-run durable store write** on these ports — process restart resumes from the last **persisted** sync checkpoint (phase markers / `--from`), so long incremental runs may reprocess after a crash (at-least-once). |
 
 | Hop | What “ack” means |
@@ -177,6 +178,7 @@ Every sync/import path below loads the same TOML via the shared CLI helper and r
 | `from kafka` | SourceDriver window; offset `commit_batch` of all sunk messages after sink |
 | `from csv` | Long-lived SourceDriver streams file reads into the window |
 | `from jsonl` | Long-lived SourceDriver streams line reads into the window |
+| `from snowflake` | Full snapshot via `RowChunkDriver` (ingestion-only; no source cursor) |
 
 ### CLI quick start
 

--- a/src/from/mod.rs
+++ b/src/from/mod.rs
@@ -16,6 +16,7 @@
 //! - `kafka`: Kafka streaming sync
 //! - `csv`: CSV file import
 //! - `jsonl`: JSONL file import
+//! - `snowflake`: Snowflake full snapshot ingestion (SQL REST API)
 //! - `transforms`: Shared `--transforms-config` loader for all `from *` sync handlers
 
 pub mod common;

--- a/src/from/snowflake.rs
+++ b/src/from/snowflake.rs
@@ -4,11 +4,14 @@
 //! CLI command (ingestion-only, no full/incremental split):
 //! - `from snowflake --account ... --user ... --private-key-path ... \
 //!    --warehouse ... --database ... --schema ... [--tables ...] [--id-columns ...] \
-//!    --to-namespace ... --to-database ...`
+//!    [--transforms-config ...] --to-namespace ... --to-database ...`
 
 use anyhow::Context;
-use surreal_sync_snowflake_source::{run_full_sync, SnowflakeClient, SourceOpts, SyncOpts};
+use surreal_sync_snowflake_source::{
+    run_full_sync_with_transforms, SnowflakeClient, SourceOpts, SyncOpts,
+};
 
+use super::transforms::load_transforms_from_args;
 use super::{get_sdk_version, SdkVersion};
 use crate::SnowflakeArgs;
 
@@ -64,6 +67,7 @@ async fn run_v2(args: SnowflakeArgs) -> anyhow::Result<()> {
         tracing::info!("Running in dry-run mode - no data will be written");
     }
 
+    let (pipeline, apply_opts) = load_transforms_from_args(args.transforms_config.as_deref())?;
     let (source_opts, sync_opts) = build_opts(&args)?;
     let client = SnowflakeClient::new(&source_opts)?;
 
@@ -77,7 +81,15 @@ async fn run_v2(args: SnowflakeArgs) -> anyhow::Result<()> {
             .await?;
     let sink = surreal2_sink::Surreal2Sink::new(surreal);
 
-    run_full_sync(&client, &sink, &source_opts, &sync_opts).await?;
+    run_full_sync_with_transforms(
+        &client,
+        &sink,
+        &source_opts,
+        &sync_opts,
+        &pipeline,
+        &apply_opts,
+    )
+    .await?;
 
     tracing::info!("Snowflake ingestion completed successfully");
     Ok(())
@@ -90,6 +102,7 @@ async fn run_v3(args: SnowflakeArgs) -> anyhow::Result<()> {
         tracing::info!("Running in dry-run mode - no data will be written");
     }
 
+    let (pipeline, apply_opts) = load_transforms_from_args(args.transforms_config.as_deref())?;
     let (source_opts, sync_opts) = build_opts(&args)?;
     let client = SnowflakeClient::new(&source_opts)?;
 
@@ -103,7 +116,15 @@ async fn run_v3(args: SnowflakeArgs) -> anyhow::Result<()> {
             .await?;
     let sink = surreal3_sink::Surreal3Sink::new(surreal);
 
-    run_full_sync(&client, &sink, &source_opts, &sync_opts).await?;
+    run_full_sync_with_transforms(
+        &client,
+        &sink,
+        &source_opts,
+        &sync_opts,
+        &pipeline,
+        &apply_opts,
+    )
+    .await?;
 
     tracing::info!("Snowflake ingestion completed successfully");
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1630,6 +1630,11 @@ struct SnowflakeArgs {
     #[arg(long)]
     to_database: String,
 
+    /// TOML file describing the transform pipeline (`[[transforms]]`).
+    /// Omit for identity (docs pass through unchanged; no transform stage dispatch).
+    #[arg(long, value_name = "PATH")]
+    transforms_config: Option<PathBuf>,
+
     #[command(flatten)]
     surreal: SurrealOpts,
 }


### PR DESCRIPTION
This wires Snowflake source through the shared transform/apply path so `--transforms-config` batching and overlap work like other sources, and streams Snowflake result partitions one at a time into `batch_size` apply chunks so large tables stay bounded in memory instead of loading the whole result set up front.