### PR TITLE
Fix and extend MySQL TLS modes for all sync paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2570,6 +2570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
+ "libz-sys",
  "miniz_oxide",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,6 +1012,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rsa",
  "rust_decimal",
+ "rustls 0.23.41",
  "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
@@ -1022,7 +1023,6 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tracing",
  "tracing-subscriber",
- "webpki-roots 1.0.8",
  "zstd",
 ]
 
@@ -2570,7 +2570,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
- "libz-sys",
  "miniz_oxide",
 ]
 
@@ -4691,6 +4690,7 @@ dependencies = [
 name = "mysql-types"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "base64 0.22.1",
  "binlog-protocol",
  "chrono",
@@ -4698,11 +4698,13 @@ dependencies = [
  "json-types",
  "mysql_async",
  "rust_decimal",
+ "rustls 0.23.41",
  "serde",
  "serde_json",
  "sync-core",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "uuid",
 ]
 
@@ -4724,14 +4726,18 @@ dependencies = [
  "pem",
  "percent-encoding",
  "rand 0.9.4",
+ "rustls 0.23.41",
+ "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
  "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "twox-hash",
  "url",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -7890,6 +7896,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "binlog-protocol",
  "checkpoint",
  "chrono",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ base64 = "0.22"
 geo = "0.32"
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1", "with-geo-types-0_7"] }
 rust_decimal = { version = "^1.23", features = ["db-tokio-postgres"] }
-mysql_async = { version = "0.36", default-features = false, features = ["default-rustls"] }
+mysql_async = { version = "0.36", default-features = false, features = ["derive", "rustls-tls", "tls12", "aws-lc-rs", "minimal"] }
 uuid = { version = "1.10", features = ["v4"] }
 rand = "0.10"
 futures = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ base64 = "0.22"
 geo = "0.32"
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1", "with-geo-types-0_7"] }
 rust_decimal = { version = "^1.23", features = ["db-tokio-postgres"] }
-mysql_async = { version = "0.36" }
+mysql_async = { version = "0.36", default-features = false, features = ["default-rustls"] }
 uuid = { version = "1.10", features = ["v4"] }
 rand = "0.10"
 futures = "0.3"

--- a/crates/binlog-protocol/Cargo.toml
+++ b/crates/binlog-protocol/Cargo.toml
@@ -28,7 +28,7 @@ rustls-pemfile = "2.2.0"
 [dev-dependencies]
 hex = "0.4"
 tokio = { version = "1.49", features = ["full"] }
-mysql_async = { version = "0.36", default-features = false, features = ["default-rustls"] }
+mysql_async = { version = "0.36", default-features = false, features = ["derive", "rustls-tls", "tls12", "aws-lc-rs", "minimal"] }
 anyhow = "1.0.100"
 insta = { version = "1.48", features = ["json"] }
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/binlog-protocol/Cargo.toml
+++ b/crates/binlog-protocol/Cargo.toml
@@ -22,13 +22,13 @@ rand_core = { version = "0.6", features = ["getrandom"] }
 hex = "0.4"
 zstd = "0.13.3"
 tokio-rustls = "0.26.4"
+rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs", "std", "tls12"] }
 rustls-pemfile = "2.2.0"
-webpki-roots = "1.0.8"
 
 [dev-dependencies]
 hex = "0.4"
 tokio = { version = "1.49", features = ["full"] }
-mysql_async = "0.36"
+mysql_async = { version = "0.36", default-features = false, features = ["default-rustls"] }
 anyhow = "1.0.100"
 insta = { version = "1.48", features = ["json"] }
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/binlog-protocol/src/client.rs
+++ b/crates/binlog-protocol/src/client.rs
@@ -3,7 +3,7 @@ use crate::event::{EventBody, EventParser, RawEvent};
 use crate::flavor::mariadb::register;
 use crate::flavor::mysql::dump_gtid;
 use crate::flavor::Flavor;
-use crate::options::{ReplicaOptions, ResumePosition};
+use crate::options::{ReplicaOptions, ResumePosition, SslMode};
 use crate::shared::checksum::event_body;
 use crate::shared::event_header::EventHeader;
 use crate::shared::position::PositionTracker;
@@ -89,6 +89,23 @@ pub struct BinlogClient {
 
 impl BinlogClient {
     pub async fn connect(opts: ReplicaOptions) -> Result<Self, Error> {
+        match Self::connect_once(opts.clone()).await {
+            Ok(client) => Ok(client),
+            // Preferred already sent an SSL request before the handshake failed; fall back
+            // on a fresh plaintext TCP connection (MySQL-client Preferred semantics).
+            Err(Error::Ssl(msg)) if opts.ssl.is_preferred() => {
+                tracing::warn!(
+                    "TLS handshake failed under --tls-mode preferred ({msg}); retrying without TLS"
+                );
+                let mut plain = opts;
+                plain.ssl = SslMode::Disabled;
+                Self::connect_once(plain).await
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    async fn connect_once(opts: ReplicaOptions) -> Result<Self, Error> {
         let mut channel = PacketChannel::connect(&opts.host, opts.port).await?;
         let hs = handshake(&mut channel).await?;
         authenticate(

--- a/crates/binlog-protocol/src/options.rs
+++ b/crates/binlog-protocol/src/options.rs
@@ -11,8 +11,9 @@ pub struct SslOptions {
     pub key: Option<String>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub enum SslMode {
+    #[default]
     Disabled,
     Preferred(SslOptions),
     Required(SslOptions),
@@ -25,6 +26,14 @@ impl SslMode {
 
     pub fn required() -> Self {
         Self::Required(SslOptions::default())
+    }
+
+    pub fn is_preferred(&self) -> bool {
+        matches!(self, Self::Preferred(_))
+    }
+
+    pub fn is_required(&self) -> bool {
+        matches!(self, Self::Required(_))
     }
 
     pub fn options(&self) -> Option<&SslOptions> {

--- a/crates/binlog-protocol/src/shared/wire.rs
+++ b/crates/binlog-protocol/src/shared/wire.rs
@@ -3,8 +3,16 @@ use std::sync::Arc;
 
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpStream;
-use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName};
-use tokio_rustls::rustls::{ClientConfig, RootCertStore};
+use tokio_rustls::rustls::client::danger::{
+    HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier,
+};
+use tokio_rustls::rustls::crypto::{
+    verify_tls12_signature, verify_tls13_signature, CryptoProvider,
+};
+use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName, UnixTime};
+use tokio_rustls::rustls::{
+    ClientConfig, DigitallySignedStruct, Error as RustlsError, RootCertStore, SignatureScheme,
+};
 use tokio_rustls::TlsConnector;
 
 use crate::error::Error;
@@ -317,9 +325,10 @@ async fn negotiate_tls(
     };
     if handshake.capabilities & CLIENT_SSL == 0 {
         return match ssl {
+            // Preferred: server has no SSL — stay on plaintext.
             SslMode::Preferred(_) => Ok(()),
             SslMode::Required(_) => Err(Error::Ssl(
-                "server does not advertise CLIENT_SSL capability".into(),
+                "server does not advertise CLIENT_SSL capability; use a TLS-enabled MySQL server or --tls-mode preferred/disabled".into(),
             )),
             SslMode::Disabled => Ok(()),
         };
@@ -327,7 +336,12 @@ async fn negotiate_tls(
 
     let request = build_ssl_request(true);
     channel.write_packet(&request).await?;
-    channel.upgrade_tls(host, options).await
+    channel.upgrade_tls(host, options).await.map_err(|e| match e {
+        Error::Ssl(msg) if ssl.is_required() => Error::Ssl(format!(
+            "{msg}; for self-signed servers pass --tls-ca <path> or omit --tls-ca to encrypt without public-CA verification"
+        )),
+        other => other,
+    })
 }
 
 async fn drain_auth_tail(channel: &mut PacketChannel) -> Result<(), Error> {
@@ -447,8 +461,13 @@ fn auth_switch_response(
 }
 
 async fn tls_config(options: &SslOptions) -> Result<ClientConfig, Error> {
-    let mut roots = RootCertStore::empty();
-    if let Some(ca) = &options.ca {
+    // Ensure a process-wide rustls provider (needed when multiple crates pull rustls).
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+    // With --tls-ca: verify the server against that CA.
+    // Without --tls-ca: encrypt without requiring a public-CA match (MySQL REQUIRED semantics).
+    let builder = if let Some(ca) = &options.ca {
+        let mut roots = RootCertStore::empty();
         let certs = load_certs(ca).await?;
         let (added, ignored) = roots.add_parsable_certificates(certs);
         if added == 0 {
@@ -456,11 +475,13 @@ async fn tls_config(options: &SslOptions) -> Result<ClientConfig, Error> {
                 "no usable CA certificates found in {ca} (ignored {ignored})"
             )));
         }
+        ClientConfig::builder().with_root_certificates(roots)
     } else {
-        roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-    }
+        ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(AcceptAnyServerCert::new()?))
+    };
 
-    let builder = ClientConfig::builder().with_root_certificates(roots);
     match (&options.cert, &options.key) {
         (Some(cert), Some(key)) => {
             let certs = load_certs(cert).await?;
@@ -473,6 +494,58 @@ async fn tls_config(options: &SslOptions) -> Result<ClientConfig, Error> {
         (Some(_), None) | (None, Some(_)) => Err(Error::Ssl(
             "--tls-cert and --tls-key must be provided together".into(),
         )),
+    }
+}
+
+/// Encrypt-only verifier used when `--tls-ca` is omitted (MySQL `--ssl-mode=REQUIRED`).
+#[derive(Debug)]
+struct AcceptAnyServerCert {
+    algorithms: tokio_rustls::rustls::crypto::WebPkiSupportedAlgorithms,
+}
+
+impl AcceptAnyServerCert {
+    fn new() -> Result<Self, Error> {
+        let provider = CryptoProvider::get_default().cloned().ok_or_else(|| {
+            Error::Ssl("no rustls CryptoProvider installed; cannot build TLS client config".into())
+        })?;
+        Ok(Self {
+            algorithms: provider.signature_verification_algorithms,
+        })
+    }
+}
+
+impl ServerCertVerifier for AcceptAnyServerCert {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, RustlsError> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, RustlsError> {
+        verify_tls12_signature(message, cert, dss, &self.algorithms)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, RustlsError> {
+        verify_tls13_signature(message, cert, dss, &self.algorithms)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.algorithms.supported_schemes()
     }
 }
 

--- a/crates/loadtest-populate-mysql/Cargo.toml
+++ b/crates/loadtest-populate-mysql/Cargo.toml
@@ -13,7 +13,7 @@ loadtest-distributed = { path = "../loadtest-distributed" }
 mysql-types = { path = "../mysql-types" }
 
 clap = { version = "4.5", features = ["derive", "env"] }
-mysql_async = { version = "0.36" }
+mysql_async = { version = "0.36", default-features = false, features = ["default-rustls"] }
 tokio = { version = "1.49", features = ["full"] }
 async-trait = "0.1"
 thiserror = "2.0"

--- a/crates/loadtest-populate-mysql/Cargo.toml
+++ b/crates/loadtest-populate-mysql/Cargo.toml
@@ -13,7 +13,7 @@ loadtest-distributed = { path = "../loadtest-distributed" }
 mysql-types = { path = "../mysql-types" }
 
 clap = { version = "4.5", features = ["derive", "env"] }
-mysql_async = { version = "0.36", default-features = false, features = ["default-rustls"] }
+mysql_async = { version = "0.36", default-features = false, features = ["derive", "rustls-tls", "tls12", "aws-lc-rs", "minimal"] }
 tokio = { version = "1.49", features = ["full"] }
 async-trait = "0.1"
 thiserror = "2.0"

--- a/crates/mysql-binlog-source/Cargo.toml
+++ b/crates/mysql-binlog-source/Cargo.toml
@@ -12,7 +12,7 @@ checkpoint = { path = "../checkpoint" }
 chrono = { version = "0.4", features = ["serde"] }
 json-types = { path = "../json-types" }
 mysql-types = { path = "../mysql-types" }
-mysql_async = { version = "0.36", default-features = false, features = ["default-rustls"] }
+mysql_async = { version = "0.36", default-features = false, features = ["derive", "rustls-tls", "tls12", "aws-lc-rs", "minimal"] }
 surreal-sync-mysql-trigger-source = { path = "../mysql-trigger-source" }
 rand = "0.10"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/mysql-binlog-source/Cargo.toml
+++ b/crates/mysql-binlog-source/Cargo.toml
@@ -12,7 +12,7 @@ checkpoint = { path = "../checkpoint" }
 chrono = { version = "0.4", features = ["serde"] }
 json-types = { path = "../json-types" }
 mysql-types = { path = "../mysql-types" }
-mysql_async = "0.36"
+mysql_async = { version = "0.36", default-features = false, features = ["default-rustls"] }
 surreal-sync-mysql-trigger-source = { path = "../mysql-trigger-source" }
 rand = "0.10"
 serde = { version = "1.0", features = ["derive"] }
@@ -36,6 +36,8 @@ surreal-sync-interleaved-snapshot = { path = "../interleaved-snapshot" }
 surreal2-sink = { path = "../surreal2-sink" }
 surrealdb = { version = "2.6.5", features = ["protocol-ws", "kv-mem"] }
 serde = { version = "1.0", features = ["derive"] }
+anyhow = "1.0"
+mysql-types = { path = "../mysql-types" }
 
 [lib]
 name = "surreal_sync_mysql_binlog_source"

--- a/crates/mysql-binlog-source/src/client.rs
+++ b/crates/mysql-binlog-source/src/client.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use binlog_protocol::{
     BinlogClient, Flavor, MariaDbDumpFlags, MariaDbGtidList, ReplicaOptions, ResumePosition,
+    SslMode,
 };
 use mysql_async::{prelude::*, Pool, Row};
 use tracing::info;
@@ -37,8 +38,9 @@ pub fn parse_mysql_uri(uri: &str) -> Result<(String, u16, String, String, Option
     Ok((host, port, username, password, dbpart))
 }
 
-pub fn new_mysql_pool(connection_string: &str) -> Result<Pool> {
-    Ok(Pool::from_url(connection_string)?)
+/// Create a MySQL SQL pool honouring TLS mode (with Preferred plaintext fallback).
+pub async fn new_mysql_pool_with_ssl(connection_string: &str, ssl: &SslMode) -> Result<Pool> {
+    mysql_types::new_mysql_pool_with_ssl(connection_string, ssl).await
 }
 
 /// Short, actionable message when a MySQL TCP/connect attempt fails.

--- a/crates/mysql-binlog-source/src/full_sync.rs
+++ b/crates/mysql-binlog-source/src/full_sync.rs
@@ -21,8 +21,8 @@ use crate::catch_up::{
 };
 use crate::checkpoint::BinlogCheckpoint;
 use crate::client::{
-    connect_binlog_client, get_pool_conn, new_mysql_pool, resolve_database, show_master_status,
-    use_database,
+    connect_binlog_client, get_pool_conn, new_mysql_pool_with_ssl, resolve_database,
+    show_master_status, use_database,
 };
 use crate::schema::collect_mysql_database_schema;
 use crate::signal::SIGNAL_TABLE;
@@ -103,7 +103,7 @@ pub async fn run_full_sync_cancellable_with_transforms<S: SurrealSink, CS: Check
         );
     }
 
-    let pool = new_mysql_pool(&from_opts.connection_string)?;
+    let pool = new_mysql_pool_with_ssl(&from_opts.connection_string, &from_opts.ssl).await?;
     let database = resolve_database(&pool, from_opts).await?;
     let mut conn = get_pool_conn(&pool, &from_opts.connection_string).await?;
     use_database(&mut conn, &database).await?;
@@ -539,7 +539,7 @@ pub async fn read_table_chunk(
 /// from it streams only changes committed after this instant — the explicit,
 /// resumable equivalent of "start fresh from the current position".
 pub async fn capture_head_checkpoint(from_opts: &SourceOpts) -> Result<BinlogCheckpoint> {
-    let pool = new_mysql_pool(&from_opts.connection_string)?;
+    let pool = new_mysql_pool_with_ssl(&from_opts.connection_string, &from_opts.ssl).await?;
     let flavor = connect_binlog_client(from_opts).await?.flavor();
     let checkpoint = capture_binlog_checkpoint(&pool, flavor).await?;
     pool.disconnect().await?;

--- a/crates/mysql-binlog-source/src/incremental_sync.rs
+++ b/crates/mysql-binlog-source/src/incremental_sync.rs
@@ -25,7 +25,7 @@ use crate::catch_up::{
 use crate::change::cdc_change_to_universal;
 use crate::checkpoint::BinlogCheckpoint;
 use crate::client::{
-    connect_binlog_client_with_poll, get_pool_conn, new_mysql_pool, resolve_database,
+    connect_binlog_client_with_poll, get_pool_conn, new_mysql_pool_with_ssl, resolve_database,
     start_binlog_from_checkpoint, use_database, DEFAULT_BINLOG_POLL_TIMEOUT,
 };
 use crate::schema::{collect_mysql_database_schema, get_table_column_names_ordinal};
@@ -181,7 +181,7 @@ where
         );
     }
 
-    let pool = new_mysql_pool(&from_opts.connection_string)?;
+    let pool = new_mysql_pool_with_ssl(&from_opts.connection_string, &from_opts.ssl).await?;
     let database = resolve_database(&pool, &from_opts).await?;
     let mut conn = get_pool_conn(&pool, &from_opts.connection_string).await?;
     use_database(&mut conn, &database).await?;

--- a/crates/mysql-binlog-source/src/lib.rs
+++ b/crates/mysql-binlog-source/src/lib.rs
@@ -24,6 +24,7 @@ pub use catch_up::{
 };
 pub use change::cdc_change_to_universal;
 pub use checkpoint::{get_current_checkpoint, BinlogCheckpoint, BinlogReconciliationPos};
+pub use client::{connect_binlog_client, new_mysql_pool_with_ssl, parse_mysql_uri};
 pub use flavor::Flavor;
 pub use full_sync::{
     capture_head_checkpoint, run_full_sync, run_full_sync_cancellable,

--- a/crates/mysql-binlog-source/src/watermark_source.rs
+++ b/crates/mysql-binlog-source/src/watermark_source.rs
@@ -26,8 +26,8 @@ use crate::catch_up::{
 use crate::change::cdc_change_to_universal;
 use crate::checkpoint::{get_current_checkpoint, BinlogCheckpoint, BinlogReconciliationPos};
 use crate::client::{
-    connect_binlog_client, get_pool_conn, new_mysql_pool, resolve_database, start_binlog_at_end,
-    start_binlog_from_checkpoint, use_database,
+    connect_binlog_client, get_pool_conn, new_mysql_pool_with_ssl, resolve_database,
+    start_binlog_at_end, start_binlog_from_checkpoint, use_database,
 };
 use crate::full_sync::{get_primary_key_columns, read_table_chunk};
 use crate::schema::{collect_mysql_database_schema, get_table_column_names_ordinal};
@@ -108,7 +108,7 @@ impl BinlogWatermarkSource {
         from_opts: &SourceOpts,
         options: ConnectOptions,
     ) -> Result<Self> {
-        let pool = new_mysql_pool(&from_opts.connection_string)?;
+        let pool = new_mysql_pool_with_ssl(&from_opts.connection_string, &from_opts.ssl).await?;
         let database = resolve_database(&pool, from_opts).await?;
         let mut conn = get_pool_conn(&pool, &from_opts.connection_string).await?;
         use_database(&mut conn, &database).await?;
@@ -173,7 +173,7 @@ impl BinlogWatermarkSource {
 
     /// Resolve the table names that would be snapshotted for these source options.
     pub async fn resolve_snapshot_table_names(from_opts: &SourceOpts) -> Result<Vec<String>> {
-        let pool = new_mysql_pool(&from_opts.connection_string)?;
+        let pool = new_mysql_pool_with_ssl(&from_opts.connection_string, &from_opts.ssl).await?;
         let database = resolve_database(&pool, from_opts).await?;
         let mut conn = get_pool_conn(&pool, &from_opts.connection_string).await?;
         use_database(&mut conn, &database).await?;

--- a/crates/mysql-binlog-source/tests/suite/main.rs
+++ b/crates/mysql-binlog-source/tests/suite/main.rs
@@ -4,5 +4,7 @@ mod integration;
 mod interleaved_snapshot;
 mod mariadb_11_4_position;
 mod shared;
+mod tls_certs;
+mod tls_modes;
 mod transforms;
 mod types_extended;

--- a/crates/mysql-binlog-source/tests/suite/tls_certs.rs
+++ b/crates/mysql-binlog-source/tests/suite/tls_certs.rs
@@ -8,10 +8,12 @@ use tempfile::TempDir;
 
 const OPENSSL_IMAGE: &str = "alpine/openssl:latest";
 
-/// CA + server certificate files for a TLS-enabled MySQL test container.
+/// CA, server, and client certificate files for TLS MySQL/MariaDB tests.
 pub struct MysqlTlsSecrets {
     pub dir: TempDir,
     pub ca_pem: PathBuf,
+    pub client_cert: PathBuf,
+    pub client_key: PathBuf,
 }
 
 impl MysqlTlsSecrets {
@@ -31,7 +33,12 @@ subjectAltName=DNS:localhost,IP:127.0.0.1
 EOF
 openssl x509 -req -in server.csr -CA ca.pem -CAkey ca.key -CAcreateserial \
   -out server.crt -days 3650 -extfile server.ext
-chmod 644 ca.pem server.crt server.key
+openssl genrsa -traditional -out client.key 2048
+openssl req -new -key client.key -out client.csr \
+  -subj "/CN=SurrealSyncTestClient"
+openssl x509 -req -in client.csr -CA ca.pem -CAkey ca.key -CAcreateserial \
+  -out client.crt -days 3650
+chmod 644 ca.pem server.crt server.key client.crt client.key
 "#;
         std::fs::write(work.join("generate.sh"), script)?;
         #[cfg(unix)]
@@ -73,13 +80,26 @@ chmod 644 ca.pem server.crt server.key
         let ca_pem = work.join("ca.pem");
         let server_cert = work.join("server.crt");
         let server_key = work.join("server.key");
-        for path in [&ca_pem, &server_cert, &server_key] {
+        let client_cert = work.join("client.crt");
+        let client_key = work.join("client.key");
+        for path in [
+            &ca_pem,
+            &server_cert,
+            &server_key,
+            &client_cert,
+            &client_key,
+        ] {
             if !path.exists() {
                 anyhow::bail!("expected cert file missing: {}", path.display());
             }
         }
 
-        Ok(Self { dir, ca_pem })
+        Ok(Self {
+            dir,
+            ca_pem,
+            client_cert,
+            client_key,
+        })
     }
 
     pub fn secrets_dir(&self) -> &Path {

--- a/crates/mysql-binlog-source/tests/suite/tls_certs.rs
+++ b/crates/mysql-binlog-source/tests/suite/tls_certs.rs
@@ -1,0 +1,88 @@
+//! Generate TLS certificates for MySQL integration tests (via Docker openssl).
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use anyhow::{Context, Result};
+use tempfile::TempDir;
+
+const OPENSSL_IMAGE: &str = "alpine/openssl:latest";
+
+/// CA + server certificate files for a TLS-enabled MySQL test container.
+pub struct MysqlTlsSecrets {
+    pub dir: TempDir,
+    pub ca_pem: PathBuf,
+}
+
+impl MysqlTlsSecrets {
+    pub fn generate() -> Result<Self> {
+        let dir = tempfile::tempdir().context("create TLS secrets tempdir")?;
+        let work = dir.path();
+
+        let script = r#"#!/bin/sh
+set -eu
+cd /work
+openssl req -new -x509 -keyout ca.key -out ca.pem -days 3650 -nodes \
+  -subj "/CN=SurrealSyncMySQLTestCA"
+openssl req -new -newkey rsa:2048 -nodes -keyout server.key -out server.csr \
+  -subj "/CN=localhost"
+cat > server.ext <<'EOF'
+subjectAltName=DNS:localhost,IP:127.0.0.1
+EOF
+openssl x509 -req -in server.csr -CA ca.pem -CAkey ca.key -CAcreateserial \
+  -out server.crt -days 3650 -extfile server.ext
+chmod 644 ca.pem server.crt server.key
+"#;
+        std::fs::write(work.join("generate.sh"), script)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(
+                work.join("generate.sh"),
+                std::fs::Permissions::from_mode(0o755),
+            )?;
+        }
+
+        let work_str = work
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("TLS work dir is not valid UTF-8"))?;
+        let output = Command::new("docker")
+            .args([
+                "run",
+                "--rm",
+                "--entrypoint",
+                "sh",
+                "-v",
+                &format!("{work_str}:/work"),
+                "-w",
+                "/work",
+                OPENSSL_IMAGE,
+                "/work/generate.sh",
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .context("docker openssl cert generation")?;
+        if !output.status.success() {
+            anyhow::bail!(
+                "openssl cert generation failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        let ca_pem = work.join("ca.pem");
+        let server_cert = work.join("server.crt");
+        let server_key = work.join("server.key");
+        for path in [&ca_pem, &server_cert, &server_key] {
+            if !path.exists() {
+                anyhow::bail!("expected cert file missing: {}", path.display());
+            }
+        }
+
+        Ok(Self { dir, ca_pem })
+    }
+
+    pub fn secrets_dir(&self) -> &Path {
+        self.dir.path()
+    }
+}

--- a/crates/mysql-binlog-source/tests/suite/tls_modes.rs
+++ b/crates/mysql-binlog-source/tests/suite/tls_modes.rs
@@ -29,6 +29,10 @@ fn parse_mysql_uri(uri: &str) -> Result<(String, u16, String, String)> {
     Ok((host, port, username, password))
 }
 
+fn invalid_password(correct: &str) -> String {
+    format!("{correct}-invalid")
+}
+
 struct TlsMysqlContainer {
     name: String,
     connection_string: String,
@@ -496,12 +500,12 @@ async fn tls_sql_pool_modes_on_tls_server() -> Result<()> {
 async fn tls_preferred_does_not_fallback_on_auth_failure() -> Result<()> {
     crate::shared::init_logging();
     let c = TlsMysqlContainer::start("ss-mysql-tls-preferred-auth").await?;
-    let (host, port, username, _) = parse_mysql_uri(&c.connection_string)?;
+    let (host, port, username, password) = parse_mysql_uri(&c.connection_string)?;
     let err = BinlogClient::connect(ReplicaOptions {
         host,
         port,
         username,
-        password: "wrong-password".into(),
+        password: invalid_password(&password),
         server_id: 9_100_008,
         ssl: SslMode::Preferred(SslOptions {
             ca: Some(c.ca_path()),
@@ -529,7 +533,11 @@ async fn tls_preferred_does_not_fallback_on_auth_failure() -> Result<()> {
 async fn tls_sql_pool_preferred_does_not_fallback_on_auth_failure() -> Result<()> {
     crate::shared::init_logging();
     let c = TlsMysqlContainer::start("ss-mysql-tls-pool-auth").await?;
-    let bad_uri = c.connection_string.replace("testpass", "wrong-password");
+    let (host, port, username, password) = parse_mysql_uri(&c.connection_string)?;
+    let bad_uri = format!(
+        "mysql://{username}:{}@{host}:{port}/testdb",
+        invalid_password(&password)
+    );
     let err = mysql_types::new_mysql_pool_with_ssl(
         &bad_uri,
         &SslMode::Preferred(SslOptions {

--- a/crates/mysql-binlog-source/tests/suite/tls_modes.rs
+++ b/crates/mysql-binlog-source/tests/suite/tls_modes.rs
@@ -4,8 +4,8 @@ use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
-use binlog_protocol::test_images::mysql_binlog_image;
-use binlog_protocol::{BinlogClient, ReplicaOptions, SslMode, SslOptions};
+use binlog_protocol::test_images::{mariadb_binlog_image, mysql_binlog_image};
+use binlog_protocol::{BinlogClient, Flavor, ReplicaOptions, SslMode, SslOptions};
 use mysql_async::prelude::*;
 
 use crate::tls_certs::MysqlTlsSecrets;
@@ -32,11 +32,53 @@ fn parse_mysql_uri(uri: &str) -> Result<(String, u16, String, String)> {
 struct TlsMysqlContainer {
     name: String,
     connection_string: String,
+    flavor: Option<Flavor>,
     _secrets: MysqlTlsSecrets,
 }
 
 impl TlsMysqlContainer {
+    async fn start_mysql(name: &str) -> Result<Self> {
+        Self::start_with_image(
+            name,
+            &mysql_binlog_image(),
+            None,
+            &[
+                "--log-bin=mysql-bin",
+                "--binlog-format=ROW",
+                "--gtid-mode=ON",
+                "--enforce-gtid-consistency=ON",
+                "--server-id=1",
+                "--log-slave-updates=ON",
+            ],
+        )
+        .await
+    }
+
+    async fn start_mariadb(name: &str) -> Result<Self> {
+        Self::start_with_image(
+            name,
+            &mariadb_binlog_image(),
+            Some(Flavor::MariaDb),
+            &[
+                "--log-bin=mysql-bin",
+                "--binlog-format=ROW",
+                "--server-id=1",
+                "--gtid-strict-mode=ON",
+            ],
+        )
+        .await
+    }
+
     async fn start(name: &str) -> Result<Self> {
+        Self::start_mysql(name).await
+    }
+
+    async fn start_with_image(
+        name: &str,
+        image: &str,
+        flavor: Option<Flavor>,
+        engine_args: &[&str],
+    ) -> Result<Self> {
         let secrets = MysqlTlsSecrets::generate()?;
         let secrets_dir = secrets
             .secrets_dir()
@@ -50,39 +92,38 @@ impl TlsMysqlContainer {
             .stderr(Stdio::null())
             .status();
 
-        let image = mysql_binlog_image();
-        let args = [
-            "run",
-            "--name",
-            name,
-            "-e",
-            "MYSQL_ROOT_PASSWORD=testpass",
-            "-e",
-            "MYSQL_DATABASE=testdb",
-            "-p",
-            "0:3306",
-            "-v",
-            &format!("{secrets_dir}:/certs:ro"),
-            "-d",
-            &image,
-            "--log-bin=mysql-bin",
-            "--binlog-format=ROW",
-            "--gtid-mode=ON",
-            "--enforce-gtid-consistency=ON",
-            "--server-id=1",
-            "--log-slave-updates=ON",
-            "--ssl-ca=/certs/ca.pem",
-            "--ssl-cert=/certs/server.crt",
-            "--ssl-key=/certs/server.key",
-            "--require_secure_transport=OFF",
+        let mut args = vec![
+            "run".to_string(),
+            "--name".to_string(),
+            name.to_string(),
+            "-e".to_string(),
+            "MYSQL_ROOT_PASSWORD=testpass".to_string(),
+            "-e".to_string(),
+            "MYSQL_DATABASE=testdb".to_string(),
+            "-p".to_string(),
+            "0:3306".to_string(),
+            "-v".to_string(),
+            format!("{secrets_dir}:/certs:ro"),
+            "-d".to_string(),
+            image.to_string(),
         ];
+        for arg in engine_args {
+            args.push(arg.to_string());
+        }
+        args.extend([
+            "--ssl-ca=/certs/ca.pem".to_string(),
+            "--ssl-cert=/certs/server.crt".to_string(),
+            "--ssl-key=/certs/server.key".to_string(),
+            "--require_secure_transport=OFF".to_string(),
+        ]);
+
         let output = Command::new("docker")
-            .args(args)
+            .args(&args)
             .output()
-            .context("start TLS MySQL container")?;
+            .context("start TLS database container")?;
         if !output.status.success() {
             anyhow::bail!(
-                "start TLS MySQL failed: {}",
+                "start TLS database failed: {}",
                 String::from_utf8_lossy(&output.stderr)
             );
         }
@@ -92,6 +133,7 @@ impl TlsMysqlContainer {
         let container = Self {
             name: name.to_string(),
             connection_string,
+            flavor,
             _secrets: secrets,
         };
         container.wait_ready(120).await?;
@@ -100,6 +142,14 @@ impl TlsMysqlContainer {
 
     fn ca_path(&self) -> String {
         self._secrets.ca_pem.to_string_lossy().into_owned()
+    }
+
+    fn client_cert_path(&self) -> String {
+        self._secrets.client_cert.to_string_lossy().into_owned()
+    }
+
+    fn client_key_path(&self) -> String {
+        self._secrets.client_key.to_string_lossy().into_owned()
     }
 
     async fn wait_ready(&self, timeout_secs: u64) -> Result<()> {
@@ -131,7 +181,7 @@ impl TlsMysqlContainer {
             server_id,
             ssl,
             blocking_poll: Duration::from_millis(200),
-            flavor: None,
+            flavor: self.flavor,
             mariadb_flags: binlog_protocol::MariaDbDumpFlags {
                 send_annotate_rows: true,
             },
@@ -362,7 +412,7 @@ async fn tls_preferred_does_not_fallback_on_auth_failure() -> Result<()> {
     })
     .await;
     assert!(err.is_err(), "wrong password must fail under preferred");
-    let msg = format!("{:?}", err.unwrap_err());
+    let msg = err.err().map(|e| e.to_string()).unwrap_or_default();
     assert!(
         !msg.contains("retrying without TLS"),
         "preferred must not fall back on auth errors: {msg}"
@@ -443,5 +493,119 @@ async fn caching_sha2_full_auth_over_tls_required() -> Result<()> {
         .await?;
     drop(admin);
     pool.disconnect().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn tls_client_certificate_auth_connects() -> Result<()> {
+    crate::shared::init_logging();
+    let c = TlsMysqlContainer::start("ss-mysql-tls-client-cert").await?;
+
+    let pool = mysql_async::Pool::from_url(&c.connection_string)?;
+    let mut admin = pool.get_conn().await?;
+    let user = format!("cert_user_{}", std::process::id());
+    let pass = "cert_pass";
+    admin
+        .query_drop(format!("DROP USER IF EXISTS '{user}'@'%'"))
+        .await?;
+    admin
+        .query_drop(format!(
+            "CREATE USER '{user}'@'%' IDENTIFIED BY '{pass}' REQUIRE X509"
+        ))
+        .await?;
+    admin
+        .query_drop(format!(
+            "GRANT REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO '{user}'@'%'"
+        ))
+        .await?;
+    admin
+        .query_drop(format!("GRANT SELECT ON testdb.* TO '{user}'@'%'"))
+        .await?;
+    admin.query_drop("FLUSH PRIVILEGES").await?;
+    drop(admin);
+    pool.disconnect().await?;
+
+    let (host, port, _, _) = parse_mysql_uri(&c.connection_string)?;
+    let client = BinlogClient::connect(ReplicaOptions {
+        host,
+        port,
+        username: user.clone(),
+        password: pass.to_string(),
+        server_id: 9_100_009,
+        ssl: SslMode::Required(SslOptions {
+            ca: Some(c.ca_path()),
+            cert: Some(c.client_cert_path()),
+            key: Some(c.client_key_path()),
+        }),
+        blocking_poll: Duration::from_millis(200),
+        flavor: None,
+        mariadb_flags: binlog_protocol::MariaDbDumpFlags {
+            send_annotate_rows: true,
+        },
+        mariadb_gtid_strict_mode: binlog_protocol::MariaDbGtidStrictMode::ServerDefault,
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("client certificate auth failed: {e}"))?;
+    drop(client);
+
+    let (host, port, _, _) = parse_mysql_uri(&c.connection_string)?;
+    let user_uri = format!("mysql://{user}:{pass}@{host}:{port}/testdb");
+    let pool = mysql_types::new_mysql_pool_with_ssl(
+        &user_uri,
+        &SslMode::Required(SslOptions {
+            ca: Some(c.ca_path()),
+            cert: Some(c.client_cert_path()),
+            key: Some(c.client_key_path()),
+        }),
+    )
+    .await?;
+    let mut conn = pool.get_conn().await?;
+    let _: Option<i32> = conn.query_first("SELECT 1").await?;
+    drop(conn);
+    pool.disconnect().await?;
+
+    let pool = mysql_async::Pool::from_url(&c.connection_string)?;
+    let mut admin = pool.get_conn().await?;
+    admin
+        .query_drop(format!("DROP USER IF EXISTS '{user}'@'%'"))
+        .await?;
+    drop(admin);
+    pool.disconnect().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn mariadb_tls_required_with_ca_connects() -> Result<()> {
+    crate::shared::init_logging();
+    let c = TlsMysqlContainer::start_mariadb("ss-mariadb-tls-required").await?;
+    let client = c
+        .connect_binlog(
+            SslMode::Required(SslOptions {
+                ca: Some(c.ca_path()),
+                cert: None,
+                key: None,
+            }),
+            9_100_010,
+        )
+        .await?;
+    drop(client);
+    Ok(())
+}
+
+#[tokio::test]
+async fn mariadb_tls_preferred_with_ca_connects() -> Result<()> {
+    crate::shared::init_logging();
+    let c = TlsMysqlContainer::start_mariadb("ss-mariadb-tls-preferred").await?;
+    let client = c
+        .connect_binlog(
+            SslMode::Preferred(SslOptions {
+                ca: Some(c.ca_path()),
+                cert: None,
+                key: None,
+            }),
+            9_100_011,
+        )
+        .await?;
+    drop(client);
     Ok(())
 }

--- a/crates/mysql-binlog-source/tests/suite/tls_modes.rs
+++ b/crates/mysql-binlog-source/tests/suite/tls_modes.rs
@@ -202,6 +202,110 @@ impl Drop for TlsMysqlContainer {
     }
 }
 
+/// MySQL container with TLS explicitly disabled on the server.
+struct PlaintextOnlyContainer {
+    name: String,
+    connection_string: String,
+}
+
+impl PlaintextOnlyContainer {
+    async fn start(name: &str) -> Result<Self> {
+        let _ = Command::new("docker")
+            .args(["rm", "-f", name])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+
+        let image = mysql_binlog_image();
+        let output = Command::new("docker")
+            .args([
+                "run",
+                "--name",
+                name,
+                "-e",
+                "MYSQL_ROOT_PASSWORD=testpass",
+                "-e",
+                "MYSQL_DATABASE=testdb",
+                "-p",
+                "0:3306",
+                "-d",
+                &image,
+                "--ssl=0",
+                "--log-bin=mysql-bin",
+                "--binlog-format=ROW",
+                "--gtid-mode=ON",
+                "--enforce-gtid-consistency=ON",
+                "--server-id=1",
+                "--log-slave-updates=ON",
+            ])
+            .output()
+            .context("start plaintext-only MySQL container")?;
+        if !output.status.success() {
+            anyhow::bail!(
+                "start plaintext-only MySQL failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        let host_port = wait_for_port(name)?;
+        let connection_string = format!("mysql://root:testpass@127.0.0.1:{host_port}/testdb");
+        let container = Self {
+            name: name.to_string(),
+            connection_string,
+        };
+        container.wait_ready(120).await?;
+        Ok(container)
+    }
+
+    async fn wait_ready(&self, timeout_secs: u64) -> Result<()> {
+        let start = Instant::now();
+        while start.elapsed() < Duration::from_secs(timeout_secs) {
+            if let Ok(pool) = mysql_async::Pool::from_url(&self.connection_string) {
+                if let Ok(mut conn) = pool.get_conn().await {
+                    let ok: Result<Option<i32>, _> = conn.query_first("SELECT 1").await;
+                    drop(conn);
+                    let _ = pool.disconnect().await;
+                    if ok.is_ok() {
+                        return Ok(());
+                    }
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(1000)).await;
+        }
+        anyhow::bail!("plaintext-only MySQL not ready within {timeout_secs}s")
+    }
+
+    async fn connect_binlog(&self, ssl: SslMode, server_id: u32) -> Result<BinlogClient> {
+        let (host, port, username, password) = parse_mysql_uri(&self.connection_string)?;
+        BinlogClient::connect(ReplicaOptions {
+            host,
+            port,
+            username,
+            password,
+            server_id,
+            ssl,
+            blocking_poll: Duration::from_millis(200),
+            flavor: None,
+            mariadb_flags: binlog_protocol::MariaDbDumpFlags {
+                send_annotate_rows: true,
+            },
+            mariadb_gtid_strict_mode: binlog_protocol::MariaDbGtidStrictMode::ServerDefault,
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))
+    }
+}
+
+impl Drop for PlaintextOnlyContainer {
+    fn drop(&mut self) {
+        let _ = Command::new("docker")
+            .args(["rm", "-f", &self.name])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+}
+
 fn wait_for_port(name: &str) -> Result<u16> {
     for _ in 0..20 {
         let output = Command::new("docker")
@@ -315,27 +419,31 @@ async fn tls_required_without_ca_connects_self_signed() -> Result<()> {
 }
 
 #[tokio::test]
-async fn tls_required_fails_when_server_has_no_ssl() -> Result<()> {
+async fn tls_required_fails_when_server_cannot_use_tls() -> Result<()> {
     crate::shared::init_logging();
-    // Prefer a server that does not advertise CLIENT_SSL. Stock MySQL 8 images
-    // usually still enable SSL with auto-generated certs, so we simulate the
-    // failure path by requiring TLS against a host that is not MySQL — skip if
-    // the shared server does advertise SSL (common). Instead: use Required with
-    // an invalid host after confirming capability check exists via unit path.
-    //
-    // Practical check: Required with a CA that does not match still fails (no fallback).
-    let c = TlsMysqlContainer::start("ss-mysql-tls-required-badca").await?;
-    let err = c
-        .connect_binlog(
-            SslMode::Required(SslOptions {
-                ca: Some("/nonexistent/missing-ca.pem".into()),
-                cert: None,
-                key: None,
-            }),
-            9_100_006,
-        )
-        .await;
-    assert!(err.is_err(), "required must not fall back to plaintext");
+    let c = PlaintextOnlyContainer::start("ss-mysql-no-tls-required").await?;
+    let err = c.connect_binlog(SslMode::required(), 9_100_006).await;
+    assert!(
+        err.is_err(),
+        "required must fail when the server cannot use TLS"
+    );
+    let msg = err.err().map(|e| e.to_string()).unwrap_or_default();
+    assert!(
+        msg.contains("CLIENT_SSL") || msg.contains("TLS") || msg.contains("ssl"),
+        "expected a TLS capability error, got: {msg}"
+    );
+
+    let pool_err = mysql_types::new_mysql_pool_with_ssl(
+        &c.connection_string,
+        &SslMode::required(),
+    )
+    .await?
+    .get_conn()
+    .await;
+    assert!(
+        pool_err.is_err(),
+        "required SQL pool must fail when the server cannot use TLS"
+    );
     Ok(())
 }
 

--- a/crates/mysql-binlog-source/tests/suite/tls_modes.rs
+++ b/crates/mysql-binlog-source/tests/suite/tls_modes.rs
@@ -1,0 +1,393 @@
+//! Integration tests for MySQL TLS modes: disabled, preferred, required.
+
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use binlog_protocol::test_images::mysql_binlog_image;
+use binlog_protocol::{BinlogClient, ReplicaOptions, SslMode, SslOptions};
+use mysql_async::prelude::*;
+
+use crate::tls_certs::MysqlTlsSecrets;
+
+fn parse_mysql_uri(uri: &str) -> Result<(String, u16, String, String)> {
+    let rest = uri
+        .strip_prefix("mysql://")
+        .ok_or_else(|| anyhow::anyhow!("expected mysql://"))?;
+    let (auth, hostpart) = rest
+        .split_once('@')
+        .ok_or_else(|| anyhow::anyhow!("missing @"))?;
+    let (username, password) = auth
+        .split_once(':')
+        .map(|(u, p)| (u.to_string(), p.to_string()))
+        .unwrap_or((auth.to_string(), String::new()));
+    let hostport = hostpart.split_once('/').map(|(h, _)| h).unwrap_or(hostpart);
+    let (host, port) = match hostport.rsplit_once(':') {
+        Some((h, p)) => (h.to_string(), p.parse().unwrap_or(3306)),
+        None => (hostport.to_string(), 3306),
+    };
+    Ok((host, port, username, password))
+}
+
+struct TlsMysqlContainer {
+    name: String,
+    connection_string: String,
+    _secrets: MysqlTlsSecrets,
+}
+
+impl TlsMysqlContainer {
+    async fn start(name: &str) -> Result<Self> {
+        let secrets = MysqlTlsSecrets::generate()?;
+        let secrets_dir = secrets
+            .secrets_dir()
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("secrets path not utf-8"))?
+            .to_string();
+
+        let _ = Command::new("docker")
+            .args(["rm", "-f", name])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+
+        let image = mysql_binlog_image();
+        let args = [
+            "run",
+            "--name",
+            name,
+            "-e",
+            "MYSQL_ROOT_PASSWORD=testpass",
+            "-e",
+            "MYSQL_DATABASE=testdb",
+            "-p",
+            "0:3306",
+            "-v",
+            &format!("{secrets_dir}:/certs:ro"),
+            "-d",
+            &image,
+            "--log-bin=mysql-bin",
+            "--binlog-format=ROW",
+            "--gtid-mode=ON",
+            "--enforce-gtid-consistency=ON",
+            "--server-id=1",
+            "--log-slave-updates=ON",
+            "--ssl-ca=/certs/ca.pem",
+            "--ssl-cert=/certs/server.crt",
+            "--ssl-key=/certs/server.key",
+            "--require_secure_transport=OFF",
+        ];
+        let output = Command::new("docker")
+            .args(args)
+            .output()
+            .context("start TLS MySQL container")?;
+        if !output.status.success() {
+            anyhow::bail!(
+                "start TLS MySQL failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        let host_port = wait_for_port(name)?;
+        let connection_string = format!("mysql://root:testpass@127.0.0.1:{host_port}/testdb");
+        let container = Self {
+            name: name.to_string(),
+            connection_string,
+            _secrets: secrets,
+        };
+        container.wait_ready(120).await?;
+        Ok(container)
+    }
+
+    fn ca_path(&self) -> String {
+        self._secrets.ca_pem.to_string_lossy().into_owned()
+    }
+
+    async fn wait_ready(&self, timeout_secs: u64) -> Result<()> {
+        let start = Instant::now();
+        while start.elapsed() < Duration::from_secs(timeout_secs) {
+            // Prefer plaintext probe — TLS modes are what we are testing.
+            if let Ok(pool) = mysql_async::Pool::from_url(&self.connection_string) {
+                if let Ok(mut conn) = pool.get_conn().await {
+                    let ok: Result<Option<i32>, _> = conn.query_first("SELECT 1").await;
+                    drop(conn);
+                    let _ = pool.disconnect().await;
+                    if ok.is_ok() {
+                        return Ok(());
+                    }
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(1000)).await;
+        }
+        anyhow::bail!("TLS MySQL not ready within {timeout_secs}s")
+    }
+
+    async fn connect_binlog(&self, ssl: SslMode, server_id: u32) -> Result<BinlogClient> {
+        let (host, port, username, password) = parse_mysql_uri(&self.connection_string)?;
+        BinlogClient::connect(ReplicaOptions {
+            host,
+            port,
+            username,
+            password,
+            server_id,
+            ssl,
+            blocking_poll: Duration::from_millis(200),
+            flavor: None,
+            mariadb_flags: binlog_protocol::MariaDbDumpFlags {
+                send_annotate_rows: true,
+            },
+            mariadb_gtid_strict_mode: binlog_protocol::MariaDbGtidStrictMode::ServerDefault,
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))
+    }
+}
+
+impl Drop for TlsMysqlContainer {
+    fn drop(&mut self) {
+        let _ = Command::new("docker")
+            .args(["rm", "-f", &self.name])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+}
+
+fn wait_for_port(name: &str) -> Result<u16> {
+    for _ in 0..20 {
+        let output = Command::new("docker")
+            .args(["port", name, "3306"])
+            .output()?;
+        if output.status.success() {
+            if let Some(port) = String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .next()
+                .and_then(|line| line.rsplit(':').next())
+                .and_then(|p| p.trim().parse().ok())
+            {
+                return Ok(port);
+            }
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    anyhow::bail!("could not discover host port for {name}")
+}
+
+#[tokio::test]
+async fn tls_disabled_connects_to_tls_capable_server() -> Result<()> {
+    crate::shared::init_logging();
+    let c = TlsMysqlContainer::start("ss-mysql-tls-disabled").await?;
+    let client = c.connect_binlog(SslMode::Disabled, 9_100_001).await?;
+    drop(client);
+    Ok(())
+}
+
+#[tokio::test]
+async fn tls_preferred_connects_with_tls_to_tls_capable_server() -> Result<()> {
+    crate::shared::init_logging();
+    let c = TlsMysqlContainer::start("ss-mysql-tls-preferred").await?;
+    let client = c
+        .connect_binlog(
+            SslMode::Preferred(SslOptions {
+                ca: Some(c.ca_path()),
+                cert: None,
+                key: None,
+            }),
+            9_100_002,
+        )
+        .await?;
+    drop(client);
+    Ok(())
+}
+
+#[tokio::test]
+async fn tls_preferred_falls_back_on_plaintext_only_server() -> Result<()> {
+    crate::shared::init_logging();
+    // Stock shared container has no custom CA / typically allows plaintext.
+    let container = crate::shared::shared_mysql_binlog().await;
+    let (host, port, username, password) = parse_mysql_uri(&container.connection_string)?;
+    let client = BinlogClient::connect(ReplicaOptions {
+        host,
+        port,
+        username,
+        password,
+        server_id: 9_100_003,
+        // Preferred with a bogus CA forces handshake failure → plaintext retry.
+        ssl: SslMode::Preferred(SslOptions {
+            ca: Some("/nonexistent/ca.pem".into()),
+            cert: None,
+            key: None,
+        }),
+        blocking_poll: Duration::from_millis(200),
+        flavor: None,
+        mariadb_flags: binlog_protocol::MariaDbDumpFlags {
+            send_annotate_rows: true,
+        },
+        mariadb_gtid_strict_mode: binlog_protocol::MariaDbGtidStrictMode::ServerDefault,
+    })
+    .await;
+    // Either succeeds via fallback (server has SSL but bad CA) or via no-SSL path.
+    // If the shared server has no CLIENT_SSL, Preferred stays plaintext without reading CA.
+    // If it has SSL, bad CA fails upgrade → reconnect Disabled.
+    assert!(
+        client.is_ok(),
+        "preferred should fall back to plaintext: {:?}",
+        client.err()
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn tls_required_with_ca_connects() -> Result<()> {
+    crate::shared::init_logging();
+    let c = TlsMysqlContainer::start("ss-mysql-tls-required-ca").await?;
+    let client = c
+        .connect_binlog(
+            SslMode::Required(SslOptions {
+                ca: Some(c.ca_path()),
+                cert: None,
+                key: None,
+            }),
+            9_100_004,
+        )
+        .await?;
+    drop(client);
+    Ok(())
+}
+
+#[tokio::test]
+async fn tls_required_without_ca_connects_self_signed() -> Result<()> {
+    crate::shared::init_logging();
+    let c = TlsMysqlContainer::start("ss-mysql-tls-required-noca").await?;
+    // MySQL-compatible REQUIRED: encrypt without public-CA verification.
+    let client = c.connect_binlog(SslMode::required(), 9_100_005).await?;
+    drop(client);
+    Ok(())
+}
+
+#[tokio::test]
+async fn tls_required_fails_when_server_has_no_ssl() -> Result<()> {
+    crate::shared::init_logging();
+    // Prefer a server that does not advertise CLIENT_SSL. Stock MySQL 8 images
+    // usually still enable SSL with auto-generated certs, so we simulate the
+    // failure path by requiring TLS against a host that is not MySQL — skip if
+    // the shared server does advertise SSL (common). Instead: use Required with
+    // an invalid host after confirming capability check exists via unit path.
+    //
+    // Practical check: Required with a CA that does not match still fails (no fallback).
+    let c = TlsMysqlContainer::start("ss-mysql-tls-required-badca").await?;
+    let err = c
+        .connect_binlog(
+            SslMode::Required(SslOptions {
+                ca: Some("/nonexistent/missing-ca.pem".into()),
+                cert: None,
+                key: None,
+            }),
+            9_100_006,
+        )
+        .await;
+    assert!(err.is_err(), "required must not fall back to plaintext");
+    Ok(())
+}
+
+#[tokio::test]
+async fn tls_sql_pool_modes_on_tls_server() -> Result<()> {
+    crate::shared::init_logging();
+    let c = TlsMysqlContainer::start("ss-mysql-tls-sql-pool").await?;
+
+    // disabled
+    let pool =
+        mysql_types::new_mysql_pool_with_ssl(&c.connection_string, &SslMode::Disabled).await?;
+    let mut conn = pool.get_conn().await?;
+    let _: Option<i32> = conn.query_first("SELECT 1").await?;
+    drop(conn);
+    pool.disconnect().await?;
+
+    // preferred with CA
+    let preferred = SslMode::Preferred(SslOptions {
+        ca: Some(c.ca_path()),
+        cert: None,
+        key: None,
+    });
+    let pool = mysql_types::new_mysql_pool_with_ssl(&c.connection_string, &preferred).await?;
+    let mut conn = pool.get_conn().await?;
+    let _: Option<i32> = conn.query_first("SELECT 1").await?;
+    drop(conn);
+    pool.disconnect().await?;
+
+    // required without CA (self-signed OK)
+    let pool =
+        mysql_types::new_mysql_pool_with_ssl(&c.connection_string, &SslMode::required()).await?;
+    let mut conn = pool.get_conn().await?;
+    let _: Option<i32> = conn.query_first("SELECT 1").await?;
+    drop(conn);
+    pool.disconnect().await?;
+
+    // required with CA
+    let required = SslMode::Required(SslOptions {
+        ca: Some(c.ca_path()),
+        cert: None,
+        key: None,
+    });
+    let pool = mysql_types::new_mysql_pool_with_ssl(&c.connection_string, &required).await?;
+    let mut conn = pool.get_conn().await?;
+    let _: Option<i32> = conn.query_first("SELECT 1").await?;
+    drop(conn);
+    pool.disconnect().await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn caching_sha2_full_auth_over_tls_required() -> Result<()> {
+    crate::shared::init_logging();
+    let c = TlsMysqlContainer::start("ss-mysql-tls-sha2").await?;
+
+    let pool = mysql_async::Pool::from_url(&c.connection_string)?;
+    let mut admin = pool.get_conn().await?;
+    let user = format!("sha2_tls_{}", std::process::id());
+    let pass = "sha2_tls_pass";
+    admin
+        .query_drop(format!("DROP USER IF EXISTS '{user}'@'%'"))
+        .await?;
+    admin
+        .query_drop(format!(
+            "CREATE USER '{user}'@'%' IDENTIFIED WITH caching_sha2_password BY '{pass}'"
+        ))
+        .await?;
+    admin
+        .query_drop(format!(
+            "GRANT REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO '{user}'@'%'"
+        ))
+        .await?;
+    admin.query_drop("FLUSH PRIVILEGES").await?;
+
+    let (host, port, _, _) = parse_mysql_uri(&c.connection_string)?;
+    let client = BinlogClient::connect(ReplicaOptions {
+        host,
+        port,
+        username: user.clone(),
+        password: pass.to_string(),
+        server_id: 9_100_007,
+        ssl: SslMode::Required(SslOptions {
+            ca: Some(c.ca_path()),
+            cert: None,
+            key: None,
+        }),
+        blocking_poll: Duration::from_millis(200),
+        flavor: None,
+        mariadb_flags: binlog_protocol::MariaDbDumpFlags {
+            send_annotate_rows: true,
+        },
+        mariadb_gtid_strict_mode: binlog_protocol::MariaDbGtidStrictMode::ServerDefault,
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("caching_sha2 over TLS failed: {e}"))?;
+
+    drop(client);
+    admin
+        .query_drop(format!("DROP USER IF EXISTS '{user}'@'%'"))
+        .await?;
+    drop(admin);
+    pool.disconnect().await?;
+    Ok(())
+}

--- a/crates/mysql-binlog-source/tests/suite/tls_modes.rs
+++ b/crates/mysql-binlog-source/tests/suite/tls_modes.rs
@@ -433,13 +433,10 @@ async fn tls_required_fails_when_server_cannot_use_tls() -> Result<()> {
         "expected a TLS capability error, got: {msg}"
     );
 
-    let pool_err = mysql_types::new_mysql_pool_with_ssl(
-        &c.connection_string,
-        &SslMode::required(),
-    )
-    .await?
-    .get_conn()
-    .await;
+    let pool_err = mysql_types::new_mysql_pool_with_ssl(&c.connection_string, &SslMode::required())
+        .await?
+        .get_conn()
+        .await;
     assert!(
         pool_err.is_err(),
         "required SQL pool must fail when the server cannot use TLS"

--- a/crates/mysql-binlog-source/tests/suite/tls_modes.rs
+++ b/crates/mysql-binlog-source/tests/suite/tls_modes.rs
@@ -338,6 +338,60 @@ async fn tls_sql_pool_modes_on_tls_server() -> Result<()> {
 }
 
 #[tokio::test]
+async fn tls_preferred_does_not_fallback_on_auth_failure() -> Result<()> {
+    crate::shared::init_logging();
+    let c = TlsMysqlContainer::start("ss-mysql-tls-preferred-auth").await?;
+    let (host, port, username, _) = parse_mysql_uri(&c.connection_string)?;
+    let err = BinlogClient::connect(ReplicaOptions {
+        host,
+        port,
+        username,
+        password: "wrong-password".into(),
+        server_id: 9_100_008,
+        ssl: SslMode::Preferred(SslOptions {
+            ca: Some(c.ca_path()),
+            cert: None,
+            key: None,
+        }),
+        blocking_poll: Duration::from_millis(200),
+        flavor: None,
+        mariadb_flags: binlog_protocol::MariaDbDumpFlags {
+            send_annotate_rows: true,
+        },
+        mariadb_gtid_strict_mode: binlog_protocol::MariaDbGtidStrictMode::ServerDefault,
+    })
+    .await;
+    assert!(err.is_err(), "wrong password must fail under preferred");
+    let msg = format!("{:?}", err.unwrap_err());
+    assert!(
+        !msg.contains("retrying without TLS"),
+        "preferred must not fall back on auth errors: {msg}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn tls_sql_pool_preferred_does_not_fallback_on_auth_failure() -> Result<()> {
+    crate::shared::init_logging();
+    let c = TlsMysqlContainer::start("ss-mysql-tls-pool-auth").await?;
+    let bad_uri = c.connection_string.replace("testpass", "wrong-password");
+    let err = mysql_types::new_mysql_pool_with_ssl(
+        &bad_uri,
+        &SslMode::Preferred(SslOptions {
+            ca: Some(c.ca_path()),
+            cert: None,
+            key: None,
+        }),
+    )
+    .await;
+    assert!(
+        err.is_err(),
+        "preferred SQL pool must not fall back when auth fails"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn caching_sha2_full_auth_over_tls_required() -> Result<()> {
     crate::shared::init_logging();
     let c = TlsMysqlContainer::start("ss-mysql-tls-sha2").await?;

--- a/crates/mysql-trigger-source/Cargo.toml
+++ b/crates/mysql-trigger-source/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "MySQL trigger-based sync for surreal-sync"
 
 [dependencies]
-mysql_async = { version = "0.36", default-features = false, features = ["default-rustls"] }
+mysql_async = { version = "0.36", default-features = false, features = ["derive", "rustls-tls", "tls12", "aws-lc-rs", "minimal"] }
 surreal-sink = { path = "../surreal-sink" }
 surreal-sync-interleaved-snapshot = { path = "../interleaved-snapshot" }
 sync-core = { path = "../sync-core" }

--- a/crates/mysql-trigger-source/Cargo.toml
+++ b/crates/mysql-trigger-source/Cargo.toml
@@ -5,13 +5,14 @@ edition = "2021"
 description = "MySQL trigger-based sync for surreal-sync"
 
 [dependencies]
-mysql_async = "0.36"
+mysql_async = { version = "0.36", default-features = false, features = ["default-rustls"] }
 surreal-sink = { path = "../surreal-sink" }
 surreal-sync-interleaved-snapshot = { path = "../interleaved-snapshot" }
 sync-core = { path = "../sync-core" }
 sync-transform = { path = "../sync-transform" }
 checkpoint = { path = "../checkpoint" }
 mysql-types = { path = "../mysql-types" }
+binlog-protocol = { path = "../binlog-protocol" }
 json-types = { path = "../json-types" }
 uuid = { version = "1.10", features = ["v4", "serde"] }
 tokio = { version = "1.49", features = ["full"] }
@@ -33,3 +34,5 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 async-trait = "0.1"
 sync-transform = { path = "../sync-transform" }
 surreal2-sink = { path = "../surreal2-sink" }
+binlog-protocol = { path = "../binlog-protocol" }
+anyhow = "1.0.100"

--- a/crates/mysql-trigger-source/Cargo.toml
+++ b/crates/mysql-trigger-source/Cargo.toml
@@ -34,5 +34,4 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 async-trait = "0.1"
 sync-transform = { path = "../sync-transform" }
 surreal2-sink = { path = "../surreal2-sink" }
-binlog-protocol = { path = "../binlog-protocol" }
 anyhow = "1.0.100"

--- a/crates/mysql-trigger-source/src/client.rs
+++ b/crates/mysql-trigger-source/src/client.rs
@@ -3,10 +3,20 @@
 //! This module provides utilities for creating and managing MySQL connection pools.
 
 use anyhow::Result;
+use binlog_protocol::SslMode;
 use mysql_async::Pool;
 
-/// Create a new MySQL connection pool
+/// Create a new MySQL connection pool (plaintext).
 pub fn new_mysql_pool(connection_string: &str) -> Result<Pool> {
-    let pool = Pool::from_url(connection_string)?;
-    Ok(pool)
+    new_mysql_pool_sync(connection_string, &SslMode::Disabled)
+}
+
+/// Create a MySQL pool honouring TLS mode (sync; Preferred does not probe-fallback).
+pub fn new_mysql_pool_sync(connection_string: &str, ssl: &SslMode) -> Result<Pool> {
+    mysql_types::ssl::new_mysql_pool_with_ssl_sync(connection_string, ssl)
+}
+
+/// Create a MySQL pool honouring TLS mode, with Preferred plaintext fallback.
+pub async fn new_mysql_pool_with_ssl(connection_string: &str, ssl: &SslMode) -> Result<Pool> {
+    mysql_types::new_mysql_pool_with_ssl(connection_string, ssl).await
 }

--- a/crates/mysql-trigger-source/src/full_sync.rs
+++ b/crates/mysql-trigger-source/src/full_sync.rs
@@ -7,7 +7,7 @@ use crate::{SourceOpts, SyncOpts};
 use anyhow::Result;
 use async_trait::async_trait;
 use checkpoint::{Checkpoint, CheckpointStore, SyncManager, SyncPhase};
-use mysql_async::{prelude::*, Params, Pool, Row, Value};
+use mysql_async::{prelude::*, Params, Row, Value};
 use mysql_types::{row_to_typed_values_with_config, RowConversionConfig};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -73,13 +73,15 @@ pub async fn run_full_sync_with_transforms<S: SurrealSink, CS: CheckpointStore>(
     }
 
     // Create connection pool with better error context
-    let pool = Pool::from_url(&from_opts.source_uri).map_err(|e| {
-        anyhow::anyhow!(
-            "Failed to create MySQL connection pool from URI '{}': {}",
-            sanitize_connection_string(&from_opts.source_uri),
-            e
-        )
-    })?;
+    let pool = super::client::new_mysql_pool_with_ssl(&from_opts.source_uri, &from_opts.ssl)
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to create MySQL connection pool from URI '{}': {}",
+                sanitize_connection_string(&from_opts.source_uri),
+                e
+            )
+        })?;
 
     let mut conn = pool.get_conn().await.map_err(|e| {
         anyhow::anyhow!(

--- a/crates/mysql-trigger-source/src/incremental_sync.rs
+++ b/crates/mysql-trigger-source/src/incremental_sync.rs
@@ -66,7 +66,8 @@ pub async fn run_incremental_sync_with_transforms<S: SurrealSink>(
     );
 
     let sequence_id = from_checkpoint.sequence_id;
-    let pool = super::client::new_mysql_pool(&from_opts.source_uri)?;
+    let pool =
+        super::client::new_mysql_pool_with_ssl(&from_opts.source_uri, &from_opts.ssl).await?;
     let mut source = super::source::MySQLIncrementalSource::with_id_column_overrides(
         pool,
         sequence_id,

--- a/crates/mysql-trigger-source/src/lib.rs
+++ b/crates/mysql-trigger-source/src/lib.rs
@@ -18,7 +18,7 @@ pub mod testing;
 
 pub use change_tracking::setup_mysql_change_tracking;
 pub use checkpoint::{get_current_checkpoint, MySQLCheckpoint};
-pub use client::new_mysql_pool;
+pub use client::{new_mysql_pool, new_mysql_pool_with_ssl};
 pub use full_sync::{
     get_primary_key_columns, read_table_chunk, run_full_sync, run_full_sync_with_transforms,
     TableChunk,
@@ -35,6 +35,8 @@ pub use interleaved_snapshot::{
 };
 pub use source::{ChangeStream, IncrementalSource, MySQLChangeStream, MySQLIncrementalSource};
 
+pub use binlog_protocol::{SslMode, SslOptions};
+
 /// MySQL source connection options
 #[derive(Clone, Debug, Default)]
 pub struct SourceOpts {
@@ -48,6 +50,8 @@ pub struct SourceOpts {
     pub mysql_boolean_paths: Option<Vec<String>>,
     /// Optional per-table primary-key overrides (`table → ordered columns`).
     pub id_column_overrides: sync_core::IdColumnOverrides,
+    /// TLS mode for the SQL connection pool
+    pub ssl: SslMode,
 }
 
 /// Sync options (non-connection related)

--- a/crates/mysql-trigger-source/tests/tls_modes.rs
+++ b/crates/mysql-trigger-source/tests/tls_modes.rs
@@ -1,0 +1,178 @@
+//! Trigger-source SQL pool TLS mode smoke tests.
+
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use binlog_protocol::test_images::mysql_binlog_image;
+use binlog_protocol::{SslMode, SslOptions};
+use mysql_async::prelude::*;
+use surreal_sync_mysql_trigger_source::new_mysql_pool_with_ssl;
+
+/// Minimal cert generation + TLS MySQL container (mirrors binlog suite harness).
+struct TlsMysql {
+    name: String,
+    connection_string: String,
+    ca_pem: std::path::PathBuf,
+    _dir: tempfile::TempDir,
+}
+
+impl TlsMysql {
+    async fn start(name: &str) -> Result<Self> {
+        let dir = tempfile::tempdir()?;
+        let work = dir.path();
+        let script = r#"#!/bin/sh
+set -eu
+cd /work
+openssl req -new -x509 -keyout ca.key -out ca.pem -days 3650 -nodes -subj "/CN=TriggerTlsCA"
+openssl req -new -newkey rsa:2048 -nodes -keyout server.key -out server.csr -subj "/CN=localhost"
+printf 'subjectAltName=DNS:localhost,IP:127.0.0.1\n' > server.ext
+openssl x509 -req -in server.csr -CA ca.pem -CAkey ca.key -CAcreateserial -out server.crt -days 3650 -extfile server.ext
+chmod 644 ca.pem server.crt server.key
+"#;
+        std::fs::write(work.join("generate.sh"), script)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(
+                work.join("generate.sh"),
+                std::fs::Permissions::from_mode(0o755),
+            )?;
+        }
+        let work_str = work.to_str().unwrap();
+        let out = Command::new("docker")
+            .args([
+                "run",
+                "--rm",
+                "--entrypoint",
+                "sh",
+                "-v",
+                &format!("{work_str}:/work"),
+                "-w",
+                "/work",
+                "alpine/openssl:latest",
+                "/work/generate.sh",
+            ])
+            .output()?;
+        if !out.status.success() {
+            anyhow::bail!("{}", String::from_utf8_lossy(&out.stderr));
+        }
+
+        let _ = Command::new("docker")
+            .args(["rm", "-f", name])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+        let image = mysql_binlog_image();
+        let out = Command::new("docker")
+            .args([
+                "run",
+                "--name",
+                name,
+                "-e",
+                "MYSQL_ROOT_PASSWORD=testpass",
+                "-e",
+                "MYSQL_DATABASE=testdb",
+                "-p",
+                "0:3306",
+                "-v",
+                &format!("{work_str}:/certs:ro"),
+                "-d",
+                &image,
+                "--ssl-ca=/certs/ca.pem",
+                "--ssl-cert=/certs/server.crt",
+                "--ssl-key=/certs/server.key",
+                "--require_secure_transport=OFF",
+            ])
+            .output()?;
+        if !out.status.success() {
+            anyhow::bail!("{}", String::from_utf8_lossy(&out.stderr));
+        }
+
+        let port = loop_port(name)?;
+        let connection_string = format!("mysql://root:testpass@127.0.0.1:{port}/testdb");
+        let this = Self {
+            name: name.to_string(),
+            connection_string,
+            ca_pem: work.join("ca.pem"),
+            _dir: dir,
+        };
+        this.wait_ready().await?;
+        Ok(this)
+    }
+
+    async fn wait_ready(&self) -> Result<()> {
+        let start = Instant::now();
+        while start.elapsed() < Duration::from_secs(120) {
+            if let Ok(pool) = mysql_async::Pool::from_url(&self.connection_string) {
+                if let Ok(mut conn) = pool.get_conn().await {
+                    let ok: Result<Option<i32>, _> = conn.query_first("SELECT 1").await;
+                    drop(conn);
+                    let _ = pool.disconnect().await;
+                    if ok.is_ok() {
+                        return Ok(());
+                    }
+                }
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+        anyhow::bail!("not ready")
+    }
+}
+
+impl Drop for TlsMysql {
+    fn drop(&mut self) {
+        let _ = Command::new("docker")
+            .args(["rm", "-f", &self.name])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+}
+
+fn loop_port(name: &str) -> Result<u16> {
+    for _ in 0..20 {
+        let output = Command::new("docker")
+            .args(["port", name, "3306"])
+            .output()?;
+        if let Some(port) = String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .next()
+            .and_then(|l| l.rsplit(':').next())
+            .and_then(|p| p.trim().parse().ok())
+        {
+            return Ok(port);
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    anyhow::bail!("no port")
+}
+
+#[tokio::test]
+async fn trigger_pool_tls_modes() -> Result<()> {
+    let c = TlsMysql::start("ss-mysql-trigger-tls").await?;
+
+    for ssl in [
+        SslMode::Disabled,
+        SslMode::Preferred(SslOptions {
+            ca: Some(c.ca_pem.to_string_lossy().into_owned()),
+            cert: None,
+            key: None,
+        }),
+        SslMode::required(),
+        SslMode::Required(SslOptions {
+            ca: Some(c.ca_pem.to_string_lossy().into_owned()),
+            cert: None,
+            key: None,
+        }),
+    ] {
+        let pool = new_mysql_pool_with_ssl(&c.connection_string, &ssl)
+            .await
+            .with_context(|| format!("pool for {ssl:?}"))?;
+        let mut conn = pool.get_conn().await?;
+        let _: Option<i32> = conn.query_first("SELECT 1").await?;
+        drop(conn);
+        pool.disconnect().await?;
+    }
+    Ok(())
+}

--- a/crates/mysql-trigger-source/tests/transforms.rs
+++ b/crates/mysql-trigger-source/tests/transforms.rs
@@ -128,6 +128,7 @@ async fn identity_and_external_mutate_incremental() -> Result<()> {
         tables: vec!["people".to_string()],
         mysql_boolean_paths: None,
         id_column_overrides: Default::default(),
+        ssl: Default::default(),
     };
     let from_checkpoint = MySQLCheckpoint {
         sequence_id: 0,
@@ -230,6 +231,7 @@ async fn composite_pk_entity_writes_surreal_array_record_ids() -> Result<()> {
         tables: vec!["ledger".to_string()],
         mysql_boolean_paths: None,
         id_column_overrides: Default::default(),
+        ssl: Default::default(),
     };
     let sync_opts = surreal_sync_mysql_trigger_source::SyncOpts {
         batch_size: 100,
@@ -335,6 +337,7 @@ async fn flatten_id_toml_writes_surreal_text_record_ids() -> Result<()> {
         tables: vec!["ledger".to_string()],
         mysql_boolean_paths: None,
         id_column_overrides: Default::default(),
+        ssl: Default::default(),
     };
     let sync_opts = surreal_sync_mysql_trigger_source::SyncOpts {
         batch_size: 100,

--- a/crates/mysql-types/Cargo.toml
+++ b/crates/mysql-types/Cargo.toml
@@ -9,13 +9,16 @@ license = "MIT"
 sync-core = { path = "../sync-core" }
 json-types = { path = "../json-types" }
 binlog-protocol = { path = "../binlog-protocol" }
-mysql_async = { version = "0.36" }
+mysql_async = { version = "0.36", default-features = false, features = ["default-rustls"] }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.0", features = ["v4", "serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"
 base64 = "0.22"
+anyhow = "1.0.100"
+tracing = "0.1"
+rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs", "std"] }
 
 [dev-dependencies]
 tokio = { version = "1.49", features = ["full"] }

--- a/crates/mysql-types/Cargo.toml
+++ b/crates/mysql-types/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 sync-core = { path = "../sync-core" }
 json-types = { path = "../json-types" }
 binlog-protocol = { path = "../binlog-protocol" }
-mysql_async = { version = "0.36", default-features = false, features = ["default-rustls"] }
+mysql_async = { version = "0.36", default-features = false, features = ["derive", "rustls-tls", "tls12", "aws-lc-rs", "minimal"] }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.0", features = ["v4", "serde"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/mysql-types/src/lib.rs
+++ b/crates/mysql-types/src/lib.rs
@@ -34,6 +34,7 @@ pub mod ddl;
 pub mod forward;
 pub mod reverse;
 pub mod schema;
+pub mod ssl;
 
 pub use binlog::{
     apply_mysql_json_diffs_to_cell, binlog_cell_to_universal_value, BinlogColumnMeta,
@@ -46,3 +47,4 @@ pub use reverse::{
     RowConversionConfig,
 };
 pub use schema::mysql_column_to_universal_type;
+pub use ssl::new_mysql_pool_with_ssl;

--- a/crates/mysql-types/src/ssl.rs
+++ b/crates/mysql-types/src/ssl.rs
@@ -1,0 +1,98 @@
+//! Shared MySQL TLS helpers for `mysql_async` connection pools.
+//!
+//! Maps surreal-sync [`SslMode`] (disabled / preferred / required) onto
+//! `mysql_async::SslOpts` with MySQL-client-compatible semantics.
+
+use std::path::PathBuf;
+
+use anyhow::{bail, Context, Result};
+use binlog_protocol::{SslMode, SslOptions};
+use mysql_async::{Opts, OptsBuilder, Pool, SslOpts};
+use tracing::warn;
+
+/// Build `mysql_async` SSL options from surreal-sync TLS options.
+///
+/// - With a CA path: verify the server against that CA only.
+/// - Without a CA: encrypt without requiring a public-CA match (MySQL REQUIRED).
+fn mysql_async_ssl_opts(options: &SslOptions) -> Result<SslOpts> {
+    let mut ssl = SslOpts::default();
+
+    match (&options.cert, &options.key) {
+        (Some(cert), Some(key)) => {
+            let identity = mysql_async::ClientIdentity::new(
+                PathBuf::from(cert).into(),
+                PathBuf::from(key).into(),
+            );
+            ssl = ssl.with_client_identity(Some(identity));
+        }
+        (None, None) => {}
+        (Some(_), None) | (None, Some(_)) => {
+            bail!("--tls-cert and --tls-key must be provided together");
+        }
+    }
+
+    if let Some(ca) = &options.ca {
+        ssl = ssl
+            .with_root_certs(vec![PathBuf::from(ca).into()])
+            .with_disable_built_in_roots(true);
+    } else {
+        // MySQL `--ssl-mode=REQUIRED`: encrypt without public-CA verification.
+        ssl = ssl
+            .with_danger_accept_invalid_certs(true)
+            .with_danger_skip_domain_validation(true);
+    }
+
+    Ok(ssl)
+}
+
+fn pool_with_ssl(connection_string: &str, options: &SslOptions) -> Result<Pool> {
+    // mysql_async rustls backend needs a process-wide CryptoProvider.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    let base = Opts::from_url(connection_string)
+        .with_context(|| format!("invalid MySQL connection string: {connection_string}"))?;
+    let ssl_opts = mysql_async_ssl_opts(options)?;
+    let opts = OptsBuilder::from_opts(base).ssl_opts(Some(ssl_opts));
+    Ok(Pool::new(opts))
+}
+
+fn pool_plaintext(connection_string: &str) -> Result<Pool> {
+    Pool::from_url(connection_string)
+        .with_context(|| format!("invalid MySQL connection string: {connection_string}"))
+}
+
+/// Create a MySQL pool honouring [`SslMode`].
+///
+/// For [`SslMode::Preferred`], probes an SSL connection and falls back to
+/// plaintext if the TLS handshake fails (MySQL Preferred semantics).
+pub async fn new_mysql_pool_with_ssl(connection_string: &str, ssl: &SslMode) -> Result<Pool> {
+    match ssl {
+        SslMode::Disabled => pool_plaintext(connection_string),
+        SslMode::Required(options) => pool_with_ssl(connection_string, options),
+        SslMode::Preferred(options) => {
+            let pool = pool_with_ssl(connection_string, options)?;
+            match pool.get_conn().await {
+                Ok(_conn) => Ok(pool),
+                Err(e) => {
+                    warn!(
+                        "TLS handshake failed under --tls-mode preferred ({e}); retrying without TLS"
+                    );
+                    pool_plaintext(connection_string)
+                }
+            }
+        }
+    }
+}
+
+/// Synchronous pool builder for callers that cannot await Preferred fallback.
+///
+/// [`SslMode::Preferred`] is treated like Required for the initial pool config
+/// (TLS attempted on first connect). Prefer [`new_mysql_pool_with_ssl`] when
+/// Preferred fallback is required.
+pub fn new_mysql_pool_with_ssl_sync(connection_string: &str, ssl: &SslMode) -> Result<Pool> {
+    match ssl {
+        SslMode::Disabled => pool_plaintext(connection_string),
+        SslMode::Preferred(options) | SslMode::Required(options) => {
+            pool_with_ssl(connection_string, options)
+        }
+    }
+}

--- a/crates/mysql-types/src/ssl.rs
+++ b/crates/mysql-types/src/ssl.rs
@@ -63,11 +63,10 @@ fn pool_plaintext(connection_string: &str) -> Result<Pool> {
 /// Whether a pool connect failure under Preferred should retry without TLS.
 fn is_tls_encryption_failure(err: &mysql_async::Error) -> bool {
     use mysql_async::{DriverError, Error, IoError};
-    match err {
-        Error::Io(IoError::Tls(_)) => true,
-        Error::Driver(DriverError::NoClientSslFlagFromServer) => true,
-        _ => false,
-    }
+    matches!(
+        err,
+        Error::Io(IoError::Tls(_)) | Error::Driver(DriverError::NoClientSslFlagFromServer)
+    )
 }
 
 /// Create a MySQL pool honouring [`SslMode`].

--- a/crates/mysql-types/src/ssl.rs
+++ b/crates/mysql-types/src/ssl.rs
@@ -60,6 +60,16 @@ fn pool_plaintext(connection_string: &str) -> Result<Pool> {
         .with_context(|| format!("invalid MySQL connection string: {connection_string}"))
 }
 
+/// Whether a pool connect failure under Preferred should retry without TLS.
+fn is_tls_encryption_failure(err: &mysql_async::Error) -> bool {
+    use mysql_async::{DriverError, Error, IoError};
+    match err {
+        Error::Io(IoError::Tls(_)) => true,
+        Error::Driver(DriverError::NoClientSslFlagFromServer) => true,
+        _ => false,
+    }
+}
+
 /// Create a MySQL pool honouring [`SslMode`].
 ///
 /// For [`SslMode::Preferred`], probes an SSL connection and falls back to
@@ -72,12 +82,15 @@ pub async fn new_mysql_pool_with_ssl(connection_string: &str, ssl: &SslMode) -> 
             let pool = pool_with_ssl(connection_string, options)?;
             match pool.get_conn().await {
                 Ok(_conn) => Ok(pool),
-                Err(e) => {
+                Err(e) if is_tls_encryption_failure(&e) => {
                     warn!(
                         "TLS handshake failed under --tls-mode preferred ({e}); retrying without TLS"
                     );
                     pool_plaintext(connection_string)
                 }
+                Err(e) => Err(e).with_context(|| {
+                    format!("failed to connect to MySQL with TLS: {connection_string}")
+                }),
             }
         }
     }

--- a/docs/mariadb.md
+++ b/docs/mariadb.md
@@ -22,6 +22,10 @@ You need appropriate permissions to create triggers and tables in the MariaDB da
 
 Every table you select for sync must have a usable primary key (single- or multi-column). Composite PKs become SurrealDB array record IDs (`table:[k1, k2]`) by default; join-table relations stay colon-flattened. Optional `flatten_id` / custom workers: [How sync works — Record IDs](sync-pipeline.md#record-ids-and-composite-primary-keys). `surreal-sync` also writes a small `surreal_sync_signal` table on the source for watermark signalling.
 
+## TLS
+
+Use the same `--tls-mode` / `--tls-ca` / `--tls-cert` / `--tls-key` flags as MySQL trigger sync (MariaDB speaks the MySQL protocol). See [Surreal-Sync for MySQL — TLS](mysql.md#tls).
+
 ## Combined sync
 
 The `sync` command runs the watermark snapshot and continues incremental sync from the handed-off end position in one process — no separate incremental replay pass is needed to reach consistency.

--- a/docs/mariadb.md
+++ b/docs/mariadb.md
@@ -24,7 +24,7 @@ Every table you select for sync must have a usable primary key (single- or multi
 
 ## TLS
 
-Use the same `--tls-mode` / `--tls-ca` / `--tls-cert` / `--tls-key` flags as MySQL trigger sync (MariaDB speaks the MySQL protocol). See [Surreal-Sync for MySQL — TLS](mysql.md#tls).
+MariaDB uses the same `--tls-mode`, `--tls-ca`, `--tls-cert`, and `--tls-key` flags as MySQL trigger sync. See [Surreal-Sync for MySQL — TLS](mysql.md#tls) for mode semantics, preferred fallback, and when to pass a CA. Binlog CDC uses the same flags — see [MySQL Binlog — TLS](mysql-binlog.md#tls-for-mysql-connections).
 
 ## Combined sync
 

--- a/docs/mysql-binlog.md
+++ b/docs/mysql-binlog.md
@@ -226,6 +226,8 @@ Use `--tls-mode` when MySQL is only reachable over an untrusted network (or when
 
 The same flags apply to the SQL connection used for snapshots and to the binlog replication stream.
 
+When `--tls-mode disabled`, `--tls-ca`, `--tls-cert`, and `--tls-key` are ignored.
+
 ### Authentication plugins
 
 MySQL 8 defaults to `caching_sha2_password`. surreal-sync supports the stages of that plugin (and the older `mysql_native_password` plugin) as follows:

--- a/docs/mysql-binlog.md
+++ b/docs/mysql-binlog.md
@@ -210,14 +210,17 @@ binlog_row_image=FULL
 gtid_strict_mode=ON   # recommended
 ```
 
-### TLS for the replication connection
+### TLS for MySQL connections
 
-Provide `--tls-mode` to encrypt the replication connection when the server is reachable only over an untrusted network:
+Use `--tls-mode` when MySQL is only reachable over an untrusted network (or when your server requires encrypted clients):
 
-- `--tls-mode disabled` (default) — plaintext; use only on a trusted network or VPN.
-- `--tls-mode preferred` — use TLS if the server offers it.
-- `--tls-mode required` — require TLS; fail if unavailable.
-- `--tls-ca <PATH>` / `--tls-cert <PATH>` / `--tls-key <PATH>` — verify the server and/or present a client certificate.
+- `--tls-mode disabled` (default) — plain connection. Fine on a trusted network or VPN.
+- `--tls-mode preferred` — try TLS; if the server cannot do TLS (or the handshake fails), continue without encryption.
+- `--tls-mode required` — always use TLS; fail if encryption cannot be established.
+- `--tls-ca <PATH>` — trust this CA when checking the server certificate. Pass this when you want strict verification (for example a private CA). If you omit it, surreal-sync still encrypts in `preferred`/`required` but does not require a public CA match — typical for self-signed lab or Docker MySQL setups.
+- `--tls-cert <PATH>` / `--tls-key <PATH>` — present a client certificate when the server asks for one (both required together).
+
+The same flags apply to the SQL connection used for snapshots and to the binlog replication stream.
 
 ### Authentication plugins
 

--- a/docs/mysql-binlog.md
+++ b/docs/mysql-binlog.md
@@ -215,10 +215,14 @@ gtid_strict_mode=ON   # recommended
 Use `--tls-mode` when MySQL is only reachable over an untrusted network (or when your server requires encrypted clients):
 
 - `--tls-mode disabled` (default) — plain connection. Fine on a trusted network or VPN.
-- `--tls-mode preferred` — try TLS; if the server cannot do TLS (or the handshake fails), continue without encryption.
+- `--tls-mode preferred` — try TLS first; if the server cannot encrypt the connection (or the TLS handshake fails), surreal-sync falls back to a plain connection.
 - `--tls-mode required` — always use TLS; fail if encryption cannot be established.
-- `--tls-ca <PATH>` — trust this CA when checking the server certificate. Pass this when you want strict verification (for example a private CA). If you omit it, surreal-sync still encrypts in `preferred`/`required` but does not require a public CA match — typical for self-signed lab or Docker MySQL setups.
+- `--tls-ca <PATH>` — trust this CA when checking the server certificate. Use this when you need to confirm you are talking to the intended server (private CA, cloud provider CA bundle, etc.).
 - `--tls-cert <PATH>` / `--tls-key <PATH>` — present a client certificate when the server asks for one (both required together).
+
+**Encryption vs verification.** With `preferred` or `required`, surreal-sync encrypts the session even when you omit `--tls-ca`. Without `--tls-ca`, it does **not** verify that the server certificate belongs to the host you expect — the connection is encrypted, but an attacker on the path could present another certificate. On untrusted networks, use `--tls-mode required` **and** pass the CA that signed your server (or your provider’s CA bundle) via `--tls-ca`.
+
+**Connection string hostname.** Put the hostname you expect the server to identify as in `--connection-string` (for example the RDS/Aurora/Cloud SQL endpoint, not only `127.0.0.1` when tunnelling). When you pass `--tls-ca`, that name is checked against the certificate. For managed MySQL, download the provider’s CA file and pass it with `--tls-ca`.
 
 The same flags apply to the SQL connection used for snapshots and to the binlog replication stream.
 

--- a/docs/mysql-binlog.md
+++ b/docs/mysql-binlog.md
@@ -374,10 +374,13 @@ While a `sync` follower is streaming, snapshot additional tables on the fly. The
 surreal-sync from mysql-binlog snapshot \
   --connection-string "$CONNECTION_STRING" \
   --database "myapp" \
-  --tables "new_table,another_table"
+  --tables "new_table,another_table" \
+  --tls-mode required \
+  --tls-ca /path/to/ca.pem
 ```
 
 - `--tables` (required): comma-separated tables to snapshot.
+- TLS flags (`--tls-mode`, `--tls-ca`, `--tls-cert`, `--tls-key`) apply here the same way as on `sync`.
 
 ### Adding tables to a running sync
 

--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -24,17 +24,37 @@ Every table you select for sync must have a usable primary key (single- or multi
 
 ## TLS
 
-Encrypt the MySQL connection with the same flags as binlog sync:
+Use `--tls-mode` when MariaDB is only reachable over an untrusted network (or when your server requires encrypted clients). The same flags work for `sync`, `full`, `incremental`, and ad-hoc `snapshot`:
 
-- `--tls-mode disabled` (default) — plain connection.
-- `--tls-mode preferred` — try TLS first; fall back to plain if encryption cannot be established.
-- `--tls-mode required` — require TLS; fail if encryption cannot be established.
-- `--tls-ca <PATH>` — optional CA file to verify the server certificate. Use on untrusted networks so you know you are connecting to the intended server.
-- `--tls-cert` / `--tls-key` — optional client certificate pair.
+- `--tls-mode disabled` (default) — plain connection. Fine on a trusted network or VPN.
+- `--tls-mode preferred` — try TLS first; if the server cannot encrypt the connection (or the TLS handshake fails), surreal-sync falls back to a plain connection.
+- `--tls-mode required` — always use TLS; fail if encryption cannot be established.
+- `--tls-ca <PATH>` — trust this CA when checking the server certificate. Use this when you need to confirm you are talking to the intended server.
+- `--tls-cert <PATH>` / `--tls-key <PATH>` — present a client certificate when the server asks for one (both required together).
 
-Without `--tls-ca`, `required` and `preferred` still encrypt the session but do not verify the server identity — fine for local Docker or self-signed lab setups, risky on public networks. Use `--tls-ca` with the hostname you expect in `--connection-string` (your cloud endpoint, not a tunnel alias) when connecting to managed MySQL.
+**Encryption vs verification.** With `preferred` or `required`, surreal-sync encrypts the session even when you omit `--tls-ca`. Without `--tls-ca`, it does **not** verify that the server certificate belongs to the host you expect — the connection is encrypted, but an attacker on the path could present another certificate. On untrusted networks, use `--tls-mode required` **and** pass the CA that signed your server via `--tls-ca`.
 
-The same flags apply to snapshot signalling and streaming.
+**Connection string hostname.** Put the hostname you expect the server to identify as in `--connection-string` (for example your MariaDB cloud endpoint, not only `127.0.0.1` when tunnelling). When you pass `--tls-ca`, that name is checked against the certificate.
+
+Example with TLS on combined sync and snapshot signalling:
+
+```bash
+surreal-sync from mysql sync \
+  --connection-string "$CONNECTION_STRING" \
+  --database "myapp" \
+  --tls-mode required \
+  --tls-ca /path/to/ca.pem \
+  ...
+
+surreal-sync from mysql snapshot \
+  --connection-string "$CONNECTION_STRING" \
+  --database "myapp" \
+  --tables "new_table" \
+  --tls-mode required \
+  --tls-ca /path/to/ca.pem
+```
+
+For binlog CDC (recommended for MariaDB), see [Surreal-Sync for MySQL Binlog — TLS](mysql-binlog.md#tls-for-mysql-connections).
 
 ## Combined sync
 

--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -27,10 +27,14 @@ Every table you select for sync must have a usable primary key (single- or multi
 Encrypt the MySQL connection with the same flags as binlog sync:
 
 - `--tls-mode disabled` (default) — plain connection.
-- `--tls-mode preferred` — try TLS; fall back to plain if TLS is unavailable.
-- `--tls-mode required` — require TLS.
-- `--tls-ca <PATH>` — optional CA file for strict server verification. Omit it to encrypt without requiring a public CA (common for self-signed Docker MySQL).
+- `--tls-mode preferred` — try TLS first; fall back to plain if encryption cannot be established.
+- `--tls-mode required` — require TLS; fail if encryption cannot be established.
+- `--tls-ca <PATH>` — optional CA file to verify the server certificate. Use on untrusted networks so you know you are connecting to the intended server.
 - `--tls-cert` / `--tls-key` — optional client certificate pair.
+
+Without `--tls-ca`, `required` and `preferred` still encrypt the session but do not verify the server identity — fine for local Docker or self-signed lab setups, risky on public networks. Use `--tls-ca` with the hostname you expect in `--connection-string` (your cloud endpoint, not a tunnel alias) when connecting to managed MySQL.
+
+The same flags apply to snapshot signalling and streaming.
 
 ## Combined sync
 

--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -22,6 +22,16 @@ You need appropriate permissions to create triggers and tables in the MySQL data
 
 Every table you select for sync must have a usable primary key (single- or multi-column). Composite PKs become SurrealDB array record IDs (`table:[k1, k2]`) by default; join-table relations stay colon-flattened. Optional `flatten_id` / custom workers: [How sync works — Record IDs](sync-pipeline.md#record-ids-and-composite-primary-keys). `surreal-sync` also writes a small `surreal_sync_signal` table on the source for watermark signalling.
 
+## TLS
+
+Encrypt the MySQL connection with the same flags as binlog sync:
+
+- `--tls-mode disabled` (default) — plain connection.
+- `--tls-mode preferred` — try TLS; fall back to plain if TLS is unavailable.
+- `--tls-mode required` — require TLS.
+- `--tls-ca <PATH>` — optional CA file for strict server verification. Omit it to encrypt without requiring a public CA (common for self-signed Docker MySQL).
+- `--tls-cert` / `--tls-key` — optional client certificate pair.
+
 ## Combined sync
 
 The `sync` command runs the watermark snapshot and continues incremental sync from the handed-off end position in one process — no separate incremental replay pass is needed to reach consistency.

--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -56,6 +56,8 @@ surreal-sync from mysql snapshot \
 
 For binlog CDC (recommended for MariaDB), see [Surreal-Sync for MySQL Binlog — TLS](mysql-binlog.md#tls-for-mysql-connections).
 
+When `--tls-mode disabled`, `--tls-ca`, `--tls-cert`, and `--tls-key` are ignored.
+
 ## Combined sync
 
 The `sync` command runs the watermark snapshot and continues incremental sync from the handed-off end position in one process — no separate incremental replay pass is needed to reach consistency.

--- a/src/from/mysql.rs
+++ b/src/from/mysql.rs
@@ -68,6 +68,7 @@ async fn run_full_v2(args: MySQLFullArgs) -> anyhow::Result<()> {
         tables: args.tables,
         mysql_boolean_paths: args.boolean_paths,
         id_column_overrides: Default::default(),
+        ssl: args.tls.trigger_ssl_mode(),
     };
 
     let sync_opts = surreal_sync_mysql_trigger_source::SyncOpts {
@@ -164,6 +165,7 @@ async fn run_full_v3(args: MySQLFullArgs) -> anyhow::Result<()> {
         tables: args.tables,
         mysql_boolean_paths: args.boolean_paths,
         id_column_overrides: Default::default(),
+        ssl: args.tls.trigger_ssl_mode(),
     };
 
     let sync_opts = surreal_sync_mysql_trigger_source::SyncOpts {
@@ -315,6 +317,7 @@ async fn run_incremental_v2(args: MySQLIncrementalArgs) -> anyhow::Result<()> {
         tables: args.tables,
         mysql_boolean_paths: args.boolean_paths,
         id_column_overrides: Default::default(),
+        ssl: args.tls.trigger_ssl_mode(),
     };
 
     // Connect to SurrealDB using v2 SDK
@@ -367,6 +370,7 @@ async fn mysql_snapshot_full<S, St>(
     connection_string: String,
     database: Option<String>,
     chunk_size: usize,
+    ssl: surreal_sync_mysql_trigger_source::SslMode,
     manager: Option<&SyncManager<St>>,
     transforms: &SnapshotTransforms,
 ) -> anyhow::Result<()>
@@ -374,7 +378,8 @@ where
     S: SurrealSink,
     St: CheckpointStore,
 {
-    let pool = surreal_sync_mysql_trigger_source::new_mysql_pool(&connection_string)?;
+    let pool = surreal_sync_mysql_trigger_source::new_mysql_pool_with_ssl(&connection_string, &ssl)
+        .await?;
     let database = resolve_mysql_database(&pool, &database).await?;
     let config = InterleavedSnapshotConfig { chunk_size };
     let mut checkpointer = NoopCheckpointer;
@@ -433,6 +438,7 @@ async fn run_full_interleaved_snapshot_v2(args: MySQLFullArgs) -> anyhow::Result
                 args.connection_string,
                 args.database,
                 args.chunk_size,
+                args.tls.trigger_ssl_mode(),
                 Some(&manager),
                 &transforms,
             )
@@ -454,6 +460,7 @@ async fn run_full_interleaved_snapshot_v2(args: MySQLFullArgs) -> anyhow::Result
                 args.connection_string,
                 args.database,
                 args.chunk_size,
+                args.tls.trigger_ssl_mode(),
                 Some(&manager),
                 &transforms,
             )
@@ -465,6 +472,7 @@ async fn run_full_interleaved_snapshot_v2(args: MySQLFullArgs) -> anyhow::Result
                 args.connection_string,
                 args.database,
                 args.chunk_size,
+                args.tls.trigger_ssl_mode(),
                 None,
                 &transforms,
             )
@@ -504,6 +512,7 @@ async fn run_full_interleaved_snapshot_v3(args: MySQLFullArgs) -> anyhow::Result
                 args.connection_string,
                 args.database,
                 args.chunk_size,
+                args.tls.trigger_ssl_mode(),
                 Some(&manager),
                 &transforms,
             )
@@ -519,6 +528,7 @@ async fn run_full_interleaved_snapshot_v3(args: MySQLFullArgs) -> anyhow::Result
                 args.connection_string,
                 args.database,
                 args.chunk_size,
+                args.tls.trigger_ssl_mode(),
                 Some(&manager),
                 &transforms,
             )
@@ -530,6 +540,7 @@ async fn run_full_interleaved_snapshot_v3(args: MySQLFullArgs) -> anyhow::Result
                 args.connection_string,
                 args.database,
                 args.chunk_size,
+                args.tls.trigger_ssl_mode(),
                 None,
                 &transforms,
             )
@@ -603,7 +614,11 @@ async fn mysql_orchestrate<S: SurrealSink>(
     pipeline: Pipeline,
     apply_opts: ApplyOpts,
 ) -> anyhow::Result<()> {
-    let pool = surreal_sync_mysql_trigger_source::new_mysql_pool(&args.connection_string)?;
+    let pool = surreal_sync_mysql_trigger_source::new_mysql_pool_with_ssl(
+        &args.connection_string,
+        &args.tls.trigger_ssl_mode(),
+    )
+    .await?;
     let database = resolve_mysql_database(&pool, &args.database).await?;
     let config = InterleavedSnapshotConfig {
         chunk_size: args.chunk_size,
@@ -623,6 +638,7 @@ async fn mysql_orchestrate<S: SurrealSink>(
         tables: args.tables.clone(),
         mysql_boolean_paths: args.boolean_paths.clone(),
         id_column_overrides,
+        ssl: args.tls.trigger_ssl_mode(),
     };
 
     let transforms = SnapshotTransforms {
@@ -667,7 +683,11 @@ async fn mysql_orchestrate<S: SurrealSink>(
 /// Emit an ad-hoc `execute-snapshot` signal so a running `sync` snapshots the
 /// requested tables.
 pub async fn run_snapshot_signal(args: MySQLSnapshotArgs) -> anyhow::Result<()> {
-    let pool = surreal_sync_mysql_trigger_source::new_mysql_pool(&args.connection_string)?;
+    let pool = surreal_sync_mysql_trigger_source::new_mysql_pool_with_ssl(
+        &args.connection_string,
+        &args.tls.trigger_ssl_mode(),
+    )
+    .await?;
     let database = resolve_mysql_database(&pool, &args.database).await?;
     surreal_sync_mysql_trigger_source::request_snapshot(pool, database, &args.tables).await?;
     tracing::info!(
@@ -745,6 +765,7 @@ async fn run_incremental_v3(args: MySQLIncrementalArgs) -> anyhow::Result<()> {
         tables: args.tables,
         mysql_boolean_paths: args.boolean_paths,
         id_column_overrides: Default::default(),
+        ssl: args.tls.trigger_ssl_mode(),
     };
 
     // Connect to SurrealDB using v3 SDK

--- a/src/from/mysql_binlog.rs
+++ b/src/from/mysql_binlog.rs
@@ -10,7 +10,7 @@ use checkpoint::{Checkpoint, CheckpointStore, SyncManager};
 use surreal_sink::SurrealSink;
 use surreal_sync_interleaved_snapshot::SnapshotTransforms;
 use surreal_sync_mysql_binlog_source::{
-    request_snapshot, run_full_sync_cancellable_with_transforms,
+    new_mysql_pool_with_ssl, request_snapshot, run_full_sync_cancellable_with_transforms,
     run_initial_interleaved_snapshot_with_transforms,
     run_interleaved_snapshot_full_sync_with_transforms, run_replication_tail_with_transforms,
     BinlogCheckpoint, InterleavedFullSyncOptions, ReplicationTailOptions, SourceOpts, SyncOpts,
@@ -506,7 +506,7 @@ where
 /// Emit an ad-hoc execute-snapshot signal so a running `sync` snapshots the
 /// requested tables.
 pub async fn run_snapshot_signal(args: MySQLBinlogSnapshotArgs) -> anyhow::Result<()> {
-    let pool = mysql_async::Pool::from_url(&args.connection_string)?;
+    let pool = new_mysql_pool_with_ssl(&args.connection_string, &args.tls.ssl_mode()).await?;
     let database = resolve_mysql_database(&pool, &args.database).await?;
     request_snapshot(&pool, &database, &args.tables).await?;
     tracing::info!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -960,15 +960,15 @@ struct MySQLTlsArgs {
     #[arg(long, value_enum, default_value_t = MySQLTlsModeArg::default())]
     tls_mode: MySQLTlsModeArg,
 
-    /// PEM CA bundle used to verify the MySQL server certificate
+    /// PEM CA bundle used to verify the MySQL server certificate (ignored when `--tls-mode disabled`)
     #[arg(long, value_name = "PATH")]
     tls_ca: Option<String>,
 
-    /// PEM client certificate for MySQL TLS client auth
+    /// PEM client certificate for MySQL TLS client auth (ignored when `--tls-mode disabled`)
     #[arg(long, value_name = "PATH")]
     tls_cert: Option<String>,
 
-    /// PEM private key for MySQL TLS client auth
+    /// PEM private key for MySQL TLS client auth (ignored when `--tls-mode disabled`; requires `--tls-cert`)
     #[arg(long, value_name = "PATH")]
     tls_key: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1158,6 +1158,9 @@ struct MySQLBinlogSnapshotArgs {
     /// Tables to snapshot (comma-separated)
     #[arg(long, value_delimiter = ',', required = true)]
     tables: Vec<String>,
+
+    #[command(flatten)]
+    tls: MySQLTlsArgs,
 }
 
 // =============================================================================

--- a/src/main.rs
+++ b/src/main.rs
@@ -763,6 +763,9 @@ struct MySQLFullArgs {
     transforms_config: Option<PathBuf>,
 
     #[command(flatten)]
+    tls: MySQLTlsArgs,
+
+    #[command(flatten)]
     surreal: SurrealOpts,
 }
 
@@ -819,6 +822,9 @@ struct MySQLIncrementalArgs {
     transforms_config: Option<PathBuf>,
 
     #[command(flatten)]
+    tls: MySQLTlsArgs,
+
+    #[command(flatten)]
     surreal: SurrealOpts,
 }
 
@@ -872,6 +878,9 @@ struct MySQLSyncArgs {
     id_columns: Vec<String>,
 
     #[command(flatten)]
+    tls: MySQLTlsArgs,
+
+    #[command(flatten)]
     surreal: SurrealOpts,
 }
 
@@ -890,6 +899,9 @@ struct MySQLSnapshotArgs {
     /// Tables to snapshot (comma-separated)
     #[arg(long, value_delimiter = ',', required = true)]
     tables: Vec<String>,
+
+    #[command(flatten)]
+    tls: MySQLTlsArgs,
 }
 
 // =============================================================================
@@ -933,9 +945,9 @@ impl From<MariaDbGtidStrictModeArg> for surreal_sync_mysql_binlog_source::MariaD
     }
 }
 
-/// TLS behavior for the raw MySQL binlog replication connection.
+/// TLS behavior for MySQL/MariaDB SQL and binlog connections.
 #[derive(Clone, Copy, Debug, Default, ValueEnum)]
-enum MySQLBinlogTlsModeArg {
+enum MySQLTlsModeArg {
     #[default]
     Disabled,
     Preferred,
@@ -943,10 +955,10 @@ enum MySQLBinlogTlsModeArg {
 }
 
 #[derive(Clone, Debug, Args, Default)]
-struct MySQLBinlogTlsArgs {
-    /// TLS mode for the raw binlog replication connection
-    #[arg(long, value_enum, default_value_t = MySQLBinlogTlsModeArg::default())]
-    tls_mode: MySQLBinlogTlsModeArg,
+struct MySQLTlsArgs {
+    /// TLS mode for MySQL connections (`disabled`, `preferred`, or `required`)
+    #[arg(long, value_enum, default_value_t = MySQLTlsModeArg::default())]
+    tls_mode: MySQLTlsModeArg,
 
     /// PEM CA bundle used to verify the MySQL server certificate
     #[arg(long, value_name = "PATH")]
@@ -961,7 +973,7 @@ struct MySQLBinlogTlsArgs {
     tls_key: Option<String>,
 }
 
-impl MySQLBinlogTlsArgs {
+impl MySQLTlsArgs {
     fn ssl_mode(&self) -> surreal_sync_mysql_binlog_source::SslMode {
         let options = surreal_sync_mysql_binlog_source::SslOptions {
             ca: self.tls_ca.clone(),
@@ -969,12 +981,38 @@ impl MySQLBinlogTlsArgs {
             key: self.tls_key.clone(),
         };
         match self.tls_mode {
-            MySQLBinlogTlsModeArg::Disabled => surreal_sync_mysql_binlog_source::SslMode::Disabled,
-            MySQLBinlogTlsModeArg::Preferred => {
+            MySQLTlsModeArg::Disabled => surreal_sync_mysql_binlog_source::SslMode::Disabled,
+            MySQLTlsModeArg::Preferred => {
                 surreal_sync_mysql_binlog_source::SslMode::Preferred(options)
             }
-            MySQLBinlogTlsModeArg::Required => {
+            MySQLTlsModeArg::Required => {
                 surreal_sync_mysql_binlog_source::SslMode::Required(options)
+            }
+        }
+    }
+
+    fn trigger_ssl_mode(&self) -> surreal_sync_mysql_trigger_source::SslMode {
+        match self.ssl_mode() {
+            surreal_sync_mysql_binlog_source::SslMode::Disabled => {
+                surreal_sync_mysql_trigger_source::SslMode::Disabled
+            }
+            surreal_sync_mysql_binlog_source::SslMode::Preferred(o) => {
+                surreal_sync_mysql_trigger_source::SslMode::Preferred(
+                    surreal_sync_mysql_trigger_source::SslOptions {
+                        ca: o.ca,
+                        cert: o.cert,
+                        key: o.key,
+                    },
+                )
+            }
+            surreal_sync_mysql_binlog_source::SslMode::Required(o) => {
+                surreal_sync_mysql_trigger_source::SslMode::Required(
+                    surreal_sync_mysql_trigger_source::SslOptions {
+                        ca: o.ca,
+                        cert: o.cert,
+                        key: o.key,
+                    },
+                )
             }
         }
     }
@@ -1028,7 +1066,7 @@ struct MySQLBinlogSyncArgs {
     mariadb_gtid_strict_mode: MariaDbGtidStrictModeArg,
 
     #[command(flatten)]
-    tls: MySQLBinlogTlsArgs,
+    tls: MySQLTlsArgs,
 
     /// Target SurrealDB namespace
     #[arg(long)]
@@ -1853,8 +1891,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn mysql_binlog_tls_args_default_to_disabled() {
-        let args = MySQLBinlogTlsArgs::default();
+    fn mysql_tls_args_default_to_disabled() {
+        let args = MySQLTlsArgs::default();
         assert!(matches!(
             args.ssl_mode(),
             surreal_sync_mysql_binlog_source::SslMode::Disabled
@@ -1862,9 +1900,9 @@ mod tests {
     }
 
     #[test]
-    fn mysql_binlog_tls_args_preserve_ca_and_client_cert_paths() {
-        let args = MySQLBinlogTlsArgs {
-            tls_mode: MySQLBinlogTlsModeArg::Required,
+    fn mysql_tls_args_preserve_ca_and_client_cert_paths() {
+        let args = MySQLTlsArgs {
+            tls_mode: MySQLTlsModeArg::Required,
             tls_ca: Some("ca.pem".to_string()),
             tls_cert: Some("client.pem".to_string()),
             tls_key: Some("client-key.pem".to_string()),

--- a/src/testing/mysql_e2e.rs
+++ b/src/testing/mysql_e2e.rs
@@ -47,6 +47,7 @@ pub async fn run_full_sync_e2e(
             "all_types_users.metadata=settings.notifications".to_string()
         ]),
         id_column_overrides: Default::default(),
+        ssl: Default::default(),
     };
 
     let sync_opts = surreal_sync_mysql_trigger_source::SyncOpts {
@@ -123,6 +124,7 @@ pub async fn run_incremental_e2e(
         tables: vec![],
         mysql_boolean_paths: Some(vec!["all_types_posts.post_categories".to_string()]),
         id_column_overrides: Default::default(),
+        ssl: Default::default(),
     };
 
     let sync_opts = surreal_sync_mysql_trigger_source::SyncOpts {

--- a/tests/loadtest/mysql_incremental_loadtest.rs
+++ b/tests/loadtest/mysql_incremental_loadtest.rs
@@ -101,6 +101,7 @@ async fn test_mysql_incremental_loadtest_small_scale() -> Result<(), Box<dyn std
         tables: vec![],
         mysql_boolean_paths: None,
         id_column_overrides: Default::default(),
+        ssl: Default::default(),
     };
 
     let sync_opts = surreal_sync_mysql_trigger_source::SyncOpts {

--- a/tests/loadtest/mysql_loadtest.rs
+++ b/tests/loadtest/mysql_loadtest.rs
@@ -110,6 +110,7 @@ async fn test_mysql_loadtest_small_scale() -> Result<(), Box<dyn std::error::Err
         tables: vec![],
         mysql_boolean_paths: None,
         id_column_overrides: Default::default(),
+        ssl: Default::default(),
     };
 
     let sync_opts = surreal_sync_mysql_trigger_source::SyncOpts {


### PR DESCRIPTION
Binlog source already had `--tls-mode` options, but `preferred` and `required` often failed with typical self-signed MySQL setups, and trigger sync plus snapshots had no TLS settings.

This makes the three modes behave as users expect (including falling back to plain when `preferred` can’t encrypt), applies the same flags across MySQL/MariaDB trigger sync, binlog sync, and snapshots.

Intends to cover `--tls-mode` issues mentioned in #121 