### PR TITLE
Handle MySQL zero dates with configurable SurrealDB mapping

### DIFF
--- a/crates/csv-types/src/forward.rs
+++ b/crates/csv-types/src/forward.rs
@@ -146,6 +146,16 @@ impl From<UniversalValue> for CsvValue {
                     .collect();
                 CsvValue(serde_json::to_string(&serde_json::Value::Object(obj)).unwrap_or_default())
             }
+
+            UniversalValue::ZeroTemporal {
+                intended_type,
+                source,
+            } => {
+                let s = source.unwrap_or_else(|| {
+                    UniversalValue::canonical_zero_literal(&intended_type).to_string()
+                });
+                CsvValue(s)
+            }
         }
     }
 }
@@ -219,6 +229,15 @@ fn generated_value_to_json(value: &UniversalValue) -> serde_json::Value {
                 .map(|(k, v)| (k.clone(), generated_value_to_json(v)))
                 .collect();
             serde_json::Value::Object(obj)
+        }
+        UniversalValue::ZeroTemporal {
+            intended_type,
+            source,
+        } => {
+            let s = source
+                .as_deref()
+                .unwrap_or_else(|| UniversalValue::canonical_zero_literal(intended_type));
+            serde_json::Value::String(s.to_string())
         }
     }
 }

--- a/crates/json-types/src/forward.rs
+++ b/crates/json-types/src/forward.rs
@@ -161,6 +161,17 @@ impl From<UniversalValue> for JsonValue {
                     .collect();
                 JsonValue(serde_json::Value::Object(obj))
             }
+
+            // Zero temporal - preserve as MySQL-style literal string
+            UniversalValue::ZeroTemporal {
+                intended_type,
+                source,
+            } => {
+                let s = source.unwrap_or_else(|| {
+                    UniversalValue::canonical_zero_literal(&intended_type).to_string()
+                });
+                JsonValue(json!(s))
+            }
         }
     }
 }
@@ -237,6 +248,15 @@ fn generated_value_to_json(value: &UniversalValue) -> serde_json::Value {
                 .map(|(k, v)| (k.clone(), generated_value_to_json(v)))
                 .collect();
             serde_json::Value::Object(obj)
+        }
+        UniversalValue::ZeroTemporal {
+            intended_type,
+            source,
+        } => {
+            let s = source
+                .as_deref()
+                .unwrap_or_else(|| UniversalValue::canonical_zero_literal(intended_type));
+            json!(s)
         }
     }
 }

--- a/crates/json-types/src/reverse.rs
+++ b/crates/json-types/src/reverse.rs
@@ -200,21 +200,27 @@ impl From<JsonValueWithSchema> for TypedValue {
 
             // Date/time types - multiple formats supported
             (UniversalType::LocalDateTime, serde_json::Value::String(s)) => {
-                if let Some(dt) = parse_datetime_string(s) {
+                if UniversalValue::is_mysql_zero_temporal_literal(s) {
+                    TypedValue::zero_temporal(UniversalType::LocalDateTime, Some(s.clone()))
+                } else if let Some(dt) = parse_datetime_string(s) {
                     TypedValue::datetime(dt)
                 } else {
                     TypedValue::null(UniversalType::LocalDateTime)
                 }
             }
             (UniversalType::LocalDateTimeNano, serde_json::Value::String(s)) => {
-                if let Some(dt) = parse_datetime_string(s) {
+                if UniversalValue::is_mysql_zero_temporal_literal(s) {
+                    TypedValue::zero_temporal(UniversalType::LocalDateTimeNano, Some(s.clone()))
+                } else if let Some(dt) = parse_datetime_string(s) {
                     TypedValue::datetime_nano(dt)
                 } else {
                     TypedValue::null(UniversalType::LocalDateTimeNano)
                 }
             }
             (UniversalType::ZonedDateTime, serde_json::Value::String(s)) => {
-                if let Some(dt) = parse_datetime_string(s) {
+                if UniversalValue::is_mysql_zero_temporal_literal(s) {
+                    TypedValue::zero_temporal(UniversalType::ZonedDateTime, Some(s.clone()))
+                } else if let Some(dt) = parse_datetime_string(s) {
                     TypedValue::timestamptz(dt)
                 } else {
                     TypedValue::null(UniversalType::ZonedDateTime)
@@ -223,7 +229,9 @@ impl From<JsonValueWithSchema> for TypedValue {
 
             // Date stored as string
             (UniversalType::Date, serde_json::Value::String(s)) => {
-                if let Ok(dt) = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
+                if UniversalValue::is_mysql_zero_temporal_literal(s) {
+                    TypedValue::zero_temporal(UniversalType::Date, Some(s.clone()))
+                } else if let Ok(dt) = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
                     let datetime = dt.and_hms_opt(0, 0, 0).unwrap();
                     let utc_dt = DateTime::<Utc>::from_naive_utc_and_offset(datetime, Utc);
                     TypedValue::date(utc_dt)
@@ -932,6 +940,33 @@ mod tests {
         } else {
             panic!("Expected Date, got {:?}", tv.value);
         }
+    }
+
+    #[test]
+    fn test_zero_date_literal_emits_zero_temporal() {
+        let jv = JsonValueWithSchema::new(json!("0000-00-00"), UniversalType::Date);
+        let tv = TypedValue::from(jv);
+        assert!(matches!(
+            tv.value,
+            UniversalValue::ZeroTemporal {
+                intended_type: UniversalType::Date,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_zero_datetime_literal_emits_zero_temporal() {
+        let jv =
+            JsonValueWithSchema::new(json!("0000-00-00 00:00:00"), UniversalType::LocalDateTime);
+        let tv = TypedValue::from(jv);
+        assert!(matches!(
+            tv.value,
+            UniversalValue::ZeroTemporal {
+                intended_type: UniversalType::LocalDateTime,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/kafka-types/src/forward.rs
+++ b/crates/kafka-types/src/forward.rs
@@ -320,6 +320,18 @@ pub fn encode_generated_value(
                 .write_string(field_number, &json_str)
                 .map_err(|e| KafkaTypesError::ProtobufEncode(e.to_string()))?;
         }
+
+        UniversalValue::ZeroTemporal {
+            intended_type,
+            source,
+        } => {
+            let s = source
+                .as_deref()
+                .unwrap_or_else(|| UniversalValue::canonical_zero_literal(intended_type));
+            stream
+                .write_string(field_number, s)
+                .map_err(|e| KafkaTypesError::ProtobufEncode(e.to_string()))?;
+        }
     }
     Ok(())
 }
@@ -465,6 +477,15 @@ fn universal_value_to_json(value: &UniversalValue) -> serde_json::Value {
                 .map(|(k, v)| (k.clone(), universal_value_to_json(v)))
                 .collect();
             serde_json::Value::Object(obj)
+        }
+        UniversalValue::ZeroTemporal {
+            intended_type,
+            source,
+        } => {
+            let s = source
+                .as_deref()
+                .unwrap_or_else(|| UniversalValue::canonical_zero_literal(intended_type));
+            serde_json::Value::String(s.to_string())
         }
     }
 }

--- a/crates/kafka-types/src/reverse.rs
+++ b/crates/kafka-types/src/reverse.rs
@@ -333,6 +333,15 @@ fn universal_value_to_json(value: &UniversalValue) -> serde_json::Value {
                 .collect();
             serde_json::Value::Object(obj)
         }
+        UniversalValue::ZeroTemporal {
+            intended_type,
+            source,
+        } => {
+            let s = source
+                .as_deref()
+                .unwrap_or_else(|| UniversalValue::canonical_zero_literal(intended_type));
+            serde_json::Value::String(s.to_string())
+        }
     }
 }
 

--- a/crates/loadtest-populate-neo4j/src/insert.rs
+++ b/crates/loadtest-populate-neo4j/src/insert.rs
@@ -235,6 +235,16 @@ fn typed_to_neo4j_literal(typed: &TypedValue) -> String {
 
         // TimeTz - stored as string to preserve timezone format
         UniversalValue::TimeTz(s) => escape_neo4j_string(s),
+
+        UniversalValue::ZeroTemporal {
+            intended_type,
+            source,
+        } => {
+            let s = source
+                .as_deref()
+                .unwrap_or_else(|| UniversalValue::canonical_zero_literal(intended_type));
+            escape_neo4j_string(s)
+        }
     }
 }
 
@@ -318,6 +328,15 @@ fn universal_to_json(value: &UniversalValue) -> serde_json::Value {
         }
         // TimeTz - stored as string to preserve timezone format
         UniversalValue::TimeTz(s) => serde_json::json!(s),
+        UniversalValue::ZeroTemporal {
+            intended_type,
+            source,
+        } => {
+            let s = source
+                .as_deref()
+                .unwrap_or_else(|| UniversalValue::canonical_zero_literal(intended_type));
+            serde_json::json!(s)
+        }
     }
 }
 

--- a/crates/mongodb-types/src/forward.rs
+++ b/crates/mongodb-types/src/forward.rs
@@ -213,6 +213,16 @@ impl From<UniversalValue> for BsonValue {
                 }
                 BsonValue(Bson::Document(doc))
             }
+
+            UniversalValue::ZeroTemporal {
+                intended_type,
+                source,
+            } => {
+                let s = source.unwrap_or_else(|| {
+                    UniversalValue::canonical_zero_literal(&intended_type).to_string()
+                });
+                BsonValue(Bson::String(s))
+            }
         }
     }
 }
@@ -324,6 +334,15 @@ fn generated_value_to_bson(value: &UniversalValue) -> Bson {
                 doc.insert(k.clone(), generated_value_to_bson(v));
             }
             Bson::Document(doc)
+        }
+        UniversalValue::ZeroTemporal {
+            intended_type,
+            source,
+        } => {
+            let s = source
+                .as_deref()
+                .unwrap_or_else(|| UniversalValue::canonical_zero_literal(intended_type));
+            Bson::String(s.to_string())
         }
     }
 }

--- a/crates/mysql-types/src/binlog.rs
+++ b/crates/mysql-types/src/binlog.rs
@@ -157,6 +157,12 @@ fn binlog_cell_to_typed_value(
         }
         MYSQL_TYPE_DATE => {
             let (year, month, day) = extract_date_parts(cell)?;
+            if UniversalValue::is_mysql_zero_date_ymd(year, month, day) {
+                return Ok(TypedValue::zero_temporal(
+                    UniversalType::Date,
+                    Some(UniversalValue::canonical_zero_literal(&UniversalType::Date).to_string()),
+                ));
+            }
             let date = NaiveDate::from_ymd_opt(year as i32, month as u32, day as u32).ok_or_else(
                 || {
                     ConversionError::InvalidDateTime(format!(
@@ -187,6 +193,20 @@ fn binlog_cell_to_typed_value(
             ))
         }
         MYSQL_TYPE_DATETIME | MYSQL_TYPE_DATETIME2 => {
+            if let CellValue::DateTime {
+                year, month, day, ..
+            } = cell
+            {
+                if UniversalValue::is_mysql_zero_date_ymd(*year, *month, *day) {
+                    return Ok(TypedValue::zero_temporal(
+                        UniversalType::LocalDateTime,
+                        Some(
+                            UniversalValue::canonical_zero_literal(&UniversalType::LocalDateTime)
+                                .to_string(),
+                        ),
+                    ));
+                }
+            }
             Ok(TypedValue::datetime(extract_datetime(cell)?))
         }
         MYSQL_TYPE_TIMESTAMP | MYSQL_TYPE_TIMESTAMP2 => {
@@ -1396,6 +1416,50 @@ mod tests {
         )
         .unwrap_err();
         assert!(matches!(err, ConversionError::InvalidDateTime(_)));
+    }
+
+    #[test]
+    fn test_zero_date_emits_zero_temporal() {
+        let column = col("d", MYSQL_TYPE_DATE, ColumnMetadata::None);
+        let value = convert(
+            &CellValue::Date {
+                year: 0,
+                month: 0,
+                day: 0,
+            },
+            &column,
+        );
+        assert!(matches!(
+            value,
+            UniversalValue::ZeroTemporal {
+                intended_type: UniversalType::Date,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_zero_datetime_emits_zero_temporal() {
+        let column = col("dt", MYSQL_TYPE_DATETIME, ColumnMetadata::None);
+        let value = convert(
+            &CellValue::DateTime {
+                year: 0,
+                month: 0,
+                day: 0,
+                hour: 0,
+                minute: 0,
+                second: 0,
+                micros: 0,
+            },
+            &column,
+        );
+        assert!(matches!(
+            value,
+            UniversalValue::ZeroTemporal {
+                intended_type: UniversalType::LocalDateTime,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/mysql-types/src/forward.rs
+++ b/crates/mysql-types/src/forward.rs
@@ -168,6 +168,16 @@ impl From<UniversalValue> for MySQLValue {
                     serde_json::to_string(&serde_json::Value::Object(obj)).unwrap_or_default();
                 MySQLValue(Value::Bytes(json_str.into_bytes()))
             }
+
+            UniversalValue::ZeroTemporal {
+                intended_type,
+                source,
+            } => {
+                let s = source.unwrap_or_else(|| {
+                    UniversalValue::canonical_zero_literal(&intended_type).to_string()
+                });
+                MySQLValue(Value::Bytes(s.into_bytes()))
+            }
         }
     }
 }
@@ -258,6 +268,15 @@ fn generated_to_json(gv: UniversalValue) -> serde_json::Value {
                 .map(|(k, v)| (k, generated_to_json(v)))
                 .collect();
             serde_json::Value::Object(obj)
+        }
+        UniversalValue::ZeroTemporal {
+            intended_type,
+            source,
+        } => {
+            let s = source.unwrap_or_else(|| {
+                UniversalValue::canonical_zero_literal(&intended_type).to_string()
+            });
+            serde_json::Value::String(s)
         }
     }
 }

--- a/crates/mysql-types/src/reverse.rs
+++ b/crates/mysql-types/src/reverse.rs
@@ -22,7 +22,7 @@
 use chrono::{NaiveDate, NaiveTime, TimeZone, Utc};
 use mysql_async::consts::{ColumnFlags, ColumnType};
 use mysql_async::Value;
-use sync_core::{TypedValue, UniversalType};
+use sync_core::{TypedValue, UniversalType, UniversalValue};
 use thiserror::Error;
 
 // Re-export from json-types for convenience
@@ -232,6 +232,15 @@ impl TryFrom<MySQLValueWithSchema> for TypedValue {
 
             // Date/time types
             MYSQL_TYPE_DATE => {
+                if is_zero_mysql_value(&mv.value) {
+                    return Ok(TypedValue::zero_temporal(
+                        UniversalType::Date,
+                        Some(
+                            UniversalValue::canonical_zero_literal(&UniversalType::Date)
+                                .to_string(),
+                        ),
+                    ));
+                }
                 let dt = extract_date(&mv.value)?;
                 let datetime = dt.and_hms_opt(0, 0, 0).unwrap().and_utc();
                 Ok(TypedValue::date(datetime))
@@ -245,11 +254,29 @@ impl TryFrom<MySQLValueWithSchema> for TypedValue {
             }
 
             MYSQL_TYPE_DATETIME | MYSQL_TYPE_DATETIME2 => {
+                if is_zero_mysql_value(&mv.value) {
+                    return Ok(TypedValue::zero_temporal(
+                        UniversalType::LocalDateTime,
+                        Some(
+                            UniversalValue::canonical_zero_literal(&UniversalType::LocalDateTime)
+                                .to_string(),
+                        ),
+                    ));
+                }
                 let dt = extract_datetime(&mv.value)?;
                 Ok(TypedValue::datetime(dt))
             }
 
             MYSQL_TYPE_TIMESTAMP | MYSQL_TYPE_TIMESTAMP2 => {
+                if is_zero_mysql_value(&mv.value) {
+                    return Ok(TypedValue::zero_temporal(
+                        UniversalType::ZonedDateTime,
+                        Some(
+                            UniversalValue::canonical_zero_literal(&UniversalType::ZonedDateTime)
+                                .to_string(),
+                        ),
+                    ));
+                }
                 let dt = extract_datetime(&mv.value)?;
                 Ok(TypedValue::timestamptz(dt))
             }
@@ -456,6 +483,19 @@ fn extract_date(value: &Value) -> Result<NaiveDate, ConversionError> {
             expected: "date".to_string(),
             actual: value.clone(),
         }),
+    }
+}
+
+/// True when MySQL emits a zero date/datetime (`0000-00-00` / `0000-00-00 00:00:00`).
+fn is_zero_mysql_value(value: &Value) -> bool {
+    match value {
+        Value::Date(year, month, day, _, _, _, _) => {
+            UniversalValue::is_mysql_zero_date_ymd(*year, *month, *day)
+        }
+        Value::Bytes(b) => std::str::from_utf8(b)
+            .map(UniversalValue::is_mysql_zero_temporal_literal)
+            .unwrap_or(false),
+        _ => false,
     }
 }
 
@@ -1137,6 +1177,68 @@ mod tests {
         let err = result.unwrap_err();
         assert!(matches!(err, ConversionError::InvalidDateTime(_)));
         assert!(err.to_string().contains("month=13"));
+    }
+
+    #[test]
+    fn test_zero_date_emits_zero_temporal() {
+        let mv = MySQLValueWithSchema::new(
+            Value::Date(0, 0, 0, 0, 0, 0, 0),
+            ColumnType::MYSQL_TYPE_DATE,
+            ColumnFlags::empty(),
+        );
+        let tv = mv.to_typed_value().unwrap();
+        assert!(matches!(
+            tv.value,
+            UniversalValue::ZeroTemporal {
+                intended_type: UniversalType::Date,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_zero_datetime_emits_zero_temporal() {
+        let mv = MySQLValueWithSchema::new(
+            Value::Date(0, 0, 0, 0, 0, 0, 0),
+            ColumnType::MYSQL_TYPE_DATETIME,
+            ColumnFlags::empty(),
+        );
+        let tv = mv.to_typed_value().unwrap();
+        assert!(matches!(
+            tv.value,
+            UniversalValue::ZeroTemporal {
+                intended_type: UniversalType::LocalDateTime,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_zero_timestamp_emits_zero_temporal() {
+        let mv = MySQLValueWithSchema::new(
+            Value::Date(0, 0, 0, 0, 0, 0, 0),
+            ColumnType::MYSQL_TYPE_TIMESTAMP,
+            ColumnFlags::empty(),
+        );
+        let tv = mv.to_typed_value().unwrap();
+        assert!(matches!(
+            tv.value,
+            UniversalValue::ZeroTemporal {
+                intended_type: UniversalType::ZonedDateTime,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_zero_date_string_emits_zero_temporal() {
+        let mv = MySQLValueWithSchema::new(
+            Value::Bytes(b"0000-00-00".to_vec()),
+            ColumnType::MYSQL_TYPE_DATE,
+            ColumnFlags::empty(),
+        );
+        let tv = mv.to_typed_value().unwrap();
+        assert!(matches!(tv.value, UniversalValue::ZeroTemporal { .. }));
     }
 
     #[test]

--- a/crates/neo4j-types/src/forward.rs
+++ b/crates/neo4j-types/src/forward.rs
@@ -224,6 +224,17 @@ pub fn universal_to_cypher_literal(
                 .collect();
             Ok(format!("{{{}}}", entries.join(", ")))
         }
+
+        // Zero temporal - preserve as escaped MySQL-style literal string
+        UniversalValue::ZeroTemporal {
+            intended_type,
+            source,
+        } => {
+            let s = source
+                .as_deref()
+                .unwrap_or_else(|| UniversalValue::canonical_zero_literal(intended_type));
+            Ok(escape_neo4j_string(s))
+        }
     }
 }
 

--- a/crates/neo4j-types/src/reverse.rs
+++ b/crates/neo4j-types/src/reverse.rs
@@ -431,6 +431,7 @@ fn infer_element_type(value: &UniversalValue) -> UniversalType {
         UniversalValue::Thing { .. } => UniversalType::Thing,
         UniversalValue::Object(_) => UniversalType::Object,
         UniversalValue::TimeTz(_) => UniversalType::TimeTz,
+        UniversalValue::ZeroTemporal { intended_type, .. } => intended_type.clone(),
     }
 }
 
@@ -504,6 +505,15 @@ fn universal_value_to_json(value: &UniversalValue) -> serde_json::Value {
         }
         // TimeTz - stored as string to preserve timezone format
         UniversalValue::TimeTz(s) => serde_json::Value::String(s.clone()),
+        UniversalValue::ZeroTemporal {
+            intended_type,
+            source,
+        } => {
+            let s = source
+                .as_deref()
+                .unwrap_or_else(|| UniversalValue::canonical_zero_literal(intended_type));
+            serde_json::Value::String(s.to_string())
+        }
     }
 }
 

--- a/crates/postgresql-types/src/forward.rs
+++ b/crates/postgresql-types/src/forward.rs
@@ -179,6 +179,16 @@ impl From<UniversalValue> for PostgreSQLValue {
                     .collect();
                 PostgreSQLValue::Json(serde_json::Value::Object(obj))
             }
+
+            UniversalValue::ZeroTemporal {
+                intended_type,
+                source,
+            } => {
+                let s = source.unwrap_or_else(|| {
+                    UniversalValue::canonical_zero_literal(&intended_type).to_string()
+                });
+                PostgreSQLValue::Text(s)
+            }
         }
     }
 }

--- a/crates/surreal2-sink/src/lib.rs
+++ b/crates/surreal2-sink/src/lib.rs
@@ -15,6 +15,7 @@ pub use rows::{
     universal_value_to_surreal_id, write_universal_relations, write_universal_rows,
 };
 pub use sink_impl::Surreal2Sink;
+pub use sync_core::ZeroTemporalPolicy;
 pub use write::{
     apply_change, apply_universal_change, write_record, write_records, write_relation,
     write_relations,
@@ -23,6 +24,9 @@ pub use write::{
 // Re-export SurrealDB types for use by source crates
 pub use surrealdb::engine::any::Any as SurrealEngine;
 pub use surrealdb::Surreal;
+
+/// Connected SurrealDB v2 client used by [`Surreal2Sink`].
+pub type SurrealClient = Surreal<SurrealEngine>;
 
 // Re-export the SurrealSink trait
 pub use surreal_sink::SurrealSink;

--- a/crates/surreal2-sink/src/rows.rs
+++ b/crates/surreal2-sink/src/rows.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use surreal2_types::{RecordWithSurrealValues, Relation, SurrealValue};
 use surrealdb::sql::{Array, Id, Strand, Thing, Value};
 use surrealdb::Surreal;
-use sync_core::{UniversalRelation, UniversalRow, UniversalValue};
+use sync_core::{UniversalRelation, UniversalRow, UniversalValue, ZeroTemporalPolicy};
 
 /// Convert UniversalValue ID to SurrealDB Id.
 ///
@@ -73,7 +73,10 @@ fn universal_value_to_id_array_element(value: &UniversalValue) -> Result<Value> 
 /// Convert UniversalRow to RecordWithSurrealValues.
 ///
 /// Returns an error if the row's ID type is not supported.
-pub fn universal_row_to_surreal_record(row: &UniversalRow) -> Result<RecordWithSurrealValues> {
+pub fn universal_row_to_surreal_record(
+    row: &UniversalRow,
+    zero_temporal: ZeroTemporalPolicy,
+) -> Result<RecordWithSurrealValues> {
     let id = universal_value_to_surreal_id(&row.id)?;
     let thing = Thing::from((row.table.as_str(), id));
 
@@ -82,7 +85,7 @@ pub fn universal_row_to_surreal_record(row: &UniversalRow) -> Result<RecordWithS
         .iter()
         .map(|(k, v)| {
             let typed = v.clone().to_typed_value();
-            let surreal_val: SurrealValue = typed.into();
+            let surreal_val = SurrealValue::from_typed_with_policy(typed, zero_temporal);
             (k.clone(), surreal_val.into_inner())
         })
         .collect();
@@ -96,9 +99,10 @@ pub fn universal_row_to_surreal_record(row: &UniversalRow) -> Result<RecordWithS
 pub async fn write_universal_rows(
     surreal: &Surreal<surrealdb::engine::any::Any>,
     rows: &[UniversalRow],
+    zero_temporal: ZeroTemporalPolicy,
 ) -> Result<()> {
     for row in rows {
-        let record = universal_row_to_surreal_record(row)?;
+        let record = universal_row_to_surreal_record(row, zero_temporal)?;
         write_record(surreal, &record).await?;
     }
     Ok(())
@@ -107,7 +111,10 @@ pub async fn write_universal_rows(
 /// Convert UniversalRelation to SurrealDB Relation.
 ///
 /// Returns an error if any ID type is not supported.
-pub fn universal_relation_to_surreal_relation(rel: &UniversalRelation) -> Result<Relation> {
+pub fn universal_relation_to_surreal_relation(
+    rel: &UniversalRelation,
+    zero_temporal: ZeroTemporalPolicy,
+) -> Result<Relation> {
     // Convert the relation's own ID
     let id = universal_value_to_surreal_id(&rel.id)?;
     let thing_id = Thing::from((rel.relation_type.as_str(), id));
@@ -126,7 +133,7 @@ pub fn universal_relation_to_surreal_relation(rel: &UniversalRelation) -> Result
         .iter()
         .map(|(k, v)| {
             let typed = v.clone().to_typed_value();
-            let surreal_val: SurrealValue = typed.into();
+            let surreal_val = SurrealValue::from_typed_with_policy(typed, zero_temporal);
             (k.clone(), surreal_val)
         })
         .collect();
@@ -145,9 +152,10 @@ pub fn universal_relation_to_surreal_relation(rel: &UniversalRelation) -> Result
 pub async fn write_universal_relations(
     surreal: &Surreal<surrealdb::engine::any::Any>,
     relations: &[UniversalRelation],
+    zero_temporal: ZeroTemporalPolicy,
 ) -> Result<()> {
     for rel in relations {
-        let surreal_rel = universal_relation_to_surreal_relation(rel)?;
+        let surreal_rel = universal_relation_to_surreal_relation(rel, zero_temporal)?;
         write_relation(surreal, &surreal_rel).await?;
     }
     Ok(())

--- a/crates/surreal2-sink/src/sink_impl.rs
+++ b/crates/surreal2-sink/src/sink_impl.rs
@@ -4,7 +4,9 @@ use anyhow::Result;
 use surreal_sink::SurrealSink;
 use surrealdb::engine::any::Any;
 use surrealdb::Surreal;
-use sync_core::{UniversalChange, UniversalRelation, UniversalRelationChange, UniversalRow};
+use sync_core::{
+    UniversalChange, UniversalRelation, UniversalRelationChange, UniversalRow, ZeroTemporalPolicy,
+};
 
 use crate::rows::{write_universal_relations, write_universal_rows};
 use crate::write::{apply_universal_change, apply_universal_relation_change};
@@ -16,12 +18,24 @@ use crate::write::{apply_universal_change, apply_universal_relation_change};
 /// `<S: SurrealSink>` parameters.
 pub struct Surreal2Sink {
     client: Surreal<Any>,
+    zero_temporal: ZeroTemporalPolicy,
 }
 
 impl Surreal2Sink {
     /// Create a new Surreal2Sink from an existing Surreal connection.
     pub fn new(client: Surreal<Any>) -> Self {
-        Self { client }
+        Self::with_zero_temporal_policy(client, ZeroTemporalPolicy::default())
+    }
+
+    /// Create a new Surreal2Sink with an explicit zero-temporal conversion policy.
+    pub fn with_zero_temporal_policy(
+        client: Surreal<Any>,
+        zero_temporal: ZeroTemporalPolicy,
+    ) -> Self {
+        Self {
+            client,
+            zero_temporal,
+        }
     }
 
     /// Get a reference to the underlying Surreal client.
@@ -38,26 +52,31 @@ impl Surreal2Sink {
     pub fn into_inner(self) -> Surreal<Any> {
         self.client
     }
+
+    /// Zero-temporal conversion policy used when writing field values.
+    pub fn zero_temporal_policy(&self) -> ZeroTemporalPolicy {
+        self.zero_temporal
+    }
 }
 
 #[async_trait::async_trait]
 impl SurrealSink for Surreal2Sink {
     async fn write_universal_rows(&self, rows: &[UniversalRow]) -> Result<()> {
-        write_universal_rows(&self.client, rows).await
+        write_universal_rows(&self.client, rows, self.zero_temporal).await
     }
 
     async fn write_universal_relations(&self, relations: &[UniversalRelation]) -> Result<()> {
-        write_universal_relations(&self.client, relations).await
+        write_universal_relations(&self.client, relations, self.zero_temporal).await
     }
 
     async fn apply_universal_change(&self, change: &UniversalChange) -> Result<()> {
-        apply_universal_change(&self.client, change).await
+        apply_universal_change(&self.client, change, self.zero_temporal).await
     }
 
     async fn apply_universal_relation_change(
         &self,
         change: &UniversalRelationChange,
     ) -> Result<()> {
-        apply_universal_relation_change(&self.client, change).await
+        apply_universal_relation_change(&self.client, change, self.zero_temporal).await
     }
 }

--- a/crates/surreal2-sink/src/write.rs
+++ b/crates/surreal2-sink/src/write.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use surreal2_types::{RecordWithSurrealValues as Record, Relation, SurrealValue};
 use surrealdb::sql;
 use surrealdb::Surreal;
-use sync_core::{UniversalChange, UniversalChangeOp, UniversalRelationChange};
+use sync_core::{UniversalChange, UniversalChangeOp, UniversalRelationChange, ZeroTemporalPolicy};
 use tokio::time::sleep;
 
 use crate::rows::{universal_relation_to_surreal_relation, universal_value_to_surreal_id};
@@ -87,6 +87,7 @@ pub async fn apply_change(
 pub async fn apply_universal_change(
     surreal: &Surreal<surrealdb::engine::any::Any>,
     change: &UniversalChange,
+    zero_temporal: ZeroTemporalPolicy,
 ) -> anyhow::Result<()> {
     // Convert ID from UniversalValue to SurrealDB ID
     let surreal_id = universal_value_to_surreal_id(&change.id)?;
@@ -105,7 +106,7 @@ pub async fn apply_universal_change(
             let surreal_data: HashMap<String, surrealdb::sql::Value> = data
                 .iter()
                 .map(|(k, v)| {
-                    let sv = SurrealValue::from(v.clone());
+                    let sv = SurrealValue::from_universal_with_policy(v.clone(), zero_temporal);
                     (k.clone(), sv.into_inner())
                 })
                 .collect();
@@ -410,10 +411,12 @@ pub async fn write_relations(
 pub async fn apply_universal_relation_change(
     surreal: &Surreal<surrealdb::engine::any::Any>,
     change: &UniversalRelationChange,
+    zero_temporal: ZeroTemporalPolicy,
 ) -> anyhow::Result<()> {
     match change.operation {
         UniversalChangeOp::Create | UniversalChangeOp::Update => {
-            let surreal_rel = universal_relation_to_surreal_relation(&change.relation)?;
+            let surreal_rel =
+                universal_relation_to_surreal_relation(&change.relation, zero_temporal)?;
             write_relation(surreal, &surreal_rel).await?;
             tracing::trace!(
                 "Successfully upserted relation: {:?}",

--- a/crates/surreal2-types/src/forward.rs
+++ b/crates/surreal2-types/src/forward.rs
@@ -22,10 +22,55 @@ impl SurrealValue {
     pub fn as_inner(&self) -> &Value {
         &self.0
     }
-}
 
-impl From<TypedValue> for SurrealValue {
-    fn from(tv: TypedValue) -> Self {
+    /// Convert a zero-temporal sentinel using the given sink policy.
+    pub fn from_zero_temporal(
+        intended_type: &UniversalType,
+        source: Option<&str>,
+        policy: sync_core::ZeroTemporalPolicy,
+    ) -> Self {
+        match policy {
+            sync_core::ZeroTemporalPolicy::None => SurrealValue(Value::None),
+            sync_core::ZeroTemporalPolicy::Null => SurrealValue(Value::Null),
+            sync_core::ZeroTemporalPolicy::String => {
+                let s = source
+                    .unwrap_or_else(|| UniversalValue::canonical_zero_literal(intended_type))
+                    .to_string();
+                SurrealValue(Value::Strand(Strand::from(s)))
+            }
+        }
+    }
+
+    /// Convert a [`UniversalValue`] with an explicit zero-temporal policy.
+    pub fn from_universal_with_policy(
+        value: UniversalValue,
+        policy: sync_core::ZeroTemporalPolicy,
+    ) -> Self {
+        match value {
+            UniversalValue::ZeroTemporal {
+                intended_type,
+                source,
+            } => Self::from_zero_temporal(&intended_type, source.as_deref(), policy),
+            UniversalValue::Array { elements, .. } => {
+                let surreal_arr: Vec<Value> = elements
+                    .into_iter()
+                    .map(|v| Self::from_universal_with_policy(v, policy).into_inner())
+                    .collect();
+                SurrealValue(Value::Array(Array::from(surreal_arr)))
+            }
+            UniversalValue::Object(map) => {
+                let mut obj = BTreeMap::new();
+                for (k, v) in map {
+                    obj.insert(k, Self::from_universal_with_policy(v, policy).into_inner());
+                }
+                SurrealValue(Value::Object(Object::from(obj)))
+            }
+            other => SurrealValue::from(other),
+        }
+    }
+
+    /// Convert a [`TypedValue`] with an explicit zero-temporal policy.
+    pub fn from_typed_with_policy(tv: TypedValue, policy: sync_core::ZeroTemporalPolicy) -> Self {
         match (&tv.sync_type, &tv.value) {
             // JSON can be a string that needs parsing
             (UniversalType::Json, UniversalValue::Text(s)) => {
@@ -61,15 +106,21 @@ impl From<TypedValue> for SurrealValue {
                             sync_type: (**element_type).clone(),
                             value: v.clone(),
                         };
-                        SurrealValue::from(tv).into_inner()
+                        Self::from_typed_with_policy(tv, policy).into_inner()
                     })
                     .collect();
                 SurrealValue(Value::Array(Array::from(surreal_arr)))
             }
 
-            // For all other cases, delegate to From<UniversalValue>
-            _ => SurrealValue::from(tv.value),
+            // For all other cases, delegate to policy-aware UniversalValue conversion
+            _ => Self::from_universal_with_policy(tv.value, policy),
         }
+    }
+}
+
+impl From<TypedValue> for SurrealValue {
+    fn from(tv: TypedValue) -> Self {
+        Self::from_typed_with_policy(tv, sync_core::ZeroTemporalPolicy::default())
     }
 }
 
@@ -226,6 +277,16 @@ impl From<UniversalValue> for SurrealValue {
                 }
                 SurrealValue(Value::Object(Object::from(obj)))
             }
+
+            // Zero temporal — default sink policy is NONE (see ZeroTemporalPolicy)
+            UniversalValue::ZeroTemporal {
+                intended_type,
+                source,
+            } => SurrealValue::from_zero_temporal(
+                &intended_type,
+                source.as_deref(),
+                sync_core::ZeroTemporalPolicy::default(),
+            ),
         }
     }
 }
@@ -362,6 +423,30 @@ mod tests {
         let tv = TypedValue::null(UniversalType::Text);
         let surreal_val: SurrealValue = tv.into();
         assert!(matches!(surreal_val.0, Value::None));
+    }
+
+    #[test]
+    fn test_zero_temporal_policies() {
+        let zero = UniversalValue::zero_temporal(UniversalType::Date, Some("0000-00-00".into()));
+
+        let none = SurrealValue::from_universal_with_policy(
+            zero.clone(),
+            sync_core::ZeroTemporalPolicy::None,
+        );
+        assert!(matches!(none.0, Value::None));
+
+        let null = SurrealValue::from_universal_with_policy(
+            zero.clone(),
+            sync_core::ZeroTemporalPolicy::Null,
+        );
+        assert!(matches!(null.0, Value::Null));
+
+        let strand =
+            SurrealValue::from_universal_with_policy(zero, sync_core::ZeroTemporalPolicy::String);
+        match strand.0 {
+            Value::Strand(s) => assert_eq!(s.as_str(), "0000-00-00"),
+            other => panic!("expected Strand, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/surreal3-sink/src/lib.rs
+++ b/crates/surreal3-sink/src/lib.rs
@@ -15,6 +15,7 @@ pub use rows::{
     universal_value_to_surreal_id, write_universal_relations, write_universal_rows,
 };
 pub use sink_impl::Surreal3Sink;
+pub use sync_core::ZeroTemporalPolicy;
 pub use write::{
     apply_change, apply_universal_change, write_record, write_records, write_relation,
     write_relations,
@@ -23,6 +24,9 @@ pub use write::{
 // Re-export SurrealDB types for use by source crates
 pub use surrealdb::engine::any::Any as SurrealEngine;
 pub use surrealdb::Surreal;
+
+/// Connected SurrealDB v3 client used by [`Surreal3Sink`].
+pub type SurrealClient = Surreal<SurrealEngine>;
 
 // Re-export the SurrealSink trait
 pub use surreal_sink::SurrealSink;

--- a/crates/surreal3-sink/src/rows.rs
+++ b/crates/surreal3-sink/src/rows.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use surreal3_types::{RecordWithSurrealValues, Relation, SurrealValue};
 use surrealdb::types::{Array, Number, RecordId, RecordIdKey, Value};
 use surrealdb::Surreal;
-use sync_core::{UniversalRelation, UniversalRow, UniversalValue};
+use sync_core::{UniversalRelation, UniversalRow, UniversalValue, ZeroTemporalPolicy};
 
 /// Convert UniversalValue ID to SurrealDB RecordIdKey.
 ///
@@ -73,7 +73,10 @@ fn universal_value_to_id_array_element(value: &UniversalValue) -> Result<Value> 
 /// Convert UniversalRow to RecordWithSurrealValues.
 ///
 /// Returns an error if the row's ID type is not supported.
-pub fn universal_row_to_surreal_record(row: &UniversalRow) -> Result<RecordWithSurrealValues> {
+pub fn universal_row_to_surreal_record(
+    row: &UniversalRow,
+    zero_temporal: ZeroTemporalPolicy,
+) -> Result<RecordWithSurrealValues> {
     let id = universal_value_to_surreal_id(&row.id)?;
     let record_id = RecordId::new(row.table.as_str(), id);
 
@@ -82,7 +85,7 @@ pub fn universal_row_to_surreal_record(row: &UniversalRow) -> Result<RecordWithS
         .iter()
         .map(|(k, v)| {
             let typed = v.clone().to_typed_value();
-            let surreal_val: SurrealValue = typed.into();
+            let surreal_val = SurrealValue::from_typed_with_policy(typed, zero_temporal);
             (k.clone(), surreal_val.into_inner())
         })
         .collect();
@@ -96,9 +99,10 @@ pub fn universal_row_to_surreal_record(row: &UniversalRow) -> Result<RecordWithS
 pub async fn write_universal_rows(
     surreal: &Surreal<surrealdb::engine::any::Any>,
     rows: &[UniversalRow],
+    zero_temporal: ZeroTemporalPolicy,
 ) -> Result<()> {
     for row in rows {
-        let record = universal_row_to_surreal_record(row)?;
+        let record = universal_row_to_surreal_record(row, zero_temporal)?;
         write_record(surreal, &record).await?;
     }
     Ok(())
@@ -107,7 +111,10 @@ pub async fn write_universal_rows(
 /// Convert UniversalRelation to SurrealDB Relation.
 ///
 /// Returns an error if any ID type is not supported.
-pub fn universal_relation_to_surreal_relation(rel: &UniversalRelation) -> Result<Relation> {
+pub fn universal_relation_to_surreal_relation(
+    rel: &UniversalRelation,
+    zero_temporal: ZeroTemporalPolicy,
+) -> Result<Relation> {
     // Convert the relation's own ID
     let id = universal_value_to_surreal_id(&rel.id)?;
     let record_id = RecordId::new(rel.relation_type.as_str(), id);
@@ -126,7 +133,7 @@ pub fn universal_relation_to_surreal_relation(rel: &UniversalRelation) -> Result
         .iter()
         .map(|(k, v)| {
             let typed = v.clone().to_typed_value();
-            let surreal_val: SurrealValue = typed.into();
+            let surreal_val = SurrealValue::from_typed_with_policy(typed, zero_temporal);
             (k.clone(), surreal_val)
         })
         .collect();
@@ -145,9 +152,10 @@ pub fn universal_relation_to_surreal_relation(rel: &UniversalRelation) -> Result
 pub async fn write_universal_relations(
     surreal: &Surreal<surrealdb::engine::any::Any>,
     relations: &[UniversalRelation],
+    zero_temporal: ZeroTemporalPolicy,
 ) -> Result<()> {
     for rel in relations {
-        let surreal_rel = universal_relation_to_surreal_relation(rel)?;
+        let surreal_rel = universal_relation_to_surreal_relation(rel, zero_temporal)?;
         write_relation(surreal, &surreal_rel).await?;
     }
     Ok(())

--- a/crates/surreal3-sink/src/sink_impl.rs
+++ b/crates/surreal3-sink/src/sink_impl.rs
@@ -4,7 +4,9 @@ use anyhow::Result;
 use surreal_sink::SurrealSink;
 use surrealdb::engine::any::Any;
 use surrealdb::Surreal;
-use sync_core::{UniversalChange, UniversalRelation, UniversalRelationChange, UniversalRow};
+use sync_core::{
+    UniversalChange, UniversalRelation, UniversalRelationChange, UniversalRow, ZeroTemporalPolicy,
+};
 
 use crate::rows::{write_universal_relations, write_universal_rows};
 use crate::write::{apply_universal_change, apply_universal_relation_change};
@@ -16,12 +18,24 @@ use crate::write::{apply_universal_change, apply_universal_relation_change};
 /// `<S: SurrealSink>` parameters.
 pub struct Surreal3Sink {
     client: Surreal<Any>,
+    zero_temporal: ZeroTemporalPolicy,
 }
 
 impl Surreal3Sink {
     /// Create a new Surreal3Sink from an existing Surreal connection.
     pub fn new(client: Surreal<Any>) -> Self {
-        Self { client }
+        Self::with_zero_temporal_policy(client, ZeroTemporalPolicy::default())
+    }
+
+    /// Create a new Surreal3Sink with an explicit zero-temporal conversion policy.
+    pub fn with_zero_temporal_policy(
+        client: Surreal<Any>,
+        zero_temporal: ZeroTemporalPolicy,
+    ) -> Self {
+        Self {
+            client,
+            zero_temporal,
+        }
     }
 
     /// Get a reference to the underlying Surreal client.
@@ -38,26 +52,31 @@ impl Surreal3Sink {
     pub fn into_inner(self) -> Surreal<Any> {
         self.client
     }
+
+    /// Zero-temporal conversion policy used when writing field values.
+    pub fn zero_temporal_policy(&self) -> ZeroTemporalPolicy {
+        self.zero_temporal
+    }
 }
 
 #[async_trait::async_trait]
 impl SurrealSink for Surreal3Sink {
     async fn write_universal_rows(&self, rows: &[UniversalRow]) -> Result<()> {
-        write_universal_rows(&self.client, rows).await
+        write_universal_rows(&self.client, rows, self.zero_temporal).await
     }
 
     async fn write_universal_relations(&self, relations: &[UniversalRelation]) -> Result<()> {
-        write_universal_relations(&self.client, relations).await
+        write_universal_relations(&self.client, relations, self.zero_temporal).await
     }
 
     async fn apply_universal_change(&self, change: &UniversalChange) -> Result<()> {
-        apply_universal_change(&self.client, change).await
+        apply_universal_change(&self.client, change, self.zero_temporal).await
     }
 
     async fn apply_universal_relation_change(
         &self,
         change: &UniversalRelationChange,
     ) -> Result<()> {
-        apply_universal_relation_change(&self.client, change).await
+        apply_universal_relation_change(&self.client, change, self.zero_temporal).await
     }
 }

--- a/crates/surreal3-sink/src/write.rs
+++ b/crates/surreal3-sink/src/write.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use surreal3_types::{RecordWithSurrealValues as Record, Relation, SurrealValue};
 use surrealdb::types::{Number, RecordId, RecordIdKey, Value};
 use surrealdb::Surreal;
-use sync_core::{UniversalChange, UniversalChangeOp, UniversalRelationChange};
+use sync_core::{UniversalChange, UniversalChangeOp, UniversalRelationChange, ZeroTemporalPolicy};
 use tokio::time::sleep;
 
 use crate::rows::{universal_relation_to_surreal_relation, universal_value_to_surreal_id};
@@ -121,6 +121,7 @@ pub async fn apply_change(
 pub async fn apply_universal_change(
     surreal: &Surreal<surrealdb::engine::any::Any>,
     change: &UniversalChange,
+    zero_temporal: ZeroTemporalPolicy,
 ) -> anyhow::Result<()> {
     // Convert ID from UniversalValue to SurrealDB ID
     let surreal_id = universal_value_to_surreal_id(&change.id)?;
@@ -139,7 +140,7 @@ pub async fn apply_universal_change(
             let surreal_data: HashMap<String, surrealdb::types::Value> = data
                 .iter()
                 .map(|(k, v)| {
-                    let sv = SurrealValue::from(v.clone());
+                    let sv = SurrealValue::from_universal_with_policy(v.clone(), zero_temporal);
                     (k.clone(), sv.into_inner())
                 })
                 .collect();
@@ -473,10 +474,12 @@ pub async fn write_relations(
 pub async fn apply_universal_relation_change(
     surreal: &Surreal<surrealdb::engine::any::Any>,
     change: &UniversalRelationChange,
+    zero_temporal: ZeroTemporalPolicy,
 ) -> anyhow::Result<()> {
     match change.operation {
         UniversalChangeOp::Create | UniversalChangeOp::Update => {
-            let surreal_rel = universal_relation_to_surreal_relation(&change.relation)?;
+            let surreal_rel =
+                universal_relation_to_surreal_relation(&change.relation, zero_temporal)?;
             write_relation(surreal, &surreal_rel).await?;
             tracing::trace!(
                 "Successfully upserted relation: {:?}",

--- a/crates/surreal3-types/src/forward.rs
+++ b/crates/surreal3-types/src/forward.rs
@@ -22,10 +22,55 @@ impl SurrealValue {
     pub fn as_inner(&self) -> &Value {
         &self.0
     }
-}
 
-impl From<TypedValue> for SurrealValue {
-    fn from(tv: TypedValue) -> Self {
+    /// Convert a zero-temporal sentinel using the given sink policy.
+    pub fn from_zero_temporal(
+        intended_type: &UniversalType,
+        source: Option<&str>,
+        policy: sync_core::ZeroTemporalPolicy,
+    ) -> Self {
+        match policy {
+            sync_core::ZeroTemporalPolicy::None => SurrealValue(Value::None),
+            sync_core::ZeroTemporalPolicy::Null => SurrealValue(Value::Null),
+            sync_core::ZeroTemporalPolicy::String => {
+                let s = source
+                    .unwrap_or_else(|| UniversalValue::canonical_zero_literal(intended_type))
+                    .to_string();
+                SurrealValue(Value::String(s))
+            }
+        }
+    }
+
+    /// Convert a [`UniversalValue`] with an explicit zero-temporal policy.
+    pub fn from_universal_with_policy(
+        value: UniversalValue,
+        policy: sync_core::ZeroTemporalPolicy,
+    ) -> Self {
+        match value {
+            UniversalValue::ZeroTemporal {
+                intended_type,
+                source,
+            } => Self::from_zero_temporal(&intended_type, source.as_deref(), policy),
+            UniversalValue::Array { elements, .. } => {
+                let surreal_arr: Vec<Value> = elements
+                    .into_iter()
+                    .map(|v| Self::from_universal_with_policy(v, policy).into_inner())
+                    .collect();
+                SurrealValue(Value::Array(Array::from(surreal_arr)))
+            }
+            UniversalValue::Object(map) => {
+                let mut obj = BTreeMap::new();
+                for (k, v) in map {
+                    obj.insert(k, Self::from_universal_with_policy(v, policy).into_inner());
+                }
+                SurrealValue(Value::Object(Object::from(obj)))
+            }
+            other => SurrealValue::from(other),
+        }
+    }
+
+    /// Convert a [`TypedValue`] with an explicit zero-temporal policy.
+    pub fn from_typed_with_policy(tv: TypedValue, policy: sync_core::ZeroTemporalPolicy) -> Self {
         match (&tv.sync_type, &tv.value) {
             // JSON can be a string that needs parsing
             (UniversalType::Json, UniversalValue::Text(s)) => {
@@ -61,15 +106,21 @@ impl From<TypedValue> for SurrealValue {
                             sync_type: (**element_type).clone(),
                             value: v.clone(),
                         };
-                        SurrealValue::from(tv).into_inner()
+                        Self::from_typed_with_policy(tv, policy).into_inner()
                     })
                     .collect();
                 SurrealValue(Value::Array(Array::from(surreal_arr)))
             }
 
-            // For all other cases, delegate to From<UniversalValue>
-            _ => SurrealValue::from(tv.value),
+            // For all other cases, delegate to policy-aware UniversalValue conversion
+            _ => Self::from_universal_with_policy(tv.value, policy),
         }
+    }
+}
+
+impl From<TypedValue> for SurrealValue {
+    fn from(tv: TypedValue) -> Self {
+        Self::from_typed_with_policy(tv, sync_core::ZeroTemporalPolicy::default())
     }
 }
 
@@ -223,6 +274,16 @@ impl From<UniversalValue> for SurrealValue {
                 }
                 SurrealValue(Value::Object(Object::from(obj)))
             }
+
+            // Zero temporal — default sink policy is NONE (see ZeroTemporalPolicy)
+            UniversalValue::ZeroTemporal {
+                intended_type,
+                source,
+            } => SurrealValue::from_zero_temporal(
+                &intended_type,
+                source.as_deref(),
+                sync_core::ZeroTemporalPolicy::default(),
+            ),
         }
     }
 }
@@ -359,6 +420,30 @@ mod tests {
         let tv = TypedValue::null(UniversalType::Text);
         let surreal_val: SurrealValue = tv.into();
         assert!(matches!(surreal_val.0, Value::None));
+    }
+
+    #[test]
+    fn test_zero_temporal_policies() {
+        let zero = UniversalValue::zero_temporal(UniversalType::Date, Some("0000-00-00".into()));
+
+        let none = SurrealValue::from_universal_with_policy(
+            zero.clone(),
+            sync_core::ZeroTemporalPolicy::None,
+        );
+        assert!(matches!(none.0, Value::None));
+
+        let null = SurrealValue::from_universal_with_policy(
+            zero.clone(),
+            sync_core::ZeroTemporalPolicy::Null,
+        );
+        assert!(matches!(null.0, Value::Null));
+
+        let string =
+            SurrealValue::from_universal_with_policy(zero, sync_core::ZeroTemporalPolicy::String);
+        match string.0 {
+            Value::String(s) => assert_eq!(s, "0000-00-00"),
+            other => panic!("expected String, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/sync-core/src/lib.rs
+++ b/crates/sync-core/src/lib.rs
@@ -79,4 +79,5 @@ pub use types::{GeometryType, ToDdl, UniversalType};
 pub use values::{
     GeometryData, RowConverter, TypedValue, TypedValueError, UniversalChange, UniversalChangeOp,
     UniversalRelation, UniversalRow, UniversalRowBuilder, UniversalThingRef, UniversalValue,
+    ZeroTemporalPolicy,
 };

--- a/crates/sync-core/src/values.rs
+++ b/crates/sync-core/src/values.rs
@@ -199,6 +199,32 @@ pub enum UniversalValue {
 
     /// Null value (can be any nullable type)
     Null,
+
+    /// Source emitted a temporal that is not a valid calendar/chrono value
+    /// (e.g. MySQL/MariaDB zero date `0000-00-00`).
+    ///
+    /// Distinct from [`UniversalValue::Null`]: SQL NULL stays `Null`; MySQL-style
+    /// zero dates/timestamps use this sentinel so transforms retain the intended
+    /// column type before the SurrealDB sink maps it.
+    ZeroTemporal {
+        /// Intended column type (`Date`, `Time`, `LocalDateTime`, `ZonedDateTime`, …)
+        intended_type: UniversalType,
+        /// Optional source literal for transforms/debugging, e.g. `"0000-00-00 00:00:00"`
+        source: Option<String>,
+    },
+}
+
+/// How the SurrealDB sink represents [`UniversalValue::ZeroTemporal`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ZeroTemporalPolicy {
+    /// SurrealDB `NONE` (undefined). Default — safe for typed datetime fields.
+    #[default]
+    None,
+    /// SurrealDB `NULL`.
+    Null,
+    /// Canonical MySQL-style zero literal string (e.g. `"0000-00-00"`).
+    String,
 }
 
 /// Geometry data representation.
@@ -286,11 +312,65 @@ impl UniversalValue {
         Self::Jsonb(Box::new(value))
     }
 
+    /// Create a zero-temporal sentinel with the intended column type.
+    pub fn zero_temporal(intended_type: UniversalType, source: Option<String>) -> Self {
+        Self::ZeroTemporal {
+            intended_type,
+            source,
+        }
+    }
+
+    /// Canonical MySQL-style zero literal for an intended temporal type.
+    pub fn canonical_zero_literal(intended_type: &UniversalType) -> &'static str {
+        match intended_type {
+            UniversalType::Date => "0000-00-00",
+            UniversalType::Time | UniversalType::TimeTz => "00:00:00",
+            UniversalType::LocalDateTime
+            | UniversalType::LocalDateTimeNano
+            | UniversalType::ZonedDateTime => "0000-00-00 00:00:00",
+            _ => "0000-00-00 00:00:00",
+        }
+    }
+
+    /// Whether `s` is a MySQL/MariaDB zero date or zero datetime literal.
+    ///
+    /// Matches `0000-00-00` and `0000-00-00 00:00:00` with optional fractional seconds.
+    pub fn is_mysql_zero_temporal_literal(s: &str) -> bool {
+        let s = s.trim();
+        if s == "0000-00-00" {
+            return true;
+        }
+        s.starts_with("0000-00-00 00:00:00")
+    }
+
+    /// Whether year/month/day are the MySQL zero-date triple `(0, 0, 0)`.
+    pub fn is_mysql_zero_date_ymd(year: u16, month: u8, day: u8) -> bool {
+        year == 0 && month == 0 && day == 0
+    }
+
+    /// Whether `intended_type` may be used with [`UniversalValue::ZeroTemporal`].
+    pub fn is_zero_temporal_type(intended_type: &UniversalType) -> bool {
+        matches!(
+            intended_type,
+            UniversalType::Date
+                | UniversalType::Time
+                | UniversalType::LocalDateTime
+                | UniversalType::LocalDateTimeNano
+                | UniversalType::ZonedDateTime
+                | UniversalType::TimeTz
+        )
+    }
+
     // === Predicates ===
 
     /// Check if this value is null.
     pub fn is_null(&self) -> bool {
         matches!(self, Self::Null)
+    }
+
+    /// Check if this value is a zero-temporal sentinel.
+    pub fn is_zero_temporal(&self) -> bool {
+        matches!(self, Self::ZeroTemporal { .. })
     }
 
     // === Accessors ===
@@ -423,6 +503,7 @@ impl UniversalValue {
             Self::Thing { .. } => "Thing",
             Self::Object(_) => "Object",
             Self::Null => "Null",
+            Self::ZeroTemporal { .. } => "ZeroTemporal",
         }
     }
 
@@ -501,6 +582,7 @@ impl UniversalValue {
             // Null doesn't have a single type - this is a special case
             // We use Text as a placeholder, but callers should handle Null explicitly
             Self::Null => UniversalType::Text,
+            Self::ZeroTemporal { intended_type, .. } => intended_type.clone(),
         }
     }
 }
@@ -536,6 +618,7 @@ impl TypedValue {
     /// # Strict 1:1 Valid Combinations
     ///
     /// - `Null` is valid for any type
+    /// - `ZeroTemporal` is valid when `sync_type` equals `intended_type` and is temporal
     /// - `Bool` type requires `Bool` value
     /// - `TinyInt` type requires `TinyInt` value
     /// - `SmallInt` type requires `SmallInt` value
@@ -568,6 +651,18 @@ impl TypedValue {
         // Null is always valid for any type
         if matches!(value, UniversalValue::Null) {
             return Ok(Self::new(sync_type, value));
+        }
+
+        // ZeroTemporal is valid when sync_type matches intended_type and is temporal
+        if let UniversalValue::ZeroTemporal { intended_type, .. } = &value {
+            if sync_type == *intended_type && UniversalValue::is_zero_temporal_type(&sync_type) {
+                return Ok(Self::new(sync_type, value));
+            }
+            return Err(TypedValueError {
+                expected_value: Self::expected_value_description(&sync_type),
+                actual_value: value.variant_name().to_string(),
+                sync_type,
+            });
         }
 
         // Strict 1:1 validation - each type requires its exact corresponding value variant
@@ -752,6 +847,25 @@ impl TypedValue {
     /// Create a null typed value with a specified type.
     pub fn null(sync_type: UniversalType) -> Self {
         Self::new(sync_type, UniversalValue::Null)
+    }
+
+    /// Create a zero-temporal typed value with the intended column type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `intended_type` is not a temporal type allowed for zero temporals.
+    pub fn zero_temporal(intended_type: UniversalType, source: Option<String>) -> Self {
+        assert!(
+            UniversalValue::is_zero_temporal_type(&intended_type),
+            "zero_temporal requires a temporal UniversalType, got {intended_type:?}"
+        );
+        Self::new(
+            intended_type.clone(),
+            UniversalValue::ZeroTemporal {
+                intended_type,
+                source,
+            },
+        )
     }
 
     /// Create a decimal typed value.
@@ -1231,6 +1345,33 @@ mod tests {
         assert!(TypedValue::try_with_type(UniversalType::Bool, UniversalValue::Null).is_ok());
         assert!(TypedValue::try_with_type(UniversalType::Int32, UniversalValue::Null).is_ok());
         assert!(TypedValue::try_with_type(UniversalType::Text, UniversalValue::Null).is_ok());
+
+        // ZeroTemporal is valid when sync_type matches intended_type
+        assert!(TypedValue::try_with_type(
+            UniversalType::Date,
+            UniversalValue::zero_temporal(UniversalType::Date, Some("0000-00-00".into()))
+        )
+        .is_ok());
+        assert!(TypedValue::try_with_type(
+            UniversalType::LocalDateTime,
+            UniversalValue::zero_temporal(
+                UniversalType::LocalDateTime,
+                Some("0000-00-00 00:00:00".into())
+            )
+        )
+        .is_ok());
+        // Mismatched intended_type is invalid
+        assert!(TypedValue::try_with_type(
+            UniversalType::Date,
+            UniversalValue::zero_temporal(UniversalType::LocalDateTime, None)
+        )
+        .is_err());
+        // Non-temporal intended_type is invalid
+        assert!(TypedValue::try_with_type(
+            UniversalType::Text,
+            UniversalValue::zero_temporal(UniversalType::Text, None)
+        )
+        .is_err());
 
         // JSON type with Json value (strict 1:1)
         assert!(TypedValue::try_with_type(

--- a/docs/mysql-data-types.md
+++ b/docs/mysql-data-types.md
@@ -93,9 +93,12 @@ Note: Complex spatial operations specific to MySQL are not preserved.
 
 ### Data Integrity Notes
 
-- **NULL handling**: MySQL NULL values become SurrealDB null
-- **Zero dates**: MySQL zero dates ('0000-00-00') may cause conversion issues
-- **Invalid dates**: Invalid MySQL dates are converted to null with warning
+- **NULL handling**: MySQL NULL values become SurrealDB `NONE` (via `UniversalValue::Null`)
+- **Zero dates**: MySQL/MariaDB zero dates (`0000-00-00`, `0000-00-00 00:00:00`) become `UniversalValue::ZeroTemporal` with the intended column type preserved for transforms. The SurrealDB sink maps them according to `[sink.surrealdb] zero_temporal`:
+  - `none` (default) → SurrealDB `NONE`
+  - `null` → SurrealDB `NULL`
+  - `string` → literal string such as `"0000-00-00"` / `"0000-00-00 00:00:00"`
+- **Invalid dates**: Non-zero invalid calendar values (e.g. month 13) still fail conversion; they are not treated as zero dates
 - **Charset encoding**: Text data is converted assuming UTF-8 encoding
 
 ## Testing and Validation

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use std::path::Path;
+use sync_core::ZeroTemporalPolicy;
 
 /// Generic config file structure. `S` is the source-specific config type,
 /// determined by which subcommand is being run.
@@ -40,6 +41,10 @@ pub struct SurrealDBSinkConfig {
     pub dry_run: bool,
 
     pub sdk_version: Option<String>,
+
+    /// How zero temporal values (e.g. MySQL `0000-00-00`) are written to SurrealDB.
+    #[serde(default)]
+    pub zero_temporal: ZeroTemporalPolicy,
 }
 
 fn default_surreal_endpoint() -> String {
@@ -94,5 +99,27 @@ database = "db"
         assert_eq!(config.sink.surrealdb.username, "root");
         assert_eq!(config.sink.surrealdb.batch_size, 1000);
         assert!(!config.sink.surrealdb.dry_run);
+        assert_eq!(
+            config.sink.surrealdb.zero_temporal,
+            ZeroTemporalPolicy::None
+        );
+    }
+
+    #[test]
+    fn test_load_zero_temporal_policy() {
+        let toml_str = r#"
+[source]
+name = "test"
+
+[sink.surrealdb]
+namespace = "ns"
+database = "db"
+zero_temporal = "string"
+"#;
+        let config: ConfigFile<DummySource> = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.sink.surrealdb.zero_temporal,
+            ZeroTemporalPolicy::String
+        );
     }
 }

--- a/src/from/common/mod.rs
+++ b/src/from/common/mod.rs
@@ -2,8 +2,10 @@
 
 mod schema;
 mod sdk_version;
+mod sink;
 
 pub use schema::{
     extract_json_fields_from_schema, extract_postgresql_database, load_schema_if_provided,
 };
 pub use sdk_version::{get_sdk_version, SdkVersion};
+pub use sink::{make_surreal2_sink, make_surreal3_sink};

--- a/src/from/common/sink.rs
+++ b/src/from/common/sink.rs
@@ -1,0 +1,19 @@
+//! Helpers for constructing SurrealDB sinks with config-driven options.
+
+use sync_core::ZeroTemporalPolicy;
+
+/// Build a SurrealDB v2 sink with the given zero-temporal policy.
+pub fn make_surreal2_sink(
+    client: surreal2_sink::SurrealClient,
+    zero_temporal: ZeroTemporalPolicy,
+) -> surreal2_sink::Surreal2Sink {
+    surreal2_sink::Surreal2Sink::with_zero_temporal_policy(client, zero_temporal)
+}
+
+/// Build a SurrealDB v3 sink with the given zero-temporal policy.
+pub fn make_surreal3_sink(
+    client: surreal3_sink::SurrealClient,
+    zero_temporal: ZeroTemporalPolicy,
+) -> surreal3_sink::Surreal3Sink {
+    surreal3_sink::Surreal3Sink::with_zero_temporal_policy(client, zero_temporal)
+}

--- a/src/from/csv.rs
+++ b/src/from/csv.rs
@@ -5,7 +5,9 @@
 //! - Import: `from csv --files ... --table ... --to-namespace ... --to-database ...`
 
 use super::transforms::load_transforms_from_args;
-use super::{get_sdk_version, load_schema_if_provided, SdkVersion};
+use super::{
+    get_sdk_version, load_schema_if_provided, make_surreal2_sink, make_surreal3_sink, SdkVersion,
+};
 use crate::CsvArgs;
 
 /// Run CSV import, dispatching to appropriate SDK version.
@@ -42,7 +44,7 @@ async fn run_v2(args: CsvArgs) -> anyhow::Result<()> {
     let surreal =
         surreal2_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal2_sink::Surreal2Sink::new(surreal);
+    let sink = make_surreal2_sink(surreal, args.surreal.zero_temporal);
 
     let config = surreal_sync::csv::Config {
         sources: vec![],
@@ -86,7 +88,7 @@ async fn run_v3(args: CsvArgs) -> anyhow::Result<()> {
     let surreal =
         surreal3_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal3_sink::Surreal3Sink::new(surreal);
+    let sink = make_surreal3_sink(surreal, args.surreal.zero_temporal);
 
     let config = surreal_sync::csv::Config {
         sources: vec![],

--- a/src/from/jsonl.rs
+++ b/src/from/jsonl.rs
@@ -5,7 +5,9 @@
 //! - Import: `from jsonl --path ... --to-namespace ... --to-database ...`
 
 use super::transforms::load_transforms_from_args;
-use super::{get_sdk_version, load_schema_if_provided, SdkVersion};
+use super::{
+    get_sdk_version, load_schema_if_provided, make_surreal2_sink, make_surreal3_sink, SdkVersion,
+};
 use crate::JsonlArgs;
 
 /// Run JSONL import, dispatching to appropriate SDK version.
@@ -44,7 +46,7 @@ async fn run_v2(args: JsonlArgs) -> anyhow::Result<()> {
     let surreal =
         surreal2_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal2_sink::Surreal2Sink::new(surreal);
+    let sink = make_surreal2_sink(surreal, args.surreal.zero_temporal);
 
     // Create config with file source
     let config = surreal_sync::jsonl::Config {
@@ -87,7 +89,7 @@ async fn run_v3(args: JsonlArgs) -> anyhow::Result<()> {
     let surreal =
         surreal3_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal3_sink::Surreal3Sink::new(surreal);
+    let sink = make_surreal3_sink(surreal, args.surreal.zero_temporal);
 
     // Create config with file source
     let config = surreal_sync::jsonl::Config {

--- a/src/from/kafka.rs
+++ b/src/from/kafka.rs
@@ -8,7 +8,9 @@ use anyhow::Context;
 use sync_core::Schema;
 
 use super::transforms::load_transforms_from_args;
-use super::{get_sdk_version, parse_duration_to_secs, SdkVersion};
+use super::{
+    get_sdk_version, make_surreal2_sink, make_surreal3_sink, parse_duration_to_secs, SdkVersion,
+};
 use crate::KafkaArgs;
 
 /// Run Kafka streaming sync, dispatching to appropriate SDK version.
@@ -51,7 +53,7 @@ async fn run_v2(args: KafkaArgs) -> anyhow::Result<()> {
     let surreal =
         surreal2_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = std::sync::Arc::new(surreal2_sink::Surreal2Sink::new(surreal));
+    let sink = std::sync::Arc::new(make_surreal2_sink(surreal, args.surreal.zero_temporal));
 
     let table_schema = if let Some(schema_path) = args.schema_file {
         let schema = Schema::from_file(&schema_path)
@@ -107,7 +109,7 @@ async fn run_v3(args: KafkaArgs) -> anyhow::Result<()> {
     let surreal =
         surreal3_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = std::sync::Arc::new(surreal3_sink::Surreal3Sink::new(surreal));
+    let sink = std::sync::Arc::new(make_surreal3_sink(surreal, args.surreal.zero_temporal));
 
     let table_schema = if let Some(schema_path) = args.schema_file {
         let schema = Schema::from_file(&schema_path)

--- a/src/from/mod.rs
+++ b/src/from/mod.rs
@@ -37,5 +37,5 @@ pub mod transforms;
 pub(crate) use crate::config::parse_duration_to_secs;
 pub(crate) use common::{
     extract_json_fields_from_schema, extract_postgresql_database, get_sdk_version,
-    load_schema_if_provided, SdkVersion,
+    load_schema_if_provided, make_surreal2_sink, make_surreal3_sink, SdkVersion,
 };

--- a/src/from/mongodb.rs
+++ b/src/from/mongodb.rs
@@ -9,7 +9,9 @@ use anyhow::Context;
 use checkpoint::Checkpoint;
 
 use super::transforms::load_transforms_from_args;
-use super::{get_sdk_version, load_schema_if_provided, SdkVersion};
+use super::{
+    get_sdk_version, load_schema_if_provided, make_surreal2_sink, make_surreal3_sink, SdkVersion,
+};
 use crate::{MongoDBFullArgs, MongoDBIncrementalArgs};
 
 /// Run MongoDB full sync, dispatching to appropriate SDK version.
@@ -48,7 +50,7 @@ async fn run_full_v2(args: MongoDBFullArgs) -> anyhow::Result<()> {
     let surreal =
         surreal2_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal2_sink::Surreal2Sink::new(surreal);
+    let sink = make_surreal2_sink(surreal, args.surreal.zero_temporal);
 
     let source_opts = surreal_sync_mongodb_changestream_source::SourceOpts {
         source_uri: args.connection_string,
@@ -132,7 +134,7 @@ async fn run_full_v3(args: MongoDBFullArgs) -> anyhow::Result<()> {
     let surreal =
         surreal3_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal3_sink::Surreal3Sink::new(surreal.clone());
+    let sink = make_surreal3_sink(surreal.clone(), args.surreal.zero_temporal);
 
     let source_opts = surreal_sync_mongodb_changestream_source::SourceOpts {
         source_uri: args.connection_string,
@@ -278,7 +280,7 @@ async fn run_incremental_v2(args: MongoDBIncrementalArgs) -> anyhow::Result<()> 
     let surreal =
         surreal2_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal2_sink::Surreal2Sink::new(surreal);
+    let sink = make_surreal2_sink(surreal, args.surreal.zero_temporal);
 
     surreal_sync_mongodb_changestream_source::run_incremental_sync_with_transforms(
         &sink,
@@ -365,7 +367,7 @@ async fn run_incremental_v3(args: MongoDBIncrementalArgs) -> anyhow::Result<()> 
     let surreal =
         surreal3_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal3_sink::Surreal3Sink::new(surreal);
+    let sink = make_surreal3_sink(surreal, args.surreal.zero_temporal);
 
     surreal_sync_mongodb_changestream_source::run_incremental_sync_with_transforms(
         &sink,

--- a/src/from/mysql.rs
+++ b/src/from/mysql.rs
@@ -16,7 +16,9 @@ use surreal_sync_mysql_trigger_source::{MySQLCheckpoint, ReplicationTailOptions}
 use sync_transform::{ApplyOpts, Pipeline};
 
 use super::transforms::load_transforms_from_args;
-use super::{get_sdk_version, load_schema_if_provided, SdkVersion};
+use super::{
+    get_sdk_version, load_schema_if_provided, make_surreal2_sink, make_surreal3_sink, SdkVersion,
+};
 use crate::{MySQLFullArgs, MySQLIncrementalArgs, MySQLSnapshotArgs, MySQLSyncArgs, SyncStrategy};
 
 /// Run MySQL full sync, dispatching by strategy then SDK version.
@@ -58,7 +60,7 @@ async fn run_full_v2(args: MySQLFullArgs) -> anyhow::Result<()> {
     let surreal =
         surreal2_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal2_sink::Surreal2Sink::new(surreal);
+    let sink = make_surreal2_sink(surreal, args.surreal.zero_temporal);
 
     let source_opts = surreal_sync_mysql_trigger_source::SourceOpts {
         source_uri: args.connection_string,
@@ -154,7 +156,7 @@ async fn run_full_v3(args: MySQLFullArgs) -> anyhow::Result<()> {
     let surreal =
         surreal3_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal3_sink::Surreal3Sink::new(surreal.clone());
+    let sink = make_surreal3_sink(surreal.clone(), args.surreal.zero_temporal);
 
     let source_opts = surreal_sync_mysql_trigger_source::SourceOpts {
         source_uri: args.connection_string,
@@ -319,7 +321,7 @@ async fn run_incremental_v2(args: MySQLIncrementalArgs) -> anyhow::Result<()> {
     let surreal =
         surreal2_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal2_sink::Surreal2Sink::new(surreal);
+    let sink = make_surreal2_sink(surreal, args.surreal.zero_temporal);
 
     let (pipeline, apply_opts) = load_transforms_from_args(args.transforms_config.as_deref())?;
     surreal_sync_mysql_trigger_source::run_incremental_sync_with_transforms(
@@ -415,7 +417,7 @@ async fn run_full_interleaved_snapshot_v2(args: MySQLFullArgs) -> anyhow::Result
     let surreal =
         surreal2_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal2_sink::Surreal2Sink::new(surreal);
+    let sink = make_surreal2_sink(surreal, args.surreal.zero_temporal);
 
     let (pipeline, apply_opts) = load_transforms_from_args(args.transforms_config.as_deref())?;
     let transforms = SnapshotTransforms {
@@ -486,7 +488,7 @@ async fn run_full_interleaved_snapshot_v3(args: MySQLFullArgs) -> anyhow::Result
     let surreal =
         surreal3_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal3_sink::Surreal3Sink::new(surreal.clone());
+    let sink = make_surreal3_sink(surreal.clone(), args.surreal.zero_temporal);
 
     let (pipeline, apply_opts) = load_transforms_from_args(args.transforms_config.as_deref())?;
     let transforms = SnapshotTransforms {
@@ -571,7 +573,7 @@ async fn run_sync_v2(
     let surreal =
         surreal2_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal2_sink::Surreal2Sink::new(surreal);
+    let sink = make_surreal2_sink(surreal, args.surreal.zero_temporal);
     mysql_orchestrate(&sink, args, pipeline, apply_opts).await
 }
 
@@ -591,7 +593,7 @@ async fn run_sync_v3(
     let surreal =
         surreal3_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal3_sink::Surreal3Sink::new(surreal);
+    let sink = make_surreal3_sink(surreal, args.surreal.zero_temporal);
     mysql_orchestrate(&sink, args, pipeline, apply_opts).await
 }
 
@@ -749,7 +751,7 @@ async fn run_incremental_v3(args: MySQLIncrementalArgs) -> anyhow::Result<()> {
     let surreal =
         surreal3_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal3_sink::Surreal3Sink::new(surreal);
+    let sink = make_surreal3_sink(surreal, args.surreal.zero_temporal);
 
     let (pipeline, apply_opts) = load_transforms_from_args(args.transforms_config.as_deref())?;
     surreal_sync_mysql_trigger_source::run_incremental_sync_with_transforms(

--- a/src/from/mysql_binlog.rs
+++ b/src/from/mysql_binlog.rs
@@ -19,7 +19,9 @@ use sync_transform::{ApplyOpts, Pipeline};
 use tokio_util::sync::CancellationToken;
 
 use super::transforms::load_transforms_from_args;
-use super::{get_sdk_version, parse_duration_to_secs, SdkVersion};
+use super::{
+    get_sdk_version, make_surreal2_sink, make_surreal3_sink, parse_duration_to_secs, SdkVersion,
+};
 use crate::{
     BinlogSnapshotModeArg, MariaDbGtidStrictModeArg, MySQLBinlogFlavorArg, MySQLBinlogSnapshotArgs,
     MySQLBinlogSyncArgs, SyncStrategy,
@@ -297,7 +299,7 @@ async fn run_sync_v2(
     let surreal =
         surreal2_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal2_sink::Surreal2Sink::new(surreal);
+    let sink = make_surreal2_sink(surreal, args.surreal.zero_temporal);
     let checkpoint_dir = args.checkpoint_dir.clone();
     let checkpoints_surreal_table = args.checkpoints_surreal_table.clone();
     match (checkpoint_dir, checkpoints_surreal_table) {
@@ -343,7 +345,7 @@ async fn run_sync_v3(
     let surreal =
         surreal3_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal3_sink::Surreal3Sink::new(surreal.clone());
+    let sink = make_surreal3_sink(surreal.clone(), args.surreal.zero_temporal);
     let checkpoint_dir = args.checkpoint_dir.clone();
     let checkpoints_surreal_table = args.checkpoints_surreal_table.clone();
     match (checkpoint_dir, checkpoints_surreal_table) {

--- a/src/from/neo4j.rs
+++ b/src/from/neo4j.rs
@@ -10,7 +10,8 @@ use checkpoint::Checkpoint;
 
 use super::transforms::load_transforms_from_args;
 use super::{
-    extract_json_fields_from_schema, get_sdk_version, load_schema_if_provided, SdkVersion,
+    extract_json_fields_from_schema, get_sdk_version, load_schema_if_provided, make_surreal2_sink,
+    make_surreal3_sink, SdkVersion,
 };
 use crate::{Neo4jFullArgs, Neo4jIncrementalArgs};
 
@@ -81,7 +82,7 @@ async fn run_full_v2(args: Neo4jFullArgs) -> anyhow::Result<()> {
     let surreal =
         surreal2_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal2_sink::Surreal2Sink::new(surreal);
+    let sink = make_surreal2_sink(surreal, args.surreal.zero_temporal);
 
     // Parse assumed_start_timestamp if provided
     let assumed_start_timestamp = if let Some(ts_str) = &args.assumed_start_timestamp {
@@ -208,7 +209,7 @@ async fn run_full_v3(args: Neo4jFullArgs) -> anyhow::Result<()> {
     let surreal =
         surreal3_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal3_sink::Surreal3Sink::new(surreal.clone());
+    let sink = make_surreal3_sink(surreal.clone(), args.surreal.zero_temporal);
 
     // Parse assumed_start_timestamp if provided
     let assumed_start_timestamp = if let Some(ts_str) = &args.assumed_start_timestamp {
@@ -424,7 +425,7 @@ async fn run_incremental_v2(args: Neo4jIncrementalArgs) -> anyhow::Result<()> {
     let surreal =
         surreal2_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal2_sink::Surreal2Sink::new(surreal);
+    let sink = make_surreal2_sink(surreal, args.surreal.zero_temporal);
 
     let sync_opts = surreal_sync_neo4j_source::SyncOpts {
         batch_size: args.surreal.batch_size,
@@ -563,7 +564,7 @@ async fn run_incremental_v3(args: Neo4jIncrementalArgs) -> anyhow::Result<()> {
     let surreal =
         surreal3_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal3_sink::Surreal3Sink::new(surreal);
+    let sink = make_surreal3_sink(surreal, args.surreal.zero_temporal);
 
     let sync_opts = surreal_sync_neo4j_source::SyncOpts {
         batch_size: args.surreal.batch_size,

--- a/src/from/postgresql_pgoutput.rs
+++ b/src/from/postgresql_pgoutput.rs
@@ -19,7 +19,9 @@ use sync_transform::{ApplyOpts, Pipeline};
 use tokio_util::sync::CancellationToken;
 
 use super::transforms::load_transforms_from_args;
-use super::{get_sdk_version, parse_duration_to_secs, SdkVersion};
+use super::{
+    get_sdk_version, make_surreal2_sink, make_surreal3_sink, parse_duration_to_secs, SdkVersion,
+};
 use crate::{
     BinlogSnapshotModeArg, PostgreSQLPgoutputSnapshotArgs, PostgreSQLPgoutputSyncArgs, SyncStrategy,
 };
@@ -254,7 +256,7 @@ async fn run_sync_v2(
     let surreal =
         surreal2_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal2_sink::Surreal2Sink::new(surreal);
+    let sink = make_surreal2_sink(surreal, args.surreal.zero_temporal);
     let checkpoint_dir = args.checkpoint_dir.clone();
     let checkpoints_surreal_table = args.checkpoints_surreal_table.clone();
     match (checkpoint_dir, checkpoints_surreal_table) {
@@ -300,7 +302,7 @@ async fn run_sync_v3(
     let surreal =
         surreal3_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal3_sink::Surreal3Sink::new(surreal.clone());
+    let sink = make_surreal3_sink(surreal.clone(), args.surreal.zero_temporal);
     let checkpoint_dir = args.checkpoint_dir.clone();
     let checkpoints_surreal_table = args.checkpoints_surreal_table.clone();
     match (checkpoint_dir, checkpoints_surreal_table) {

--- a/src/from/postgresql_trigger.rs
+++ b/src/from/postgresql_trigger.rs
@@ -23,7 +23,10 @@ use surreal_sync_postgresql_trigger_source::{PostgreSQLCheckpoint, ReplicationTa
 use sync_transform::{ApplyOpts, Pipeline};
 
 use super::transforms::load_transforms_from_args;
-use super::{extract_postgresql_database, get_sdk_version, load_schema_if_provided, SdkVersion};
+use super::{
+    extract_postgresql_database, get_sdk_version, load_schema_if_provided, make_surreal2_sink,
+    make_surreal3_sink, SdkVersion,
+};
 use crate::config::load_config;
 use crate::{
     PostgreSQLTriggerFullArgs, PostgreSQLTriggerIncrementalArgs, PostgreSQLTriggerSnapshotArgs,
@@ -92,6 +95,7 @@ fn resolve_full_args(args: PostgreSQLTriggerFullArgs) -> anyhow::Result<Resolved
                 batch_size: sink.batch_size,
                 dry_run: sink.dry_run,
                 surreal_sdk_version: args.surreal.surreal_sdk_version.or(sink.sdk_version),
+                zero_temporal: sink.zero_temporal,
             },
         })
     } else {
@@ -152,6 +156,7 @@ fn resolve_incremental_args(
                 batch_size: sink.batch_size,
                 dry_run: sink.dry_run,
                 surreal_sdk_version: args.surreal.surreal_sdk_version.or(sink.sdk_version),
+                zero_temporal: sink.zero_temporal,
             },
         })
     } else {
@@ -218,7 +223,7 @@ async fn run_full_v2(args: ResolvedTriggerFullArgs) -> anyhow::Result<()> {
     let surreal =
         surreal2_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal2_sink::Surreal2Sink::new(surreal);
+    let sink = make_surreal2_sink(surreal, args.surreal.zero_temporal);
 
     let source_database = extract_postgresql_database(&args.connection_string);
     let source_opts = surreal_sync_postgresql_trigger_source::SourceOpts {
@@ -301,7 +306,7 @@ async fn run_full_v3(args: ResolvedTriggerFullArgs) -> anyhow::Result<()> {
     let surreal =
         surreal3_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal3_sink::Surreal3Sink::new(surreal.clone());
+    let sink = make_surreal3_sink(surreal.clone(), args.surreal.zero_temporal);
 
     let source_database = extract_postgresql_database(&args.connection_string);
     let source_opts = surreal_sync_postgresql_trigger_source::SourceOpts {
@@ -439,7 +444,7 @@ async fn run_full_interleaved_snapshot_v2(args: ResolvedTriggerFullArgs) -> anyh
     let surreal =
         surreal2_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal2_sink::Surreal2Sink::new(surreal);
+    let sink = make_surreal2_sink(surreal, args.surreal.zero_temporal);
     let source_opts = trigger_source_opts(&args.connection_string, args.tables.clone());
 
     let (pipeline, apply_opts) = load_transforms_from_args(args.transforms_config.as_deref())?;
@@ -510,7 +515,7 @@ async fn run_full_interleaved_snapshot_v3(args: ResolvedTriggerFullArgs) -> anyh
     let surreal =
         surreal3_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal3_sink::Surreal3Sink::new(surreal.clone());
+    let sink = make_surreal3_sink(surreal.clone(), args.surreal.zero_temporal);
     let source_opts = trigger_source_opts(&args.connection_string, args.tables.clone());
 
     let (pipeline, apply_opts) = load_transforms_from_args(args.transforms_config.as_deref())?;
@@ -592,7 +597,7 @@ async fn run_sync_v2(
     let surreal =
         surreal2_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal2_sink::Surreal2Sink::new(surreal);
+    let sink = make_surreal2_sink(surreal, args.surreal.zero_temporal);
     pg_trigger_orchestrate(&sink, args, pipeline, apply_opts).await
 }
 
@@ -613,7 +618,7 @@ async fn run_sync_v3(
     let surreal =
         surreal3_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal3_sink::Surreal3Sink::new(surreal);
+    let sink = make_surreal3_sink(surreal, args.surreal.zero_temporal);
     pg_trigger_orchestrate(&sink, args, pipeline, apply_opts).await
 }
 
@@ -768,7 +773,7 @@ async fn run_incremental_v2(args: ResolvedTriggerIncrementalArgs) -> anyhow::Res
     let surreal =
         surreal2_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal2_sink::Surreal2Sink::new(surreal);
+    let sink = make_surreal2_sink(surreal, args.surreal.zero_temporal);
 
     let (pipeline, apply_opts) = load_transforms_from_args(args.transforms_config.as_deref())?;
     surreal_sync_postgresql_trigger_source::run_incremental_sync_with_transforms(
@@ -857,7 +862,7 @@ async fn run_incremental_v3(args: ResolvedTriggerIncrementalArgs) -> anyhow::Res
     let surreal =
         surreal3_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal3_sink::Surreal3Sink::new(surreal);
+    let sink = make_surreal3_sink(surreal, args.surreal.zero_temporal);
 
     let (pipeline, apply_opts) = load_transforms_from_args(args.transforms_config.as_deref())?;
     surreal_sync_postgresql_trigger_source::run_incremental_sync_with_transforms(

--- a/src/from/postgresql_wal2json.rs
+++ b/src/from/postgresql_wal2json.rs
@@ -23,7 +23,9 @@ use surreal_sync_postgresql_wal2json_source::{
 use sync_transform::{ApplyOpts, Pipeline};
 
 use super::transforms::load_transforms_from_args;
-use super::{get_sdk_version, load_schema_if_provided, SdkVersion};
+use super::{
+    get_sdk_version, load_schema_if_provided, make_surreal2_sink, make_surreal3_sink, SdkVersion,
+};
 use crate::config::load_config;
 use crate::{
     PostgreSQLLogicalFullArgs, PostgreSQLLogicalIncrementalArgs, PostgreSQLLogicalSnapshotArgs,
@@ -106,6 +108,7 @@ fn resolve_full_args(args: PostgreSQLLogicalFullArgs) -> anyhow::Result<Resolved
                 batch_size: sink.batch_size,
                 dry_run: sink.dry_run,
                 surreal_sdk_version: args.surreal.surreal_sdk_version.or(sink.sdk_version),
+                zero_temporal: sink.zero_temporal,
             },
         })
     } else {
@@ -178,6 +181,7 @@ fn resolve_incremental_args(
                 batch_size: sink.batch_size,
                 dry_run: sink.dry_run,
                 surreal_sdk_version: args.surreal.surreal_sdk_version.or(sink.sdk_version),
+                zero_temporal: sink.zero_temporal,
             },
         })
     } else {
@@ -248,7 +252,7 @@ async fn run_full_v2(args: ResolvedWal2jsonFullArgs) -> anyhow::Result<()> {
     let surreal =
         surreal2_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal2_sink::Surreal2Sink::new(surreal);
+    let sink = make_surreal2_sink(surreal, args.surreal.zero_temporal);
 
     let source_opts = surreal_sync_postgresql_wal2json_source::SourceOpts {
         connection_string: args.connection_string,
@@ -332,7 +336,7 @@ async fn run_full_v3(args: ResolvedWal2jsonFullArgs) -> anyhow::Result<()> {
     let surreal =
         surreal3_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal3_sink::Surreal3Sink::new(surreal.clone());
+    let sink = make_surreal3_sink(surreal.clone(), args.surreal.zero_temporal);
 
     let source_opts = surreal_sync_postgresql_wal2json_source::SourceOpts {
         connection_string: args.connection_string,
@@ -467,7 +471,7 @@ async fn run_incremental_v2(args: ResolvedWal2jsonIncrementalArgs) -> anyhow::Re
     let surreal =
         surreal2_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal2_sink::Surreal2Sink::new(surreal);
+    let sink = make_surreal2_sink(surreal, args.surreal.zero_temporal);
 
     let source_opts = surreal_sync_postgresql_wal2json_source::SourceOpts {
         connection_string: args.connection_string,
@@ -553,7 +557,7 @@ async fn run_incremental_v3(args: ResolvedWal2jsonIncrementalArgs) -> anyhow::Re
     let surreal =
         surreal3_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal3_sink::Surreal3Sink::new(surreal);
+    let sink = make_surreal3_sink(surreal, args.surreal.zero_temporal);
 
     let source_opts = surreal_sync_postgresql_wal2json_source::SourceOpts {
         connection_string: args.connection_string,
@@ -648,7 +652,7 @@ async fn run_full_interleaved_snapshot_v2(args: ResolvedWal2jsonFullArgs) -> any
     let surreal =
         surreal2_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal2_sink::Surreal2Sink::new(surreal);
+    let sink = make_surreal2_sink(surreal, args.surreal.zero_temporal);
     let source_opts = wal2json_source_opts(
         &args.connection_string,
         &args.slot,
@@ -724,7 +728,7 @@ async fn run_full_interleaved_snapshot_v3(args: ResolvedWal2jsonFullArgs) -> any
     let surreal =
         surreal3_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal3_sink::Surreal3Sink::new(surreal.clone());
+    let sink = make_surreal3_sink(surreal.clone(), args.surreal.zero_temporal);
     let source_opts = wal2json_source_opts(
         &args.connection_string,
         &args.slot,
@@ -811,7 +815,7 @@ async fn run_sync_v2(
     let surreal =
         surreal2_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal2_sink::Surreal2Sink::new(surreal);
+    let sink = make_surreal2_sink(surreal, args.surreal.zero_temporal);
     wal2json_orchestrate(&sink, args, pipeline, apply_opts).await
 }
 
@@ -832,7 +836,7 @@ async fn run_sync_v3(
     let surreal =
         surreal3_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal3_sink::Surreal3Sink::new(surreal);
+    let sink = make_surreal3_sink(surreal, args.surreal.zero_temporal);
     wal2json_orchestrate(&sink, args, pipeline, apply_opts).await
 }
 

--- a/src/from/snowflake.rs
+++ b/src/from/snowflake.rs
@@ -12,7 +12,7 @@ use surreal_sync_snowflake_source::{
 };
 
 use super::transforms::load_transforms_from_args;
-use super::{get_sdk_version, SdkVersion};
+use super::{get_sdk_version, make_surreal2_sink, make_surreal3_sink, SdkVersion};
 use crate::SnowflakeArgs;
 
 /// Run Snowflake ingestion, dispatching to the detected SurrealDB SDK version.
@@ -79,7 +79,7 @@ async fn run_v2(args: SnowflakeArgs) -> anyhow::Result<()> {
     let surreal =
         surreal2_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal2_sink::Surreal2Sink::new(surreal);
+    let sink = make_surreal2_sink(surreal, args.surreal.zero_temporal);
 
     run_full_sync_with_transforms(
         &client,
@@ -114,7 +114,7 @@ async fn run_v3(args: SnowflakeArgs) -> anyhow::Result<()> {
     let surreal =
         surreal3_sink::surreal_connect(&surreal_opts, &args.to_namespace, &args.to_database)
             .await?;
-    let sink = surreal3_sink::Surreal3Sink::new(surreal);
+    let sink = make_surreal3_sink(surreal, args.surreal.zero_temporal);
 
     run_full_sync_with_transforms(
         &client,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@
 //! and struct definitions.
 
 use clap::Parser;
+use sync_core::ZeroTemporalPolicy;
 
 pub mod testing;
 
@@ -113,4 +114,9 @@ pub struct SurrealOpts {
     /// SurrealDB SDK version to use. Auto-detects from server if not specified.
     #[arg(long, env = "SURREAL_SDK_VERSION", value_parser = ["v2", "v3"])]
     pub surreal_sdk_version: Option<String>,
+
+    /// How zero temporal values (e.g. MySQL `0000-00-00`) are written to SurrealDB.
+    /// Set via config file `[sink.surrealdb] zero_temporal`; not a CLI flag.
+    #[arg(skip)]
+    pub zero_temporal: ZeroTemporalPolicy,
 }


### PR DESCRIPTION
MySQL and MariaDB allow zero dates like `0000-00-00`, which used to break sync.

surreal-sync now carries those values through the pipeline distinctly from SQL NULL so transforms can still see what they were, and you can choose how SurrealDB stores them (`none`, `null`, or as a string) via sink config.

Intends to cover the second fix mentioned in #121