### PR TITLE
Cleaner library types for custom transforms

### DIFF
--- a/crates/csv-source/src/sync.rs
+++ b/crates/csv-source/src/sync.rs
@@ -8,9 +8,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use surreal_sink::SurrealSink;
 use surreal_sync_file::{FileSource, ResolvedSource, DEFAULT_BUFFER_SIZE};
-use sync_core::{
-    GeneratorTableDefinition, Schema, TypedValue, UniversalRow, UniversalType, UniversalValue,
-};
+use sync_core::{GeneratorTableDefinition, Row, Schema, Type, TypedValue, Value};
 use sync_transform::{
     run_source_runtime, ApplyOpts, CheckpointPolicy, Pipeline, PositionedEvent, SourceDriver,
     SourceRuntimeOpts,
@@ -49,7 +47,7 @@ pub struct Config {
     pub id_field: Option<String>,
 
     /// Optional multi-column record ID fields (takes precedence over `id_field`).
-    /// When two or more are set, the ID is an [`UniversalValue::Array`].
+    /// When two or more are set, the ID is an [`Value::Array`].
     pub id_columns: Vec<String>,
 
     /// Optional column names when has_headers is false
@@ -93,7 +91,7 @@ impl Default for Config {
 ///
 /// When a schema is provided, this function parses values based on their declared type.
 /// Uses the unified json-types crate for type conversion.
-fn parse_value_with_schema(value: &str, schema_type: Option<&UniversalType>) -> TypedValue {
+fn parse_value_with_schema(value: &str, schema_type: Option<&Type>) -> TypedValue {
     if let Some(data_type) = schema_type {
         // Use json-types for schema-aware conversion
         match csv_string_to_typed_value(value, data_type) {
@@ -115,25 +113,19 @@ struct DryRunSink;
 
 #[async_trait::async_trait]
 impl SurrealSink for DryRunSink {
-    async fn write_universal_rows(&self, _rows: &[UniversalRow]) -> Result<()> {
+    async fn write_rows(&self, _rows: &[Row]) -> Result<()> {
         Ok(())
     }
 
-    async fn write_universal_relations(
-        &self,
-        _relations: &[sync_core::UniversalRelation],
-    ) -> Result<()> {
+    async fn write_relations(&self, _relations: &[sync_core::Relation]) -> Result<()> {
         Ok(())
     }
 
-    async fn apply_universal_change(&self, _change: &sync_core::UniversalChange) -> Result<()> {
+    async fn apply_change(&self, _change: &sync_core::Change) -> Result<()> {
         Ok(())
     }
 
-    async fn apply_universal_relation_change(
-        &self,
-        _change: &sync_core::UniversalRelationChange,
-    ) -> Result<()> {
+    async fn apply_relation_change(&self, _change: &sync_core::RelationChange) -> Result<()> {
         Ok(())
     }
 }
@@ -194,29 +186,29 @@ impl CsvStreamDriver {
 
         let id_cols = self.effective_id_columns();
         let id_value = if id_cols.is_empty() {
-            UniversalValue::Ulid(ulid::Ulid::new())
+            Value::Ulid(ulid::Ulid::new())
         } else if id_cols.len() == 1 {
             data.get(&id_cols[0])
                 .map(|tv| tv.value.clone())
-                .unwrap_or_else(|| UniversalValue::Ulid(ulid::Ulid::new()))
+                .unwrap_or_else(|| Value::Ulid(ulid::Ulid::new()))
         } else {
             let mut parts = Vec::with_capacity(id_cols.len());
             for col in &id_cols {
                 let part = data
                     .get(col)
                     .map(|tv| tv.value.clone())
-                    .unwrap_or(UniversalValue::Null);
+                    .unwrap_or(Value::Null);
                 parts.push(part);
             }
             sync_core::build_composite_record_id(parts)
         };
 
-        let fields: HashMap<String, UniversalValue> =
+        let fields: HashMap<String, Value> =
             data.into_iter().map(|(k, tv)| (k, tv.value)).collect();
-        let row = UniversalRow::new(self.table.clone(), self.record_count, id_value, fields);
+        let row = Row::new(self.table.clone(), self.record_count, id_value, fields);
         let pos = self.record_count;
         self.record_count = self.record_count.saturating_add(1);
-        let change = sync_core::UniversalChange::update(row.table, row.id, row.fields);
+        let change = sync_core::Change::update(row.table, row.id, row.fields);
         Ok(PositionedEvent::change(change, pos))
     }
 }
@@ -523,7 +515,7 @@ mod tests {
     use std::io::Write;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
-    use sync_core::{UniversalChange, UniversalRelation};
+    use sync_core::{Change, Relation};
     use tempfile::NamedTempFile;
 
     /// Mock SurrealDB sink for testing
@@ -545,26 +537,23 @@ mod tests {
 
     #[async_trait::async_trait]
     impl SurrealSink for MockSink {
-        async fn write_universal_rows(&self, rows: &[UniversalRow]) -> anyhow::Result<()> {
+        async fn write_rows(&self, rows: &[Row]) -> anyhow::Result<()> {
             self.rows_written.fetch_add(rows.len(), Ordering::SeqCst);
             Ok(())
         }
 
-        async fn write_universal_relations(
-            &self,
-            _relations: &[UniversalRelation],
-        ) -> anyhow::Result<()> {
+        async fn write_relations(&self, _relations: &[Relation]) -> anyhow::Result<()> {
             Ok(())
         }
 
-        async fn apply_universal_change(&self, _change: &UniversalChange) -> anyhow::Result<()> {
+        async fn apply_change(&self, _change: &Change) -> anyhow::Result<()> {
             self.rows_written.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
 
-        async fn apply_universal_relation_change(
+        async fn apply_relation_change(
             &self,
-            _change: &sync_core::UniversalRelationChange,
+            _change: &sync_core::RelationChange,
         ) -> anyhow::Result<()> {
             Ok(())
         }
@@ -605,19 +594,19 @@ mod tests {
 
     #[test]
     fn test_parse_value_with_schema_int() {
-        let result = parse_value_with_schema("42", Some(&UniversalType::Int32));
+        let result = parse_value_with_schema("42", Some(&Type::Int32));
         assert_eq!(result.value.as_i32(), Some(42));
     }
 
     #[test]
     fn test_parse_value_with_schema_bool() {
-        let result = parse_value_with_schema("true", Some(&UniversalType::Bool));
+        let result = parse_value_with_schema("true", Some(&Type::Bool));
         assert_eq!(result.value.as_bool(), Some(true));
     }
 
     #[test]
     fn test_parse_value_with_schema_text() {
-        let result = parse_value_with_schema("hello", Some(&UniversalType::Text));
+        let result = parse_value_with_schema("hello", Some(&Type::Text));
         assert_eq!(result.value.as_str(), Some("hello"));
     }
 

--- a/crates/csv-source/tests/transforms.rs
+++ b/crates/csv-source/tests/transforms.rs
@@ -9,12 +9,12 @@ use std::sync::Mutex;
 
 use surreal_sink::SurrealSink;
 use surreal_sync_csv_source::{sync, sync_with_transforms, Config};
-use sync_core::{UniversalChange, UniversalRelation, UniversalRow, UniversalValue};
+use sync_core::{Change, Relation, Row, Value};
 use sync_transform::{ApplyOpts, ChildStdioMode, ExternalTransform, FramerKind, Pipeline};
 use tempfile::NamedTempFile;
 
 struct CaptureSink {
-    rows: Mutex<Vec<UniversalRow>>,
+    rows: Mutex<Vec<Row>>,
     rows_written: Arc<AtomicUsize>,
 }
 
@@ -27,31 +27,28 @@ impl CaptureSink {
     }
 }
 
-fn change_to_row(change: &UniversalChange, index: u64) -> UniversalRow {
-    UniversalRow::new(
+fn change_to_row(change: &Change, index: u64) -> Row {
+    Row::new(
         change.table.clone(),
         index,
         change.id.clone(),
-        change.data.clone().unwrap_or_default(),
+        change.fields.clone().unwrap_or_default(),
     )
 }
 
 #[async_trait::async_trait]
 impl SurrealSink for CaptureSink {
-    async fn write_universal_rows(&self, rows: &[UniversalRow]) -> anyhow::Result<()> {
+    async fn write_rows(&self, rows: &[Row]) -> anyhow::Result<()> {
         self.rows_written.fetch_add(rows.len(), Ordering::SeqCst);
         self.rows.lock().expect("lock").extend(rows.iter().cloned());
         Ok(())
     }
 
-    async fn write_universal_relations(
-        &self,
-        _relations: &[UniversalRelation],
-    ) -> anyhow::Result<()> {
+    async fn write_relations(&self, _relations: &[Relation]) -> anyhow::Result<()> {
         Ok(())
     }
 
-    async fn apply_universal_change(&self, change: &UniversalChange) -> anyhow::Result<()> {
+    async fn apply_change(&self, change: &Change) -> anyhow::Result<()> {
         let mut rows = self.rows.lock().expect("lock");
         let index = rows.len() as u64;
         rows.push(change_to_row(change, index));
@@ -59,9 +56,9 @@ impl SurrealSink for CaptureSink {
         Ok(())
     }
 
-    async fn apply_universal_relation_change(
+    async fn apply_relation_change(
         &self,
-        _change: &sync_core::UniversalRelationChange,
+        _change: &sync_core::RelationChange,
     ) -> anyhow::Result<()> {
         Ok(())
     }
@@ -99,9 +96,9 @@ fn ensure_fixture_worker() -> PathBuf {
     path
 }
 
-fn row_name(row: &UniversalRow) -> Option<String> {
+fn row_name(row: &Row) -> Option<String> {
     match row.fields.get("name")? {
-        UniversalValue::Text(value) => Some(value.clone()),
+        Value::Text(value) => Some(value.clone()),
         other => panic!("unexpected name: {other:?}"),
     }
 }
@@ -200,7 +197,7 @@ async fn composite_id_columns_emit_array_ids() {
     assert_eq!(rows.len(), 2);
     for row in &rows {
         match &row.id {
-            UniversalValue::Array { elements, .. } => {
+            Value::Array { elements, .. } => {
                 assert_eq!(elements.len(), 2);
             }
             other => panic!("expected Array id, got {other:?}"),
@@ -210,12 +207,12 @@ async fn composite_id_columns_emit_array_ids() {
     let keys: Vec<Vec<String>> = rows
         .iter()
         .map(|r| match &r.id {
-            UniversalValue::Array { elements, .. } => elements
+            Value::Array { elements, .. } => elements
                 .iter()
                 .map(|e| match e {
-                    UniversalValue::Text(s)
-                    | UniversalValue::VarChar { value: s, .. }
-                    | UniversalValue::Char { value: s, .. } => s.clone(),
+                    Value::Text(s)
+                    | Value::VarChar { value: s, .. }
+                    | Value::Char { value: s, .. } => s.clone(),
                     other => panic!("unexpected id part: {other:?}"),
                 })
                 .collect(),
@@ -260,5 +257,5 @@ type = "flatten_id"
 
     let rows = sink.rows.lock().expect("lock").clone();
     assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0].id, UniversalValue::Text("a:b".into()));
+    assert_eq!(rows[0].id, Value::Text("a:b".into()));
 }

--- a/crates/csv-types/src/forward.rs
+++ b/crates/csv-types/src/forward.rs
@@ -3,7 +3,7 @@
 //! This module provides conversion from sync-core's `TypedValue` to CSV string values.
 
 use base64::Engine;
-use sync_core::{TypedValue, UniversalValue};
+use sync_core::{TypedValue, Value};
 
 /// Wrapper for CSV string values.
 #[derive(Debug, Clone)]
@@ -27,93 +27,89 @@ impl From<TypedValue> for CsvValue {
     }
 }
 
-impl From<UniversalValue> for CsvValue {
-    fn from(value: UniversalValue) -> Self {
+impl From<Value> for CsvValue {
+    fn from(value: Value) -> Self {
         match value {
             // Null - empty string
-            UniversalValue::Null => CsvValue(String::new()),
+            Value::Null => CsvValue(String::new()),
 
             // Boolean
-            UniversalValue::Bool(b) => CsvValue(if b {
+            Value::Bool(b) => CsvValue(if b {
                 "true".to_string()
             } else {
                 "false".to_string()
             }),
 
             // Integer types
-            UniversalValue::Int8 { value, .. } => CsvValue(value.to_string()),
-            UniversalValue::Int16(i) => CsvValue(i.to_string()),
-            UniversalValue::Int32(i) => CsvValue(i.to_string()),
-            UniversalValue::Int64(i) => CsvValue(i.to_string()),
+            Value::Int8 { value, .. } => CsvValue(value.to_string()),
+            Value::Int16(i) => CsvValue(i.to_string()),
+            Value::Int32(i) => CsvValue(i.to_string()),
+            Value::Int64(i) => CsvValue(i.to_string()),
 
             // Floating point
-            UniversalValue::Float32(f) => CsvValue(f.to_string()),
-            UniversalValue::Float64(f) => CsvValue(f.to_string()),
+            Value::Float32(f) => CsvValue(f.to_string()),
+            Value::Float64(f) => CsvValue(f.to_string()),
 
             // Decimal - preserve as-is (no precision check needed for CSV)
-            UniversalValue::Decimal { value, .. } => CsvValue(value),
+            Value::Decimal { value, .. } => CsvValue(value),
 
             // String types
-            UniversalValue::Char { value, .. } => CsvValue(value),
-            UniversalValue::VarChar { value, .. } => CsvValue(value),
-            UniversalValue::Text(s) => CsvValue(s),
+            Value::Char { value, .. } => CsvValue(value),
+            Value::VarChar { value, .. } => CsvValue(value),
+            Value::Text(s) => CsvValue(s),
 
             // Binary types - base64 encode
-            UniversalValue::Blob(b) => {
+            Value::Blob(b) => {
                 let encoded = base64::engine::general_purpose::STANDARD.encode(b);
                 CsvValue(encoded)
             }
-            UniversalValue::Bytes(b) => {
+            Value::Bytes(b) => {
                 let encoded = base64::engine::general_purpose::STANDARD.encode(b);
                 CsvValue(encoded)
             }
 
             // Date/time types - ISO 8601 format
-            UniversalValue::Date(dt) => CsvValue(dt.format("%Y-%m-%d").to_string()),
+            Value::Date(dt) => CsvValue(dt.format("%Y-%m-%d").to_string()),
             // Note: Using "%H:%M:%S%.f" to preserve fractional seconds from PostgreSQL TIME type.
-            UniversalValue::Time(dt) => CsvValue(dt.format("%H:%M:%S%.f").to_string()),
-            UniversalValue::LocalDateTime(dt) => CsvValue(dt.to_rfc3339()),
-            UniversalValue::LocalDateTimeNano(dt) => CsvValue(dt.to_rfc3339()),
-            UniversalValue::ZonedDateTime(dt) => CsvValue(dt.to_rfc3339()),
+            Value::Time(dt) => CsvValue(dt.format("%H:%M:%S%.f").to_string()),
+            Value::LocalDateTime(dt) => CsvValue(dt.to_rfc3339()),
+            Value::LocalDateTimeNano(dt) => CsvValue(dt.to_rfc3339()),
+            Value::ZonedDateTime(dt) => CsvValue(dt.to_rfc3339()),
             // TIMETZ - stored as string to preserve timezone format
-            UniversalValue::TimeTz(s) => CsvValue(s),
+            Value::TimeTz(s) => CsvValue(s),
 
             // UUID
-            UniversalValue::Uuid(u) => CsvValue(u.to_string()),
+            Value::Uuid(u) => CsvValue(u.to_string()),
 
             // ULID
-            UniversalValue::Ulid(u) => CsvValue(u.to_string()),
+            Value::Ulid(u) => CsvValue(u.to_string()),
 
             // JSON types - serialize as JSON string
-            UniversalValue::Json(payload) => {
-                CsvValue(serde_json::to_string(&*payload).unwrap_or_default())
-            }
-            UniversalValue::Jsonb(payload) => {
-                CsvValue(serde_json::to_string(&*payload).unwrap_or_default())
-            }
+            Value::Json(payload) => CsvValue(serde_json::to_string(&*payload).unwrap_or_default()),
+            Value::Jsonb(payload) => CsvValue(serde_json::to_string(&*payload).unwrap_or_default()),
 
             // Array types - serialize as JSON array
-            UniversalValue::Array { elements, .. } => {
+            Value::Array { elements, .. } => {
                 let json_arr: Vec<serde_json::Value> =
                     elements.iter().map(generated_value_to_json).collect();
                 CsvValue(serde_json::to_string(&json_arr).unwrap_or_default())
             }
 
             // Set - comma-separated values
-            UniversalValue::Set { elements, .. } => CsvValue(elements.join(",")),
+            Value::Set { elements, .. } => CsvValue(elements.join(",")),
 
             // Enum - string value
-            UniversalValue::Enum { value, .. } => CsvValue(value),
+            Value::Enum { value, .. } => CsvValue(value),
 
-            // Geometry types - serialize as GeoJSON (includes geometry_type from UniversalValue)
-            UniversalValue::Geometry { data, .. } => {
+            // Geometry types - serialize as GeoJSON (includes geometry_type from Value)
+            Value::Geometry { data, .. } => {
                 use sync_core::values::GeometryData;
                 let GeometryData(value) = data;
                 CsvValue(serde_json::to_string(&value).unwrap_or_default())
             }
 
             // Duration - format as ISO 8601 duration string
-            UniversalValue::Duration(d) => {
+            Value::Duration(d) => {
                 let secs = d.as_secs();
                 let nanos = d.subsec_nanos();
                 if nanos == 0 {
@@ -124,12 +120,12 @@ impl From<UniversalValue> for CsvValue {
             }
 
             // Thing - record reference as "table:id" format
-            UniversalValue::Thing { table, id } => {
+            Value::Thing { table, id } => {
                 let id_str = match id.as_ref() {
-                    UniversalValue::Text(s) => s.clone(),
-                    UniversalValue::Int32(i) => i.to_string(),
-                    UniversalValue::Int64(i) => i.to_string(),
-                    UniversalValue::Uuid(u) => u.to_string(),
+                    Value::Text(s) => s.clone(),
+                    Value::Int32(i) => i.to_string(),
+                    Value::Int64(i) => i.to_string(),
+                    Value::Uuid(u) => u.to_string(),
                     other => panic!(
                         "Unsupported Thing ID type: {other:?}. \
                          Supported types: Text, Int32, Int64, Uuid"
@@ -139,7 +135,7 @@ impl From<UniversalValue> for CsvValue {
             }
 
             // Object - nested document, serialize as JSON
-            UniversalValue::Object(map) => {
+            Value::Object(map) => {
                 let obj: serde_json::Map<String, serde_json::Value> = map
                     .into_iter()
                     .map(|(k, v)| (k, generated_value_to_json(&v)))
@@ -147,61 +143,60 @@ impl From<UniversalValue> for CsvValue {
                 CsvValue(serde_json::to_string(&serde_json::Value::Object(obj)).unwrap_or_default())
             }
 
-            UniversalValue::ZeroTemporal {
+            Value::ZeroTemporal {
                 intended_type,
                 source,
             } => {
-                let s = source.unwrap_or_else(|| {
-                    UniversalValue::canonical_zero_literal(&intended_type).to_string()
-                });
+                let s = source
+                    .unwrap_or_else(|| Value::canonical_zero_literal(&intended_type).to_string());
                 CsvValue(s)
             }
         }
     }
 }
 
-/// Convert a UniversalValue to JSON.
-fn generated_value_to_json(value: &UniversalValue) -> serde_json::Value {
+/// Convert a Value to JSON.
+fn generated_value_to_json(value: &Value) -> serde_json::Value {
     match value {
-        UniversalValue::Null => serde_json::Value::Null,
-        UniversalValue::Bool(b) => serde_json::json!(*b),
-        UniversalValue::Int8 { value, .. } => serde_json::json!(*value),
-        UniversalValue::Int16(i) => serde_json::json!(*i),
-        UniversalValue::Int32(i) => serde_json::json!(*i),
-        UniversalValue::Int64(i) => serde_json::json!(*i),
-        UniversalValue::Float32(f) => serde_json::json!(*f),
-        UniversalValue::Float64(f) => serde_json::json!(*f),
-        UniversalValue::Char { value, .. } => serde_json::json!(value),
-        UniversalValue::VarChar { value, .. } => serde_json::json!(value),
-        UniversalValue::Text(s) => serde_json::json!(s),
-        UniversalValue::Blob(b) | UniversalValue::Bytes(b) => {
+        Value::Null => serde_json::Value::Null,
+        Value::Bool(b) => serde_json::json!(*b),
+        Value::Int8 { value, .. } => serde_json::json!(*value),
+        Value::Int16(i) => serde_json::json!(*i),
+        Value::Int32(i) => serde_json::json!(*i),
+        Value::Int64(i) => serde_json::json!(*i),
+        Value::Float32(f) => serde_json::json!(*f),
+        Value::Float64(f) => serde_json::json!(*f),
+        Value::Char { value, .. } => serde_json::json!(value),
+        Value::VarChar { value, .. } => serde_json::json!(value),
+        Value::Text(s) => serde_json::json!(s),
+        Value::Blob(b) | Value::Bytes(b) => {
             let encoded = base64::engine::general_purpose::STANDARD.encode(b);
             serde_json::json!(encoded)
         }
-        UniversalValue::Uuid(u) => serde_json::json!(u.to_string()),
-        UniversalValue::Ulid(u) => serde_json::json!(u.to_string()),
-        UniversalValue::Date(dt) => serde_json::json!(dt.format("%Y-%m-%d").to_string()),
-        UniversalValue::Time(dt) => serde_json::json!(dt.format("%H:%M:%S%.f").to_string()),
-        UniversalValue::LocalDateTime(dt)
-        | UniversalValue::LocalDateTimeNano(dt)
-        | UniversalValue::ZonedDateTime(dt) => serde_json::json!(dt.to_rfc3339()),
-        UniversalValue::TimeTz(s) => serde_json::json!(s),
-        UniversalValue::Decimal { value, .. } => serde_json::json!(value),
-        UniversalValue::Array { elements, .. } => {
+        Value::Uuid(u) => serde_json::json!(u.to_string()),
+        Value::Ulid(u) => serde_json::json!(u.to_string()),
+        Value::Date(dt) => serde_json::json!(dt.format("%Y-%m-%d").to_string()),
+        Value::Time(dt) => serde_json::json!(dt.format("%H:%M:%S%.f").to_string()),
+        Value::LocalDateTime(dt) | Value::LocalDateTimeNano(dt) | Value::ZonedDateTime(dt) => {
+            serde_json::json!(dt.to_rfc3339())
+        }
+        Value::TimeTz(s) => serde_json::json!(s),
+        Value::Decimal { value, .. } => serde_json::json!(value),
+        Value::Array { elements, .. } => {
             serde_json::json!(elements
                 .iter()
                 .map(generated_value_to_json)
                 .collect::<Vec<_>>())
         }
-        UniversalValue::Set { elements, .. } => serde_json::json!(elements),
-        UniversalValue::Enum { value, .. } => serde_json::json!(value),
-        UniversalValue::Json(payload) | UniversalValue::Jsonb(payload) => (**payload).clone(),
-        UniversalValue::Geometry { data, .. } => {
+        Value::Set { elements, .. } => serde_json::json!(elements),
+        Value::Enum { value, .. } => serde_json::json!(value),
+        Value::Json(payload) | Value::Jsonb(payload) => (**payload).clone(),
+        Value::Geometry { data, .. } => {
             use sync_core::values::GeometryData;
             let GeometryData(value) = data;
             value.clone()
         }
-        UniversalValue::Duration(d) => {
+        Value::Duration(d) => {
             let secs = d.as_secs();
             let nanos = d.subsec_nanos();
             if nanos == 0 {
@@ -210,12 +205,12 @@ fn generated_value_to_json(value: &UniversalValue) -> serde_json::Value {
                 serde_json::json!(format!("PT{secs}.{nanos:09}S"))
             }
         }
-        UniversalValue::Thing { table, id } => {
+        Value::Thing { table, id } => {
             let id_str = match id.as_ref() {
-                UniversalValue::Text(s) => s.clone(),
-                UniversalValue::Int32(i) => i.to_string(),
-                UniversalValue::Int64(i) => i.to_string(),
-                UniversalValue::Uuid(u) => u.to_string(),
+                Value::Text(s) => s.clone(),
+                Value::Int32(i) => i.to_string(),
+                Value::Int64(i) => i.to_string(),
+                Value::Uuid(u) => u.to_string(),
                 other => panic!(
                     "Unsupported Thing ID type: {other:?}. \
                      Supported types: Text, Int32, Int64, Uuid"
@@ -223,20 +218,20 @@ fn generated_value_to_json(value: &UniversalValue) -> serde_json::Value {
             };
             serde_json::json!(format!("{table}:{id_str}"))
         }
-        UniversalValue::Object(map) => {
+        Value::Object(map) => {
             let obj: serde_json::Map<String, serde_json::Value> = map
                 .iter()
                 .map(|(k, v)| (k.clone(), generated_value_to_json(v)))
                 .collect();
             serde_json::Value::Object(obj)
         }
-        UniversalValue::ZeroTemporal {
+        Value::ZeroTemporal {
             intended_type,
             source,
         } => {
             let s = source
                 .as_deref()
-                .unwrap_or_else(|| UniversalValue::canonical_zero_literal(intended_type));
+                .unwrap_or_else(|| Value::canonical_zero_literal(intended_type));
             serde_json::Value::String(s.to_string())
         }
     }
@@ -289,11 +284,11 @@ where
 mod tests {
     use super::*;
     use chrono::{TimeZone, Utc};
-    use sync_core::UniversalType;
+    use sync_core::Type;
 
     #[test]
     fn test_null_conversion() {
-        let tv = TypedValue::null(UniversalType::Text);
+        let tv = TypedValue::null(Type::Text);
         let csv_val: CsvValue = tv.into();
         assert_eq!(csv_val.0, "");
     }

--- a/crates/csv-types/src/lib.rs
+++ b/crates/csv-types/src/lib.rs
@@ -12,14 +12,14 @@
 //!
 //! ```ignore
 //! use csv_types::{CsvValue, CsvStringWithSchema};
-//! use sync_core::{TypedValue, UniversalType};
+//! use sync_core::{TypedValue, Type};
 //!
 //! // Forward: TypedValue → CSV string
 //! let tv = TypedValue::text("hello");
 //! let csv_val: CsvValue = tv.into();
 //!
 //! // Reverse: CSV string → TypedValue
-//! let csv_str = CsvStringWithSchema::new("42", &UniversalType::Int32);
+//! let csv_str = CsvStringWithSchema::new("42", &Type::Int32);
 //! let tv = csv_str.to_typed_value().unwrap();
 //! ```
 

--- a/crates/csv-types/src/reverse.rs
+++ b/crates/csv-types/src/reverse.rs
@@ -4,7 +4,7 @@
 
 use base64::Engine;
 use chrono::{NaiveDate, NaiveTime, TimeZone, Utc};
-use sync_core::{TypedValue, UniversalType, UniversalValue};
+use sync_core::{Type, TypedValue, Value};
 
 /// A CSV string with schema information for reverse conversion.
 ///
@@ -15,12 +15,12 @@ pub struct CsvStringWithSchema<'a> {
     /// The CSV string value
     pub value: &'a str,
     /// The target schema type
-    pub schema_type: &'a UniversalType,
+    pub schema_type: &'a Type,
 }
 
 impl<'a> CsvStringWithSchema<'a> {
     /// Create a new CSV string with schema.
-    pub fn new(value: &'a str, schema_type: &'a UniversalType) -> Self {
+    pub fn new(value: &'a str, schema_type: &'a Type) -> Self {
         Self { value, schema_type }
     }
 
@@ -55,7 +55,7 @@ impl std::error::Error for CsvParseError {}
 /// This is the reverse of `CsvValue::from(TypedValue)`.
 pub fn csv_string_to_typed_value(
     value: &str,
-    schema_type: &UniversalType,
+    schema_type: &Type,
 ) -> Result<TypedValue, CsvParseError> {
     // Handle empty string as null for most types
     if value.is_empty() {
@@ -64,7 +64,7 @@ pub fn csv_string_to_typed_value(
 
     match schema_type {
         // Boolean - lenient parsing
-        UniversalType::Bool => match value.to_lowercase().as_str() {
+        Type::Bool => match value.to_lowercase().as_str() {
             "true" | "1" | "yes" | "t" | "y" => Ok(TypedValue::bool(true)),
             "false" | "0" | "no" | "f" | "n" => Ok(TypedValue::bool(false)),
             _ => Err(CsvParseError {
@@ -75,14 +75,14 @@ pub fn csv_string_to_typed_value(
         },
 
         // TinyInt with width 1 - treat as boolean (MySQL pattern)
-        UniversalType::Int8 { width: 1 } => match value.to_lowercase().as_str() {
+        Type::Int8 { width: 1 } => match value.to_lowercase().as_str() {
             "true" | "1" | "yes" | "t" | "y" => Ok(TypedValue {
                 sync_type: schema_type.clone(),
-                value: UniversalValue::Bool(true),
+                value: Value::Bool(true),
             }),
             "false" | "0" | "no" | "f" | "n" => Ok(TypedValue {
                 sync_type: schema_type.clone(),
-                value: UniversalValue::Bool(false),
+                value: Value::Bool(false),
             }),
             _ => Err(CsvParseError {
                 message: "Invalid boolean value".to_string(),
@@ -92,7 +92,7 @@ pub fn csv_string_to_typed_value(
         },
 
         // Integer types - strict 1:1 matching
-        UniversalType::Int8 { width } => match value.parse::<i8>() {
+        Type::Int8 { width } => match value.parse::<i8>() {
             Ok(i) => Ok(TypedValue::int8(i, *width)),
             Err(_) => Err(CsvParseError {
                 message: "Invalid tinyint".to_string(),
@@ -100,7 +100,7 @@ pub fn csv_string_to_typed_value(
                 expected_type: "TinyInt".to_string(),
             }),
         },
-        UniversalType::Int16 => match value.parse::<i16>() {
+        Type::Int16 => match value.parse::<i16>() {
             Ok(i) => Ok(TypedValue::int16(i)),
             Err(_) => Err(CsvParseError {
                 message: "Invalid smallint".to_string(),
@@ -108,7 +108,7 @@ pub fn csv_string_to_typed_value(
                 expected_type: "SmallInt".to_string(),
             }),
         },
-        UniversalType::Int32 => match value.parse::<i32>() {
+        Type::Int32 => match value.parse::<i32>() {
             Ok(i) => Ok(TypedValue::int32(i)),
             Err(_) => Err(CsvParseError {
                 message: "Invalid integer".to_string(),
@@ -117,7 +117,7 @@ pub fn csv_string_to_typed_value(
             }),
         },
 
-        UniversalType::Int64 => match value.parse::<i64>() {
+        Type::Int64 => match value.parse::<i64>() {
             Ok(i) => Ok(TypedValue::int64(i)),
             Err(_) => Err(CsvParseError {
                 message: "Invalid bigint".to_string(),
@@ -127,7 +127,7 @@ pub fn csv_string_to_typed_value(
         },
 
         // Float types - strict 1:1 matching
-        UniversalType::Float32 => match value.parse::<f32>() {
+        Type::Float32 => match value.parse::<f32>() {
             Ok(f) => Ok(TypedValue::float32(f)),
             Err(_) => Err(CsvParseError {
                 message: "Invalid float".to_string(),
@@ -135,7 +135,7 @@ pub fn csv_string_to_typed_value(
                 expected_type: "Float".to_string(),
             }),
         },
-        UniversalType::Float64 => match value.parse::<f64>() {
+        Type::Float64 => match value.parse::<f64>() {
             Ok(f) => Ok(TypedValue::float64(f)),
             Err(_) => Err(CsvParseError {
                 message: "Invalid double".to_string(),
@@ -145,7 +145,7 @@ pub fn csv_string_to_typed_value(
         },
 
         // Decimal
-        UniversalType::Decimal { precision, scale } => {
+        Type::Decimal { precision, scale } => {
             // Validate it's a valid decimal format
             if value.parse::<f64>().is_ok()
                 || value
@@ -163,12 +163,12 @@ pub fn csv_string_to_typed_value(
         }
 
         // String types - strict 1:1 matching
-        UniversalType::Char { length } => Ok(TypedValue::char_type(value, *length)),
-        UniversalType::VarChar { length } => Ok(TypedValue::varchar(value, *length)),
-        UniversalType::Text => Ok(TypedValue::text(value)),
+        Type::Char { length } => Ok(TypedValue::char_type(value, *length)),
+        Type::VarChar { length } => Ok(TypedValue::varchar(value, *length)),
+        Type::Text => Ok(TypedValue::text(value)),
 
         // Binary types - strict 1:1 matching
-        UniversalType::Blob => match base64::engine::general_purpose::STANDARD.decode(value) {
+        Type::Blob => match base64::engine::general_purpose::STANDARD.decode(value) {
             Ok(bytes) => Ok(TypedValue::blob(bytes)),
             Err(_) => Err(CsvParseError {
                 message: "Invalid base64".to_string(),
@@ -176,7 +176,7 @@ pub fn csv_string_to_typed_value(
                 expected_type: "Blob".to_string(),
             }),
         },
-        UniversalType::Bytes => match base64::engine::general_purpose::STANDARD.decode(value) {
+        Type::Bytes => match base64::engine::general_purpose::STANDARD.decode(value) {
             Ok(bytes) => Ok(TypedValue::bytes(bytes)),
             Err(_) => Err(CsvParseError {
                 message: "Invalid base64".to_string(),
@@ -186,7 +186,7 @@ pub fn csv_string_to_typed_value(
         },
 
         // Date - strict 1:1 matching
-        UniversalType::Date => match NaiveDate::parse_from_str(value, "%Y-%m-%d") {
+        Type::Date => match NaiveDate::parse_from_str(value, "%Y-%m-%d") {
             Ok(date) => {
                 let dt = date.and_hms_opt(0, 0, 0).unwrap();
                 Ok(TypedValue::date(Utc.from_utc_datetime(&dt)))
@@ -199,7 +199,7 @@ pub fn csv_string_to_typed_value(
         },
 
         // Time - strict 1:1 matching
-        UniversalType::Time => {
+        Type::Time => {
             match NaiveTime::parse_from_str(value, "%H:%M:%S") {
                 Ok(time) => {
                     // Use epoch date as placeholder
@@ -217,7 +217,7 @@ pub fn csv_string_to_typed_value(
         }
 
         // DateTime types - strict 1:1 matching
-        UniversalType::LocalDateTime => {
+        Type::LocalDateTime => {
             // Try RFC3339 first
             if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(value) {
                 return Ok(TypedValue::datetime(dt.with_timezone(&Utc)));
@@ -236,7 +236,7 @@ pub fn csv_string_to_typed_value(
                 expected_type: "DateTime".to_string(),
             })
         }
-        UniversalType::LocalDateTimeNano => {
+        Type::LocalDateTimeNano => {
             if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(value) {
                 return Ok(TypedValue::datetime_nano(dt.with_timezone(&Utc)));
             }
@@ -252,7 +252,7 @@ pub fn csv_string_to_typed_value(
                 expected_type: "DateTimeNano".to_string(),
             })
         }
-        UniversalType::ZonedDateTime => {
+        Type::ZonedDateTime => {
             if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(value) {
                 return Ok(TypedValue::timestamptz(dt.with_timezone(&Utc)));
             }
@@ -270,7 +270,7 @@ pub fn csv_string_to_typed_value(
         }
 
         // UUID
-        UniversalType::Uuid => match uuid::Uuid::parse_str(value) {
+        Type::Uuid => match uuid::Uuid::parse_str(value) {
             Ok(uuid) => Ok(TypedValue::uuid(uuid)),
             Err(_) => Err(CsvParseError {
                 message: "Invalid UUID".to_string(),
@@ -280,7 +280,7 @@ pub fn csv_string_to_typed_value(
         },
 
         // ULID
-        UniversalType::Ulid => match ulid::Ulid::from_string(value) {
+        Type::Ulid => match ulid::Ulid::from_string(value) {
             Ok(ulid) => Ok(TypedValue::ulid(ulid)),
             Err(_) => Err(CsvParseError {
                 message: "Invalid ULID".to_string(),
@@ -290,60 +290,56 @@ pub fn csv_string_to_typed_value(
         },
 
         // JSON types - parse JSON string
-        UniversalType::Json | UniversalType::Jsonb => {
-            match serde_json::from_str::<serde_json::Value>(value) {
-                Ok(json) => {
-                    let gen_value = json_to_generated_value(&json);
-                    Ok(TypedValue {
-                        sync_type: schema_type.clone(),
-                        value: gen_value,
-                    })
-                }
-                Err(_) => Err(CsvParseError {
-                    message: "Invalid JSON".to_string(),
-                    value: value.to_string(),
-                    expected_type: "Json".to_string(),
-                }),
+        Type::Json | Type::Jsonb => match serde_json::from_str::<serde_json::Value>(value) {
+            Ok(json) => {
+                let gen_value = json_to_generated_value(&json);
+                Ok(TypedValue {
+                    sync_type: schema_type.clone(),
+                    value: gen_value,
+                })
             }
-        }
+            Err(_) => Err(CsvParseError {
+                message: "Invalid JSON".to_string(),
+                value: value.to_string(),
+                expected_type: "Json".to_string(),
+            }),
+        },
 
         // Array types - parse JSON array with element type coercion
-        UniversalType::Array { element_type } => {
-            match serde_json::from_str::<serde_json::Value>(value) {
-                Ok(serde_json::Value::Array(arr)) => {
-                    let items: Result<Vec<UniversalValue>, CsvParseError> = arr
-                        .into_iter()
-                        .map(|item| {
-                            let item_str = match &item {
-                                serde_json::Value::String(s) => s.clone(),
-                                other => other.to_string(),
-                            };
-                            csv_string_to_typed_value(&item_str, element_type).map(|tv| tv.value)
-                        })
-                        .collect();
-                    Ok(TypedValue {
-                        sync_type: schema_type.clone(),
-                        value: UniversalValue::Array {
-                            elements: items?,
-                            element_type: element_type.clone(),
-                        },
+        Type::Array { element_type } => match serde_json::from_str::<serde_json::Value>(value) {
+            Ok(serde_json::Value::Array(arr)) => {
+                let items: Result<Vec<Value>, CsvParseError> = arr
+                    .into_iter()
+                    .map(|item| {
+                        let item_str = match &item {
+                            serde_json::Value::String(s) => s.clone(),
+                            other => other.to_string(),
+                        };
+                        csv_string_to_typed_value(&item_str, element_type).map(|tv| tv.value)
                     })
-                }
-                Ok(_) => Err(CsvParseError {
-                    message: "Expected JSON array".to_string(),
-                    value: value.to_string(),
-                    expected_type: "Array".to_string(),
-                }),
-                Err(_) => Err(CsvParseError {
-                    message: "Invalid JSON array".to_string(),
-                    value: value.to_string(),
-                    expected_type: "Array".to_string(),
-                }),
+                    .collect();
+                Ok(TypedValue {
+                    sync_type: schema_type.clone(),
+                    value: Value::Array {
+                        elements: items?,
+                        element_type: element_type.clone(),
+                    },
+                })
             }
-        }
+            Ok(_) => Err(CsvParseError {
+                message: "Expected JSON array".to_string(),
+                value: value.to_string(),
+                expected_type: "Array".to_string(),
+            }),
+            Err(_) => Err(CsvParseError {
+                message: "Invalid JSON array".to_string(),
+                value: value.to_string(),
+                expected_type: "Array".to_string(),
+            }),
+        },
 
         // Set type - strict 1:1 matching
-        UniversalType::Set {
+        Type::Set {
             values: allowed_values,
         } => {
             let items: Vec<String> = value.split(',').map(|s| s.trim().to_string()).collect();
@@ -351,10 +347,10 @@ pub fn csv_string_to_typed_value(
         }
 
         // Enum - strict 1:1 matching
-        UniversalType::Enum { values } => Ok(TypedValue::enum_type(value, values.clone())),
+        Type::Enum { values } => Ok(TypedValue::enum_type(value, values.clone())),
 
         // Geometry types - strict 1:1 matching
-        UniversalType::Geometry { geometry_type } => {
+        Type::Geometry { geometry_type } => {
             match serde_json::from_str::<serde_json::Value>(value) {
                 Ok(json) => Ok(TypedValue::geometry_geojson(json, geometry_type.clone())),
                 Err(_) => Err(CsvParseError {
@@ -365,7 +361,7 @@ pub fn csv_string_to_typed_value(
             }
         }
 
-        UniversalType::Duration => {
+        Type::Duration => {
             // Parse ISO 8601 duration format (e.g., "PT1H30M45S")
             // For simplicity, we only support "PTxS" or "PTx.xxxxxxxxxS" format
             let trimmed = value.trim();
@@ -401,13 +397,13 @@ pub fn csv_string_to_typed_value(
         }
 
         // Thing - parse "table:id" format
-        UniversalType::Thing => {
+        Type::Thing => {
             if let Some((table, id_part)) = value.split_once(':') {
                 Ok(TypedValue {
-                    sync_type: UniversalType::Thing,
-                    value: UniversalValue::Thing {
+                    sync_type: Type::Thing,
+                    value: Value::Thing {
                         table: table.to_string(),
-                        id: Box::new(UniversalValue::Text(id_part.to_string())),
+                        id: Box::new(Value::Text(id_part.to_string())),
                     },
                 })
             } else {
@@ -420,7 +416,7 @@ pub fn csv_string_to_typed_value(
         }
 
         // Object - parse JSON object
-        UniversalType::Object => {
+        Type::Object => {
             let json: serde_json::Value =
                 serde_json::from_str(value).map_err(|e| CsvParseError {
                     message: format!("Invalid JSON for Object: {e}"),
@@ -429,13 +425,13 @@ pub fn csv_string_to_typed_value(
                 })?;
 
             if let serde_json::Value::Object(obj) = json {
-                let map: std::collections::HashMap<String, UniversalValue> = obj
+                let map: std::collections::HashMap<String, Value> = obj
                     .into_iter()
                     .map(|(k, v)| (k, json_to_generated_value(&v)))
                     .collect();
                 Ok(TypedValue {
-                    sync_type: UniversalType::Object,
-                    value: UniversalValue::Object(map),
+                    sync_type: Type::Object,
+                    value: Value::Object(map),
                 })
             } else {
                 Err(CsvParseError {
@@ -450,34 +446,34 @@ pub fn csv_string_to_typed_value(
         // Note: We intentionally use String instead of DateTime because time and datetime
         // are fundamentally different types. DateTime implies a specific point in time,
         // while time with timezone represents a daily recurring time in a specific timezone.
-        UniversalType::TimeTz => Ok(TypedValue {
-            sync_type: UniversalType::TimeTz,
-            value: UniversalValue::TimeTz(value.to_string()),
+        Type::TimeTz => Ok(TypedValue {
+            sync_type: Type::TimeTz,
+            value: Value::TimeTz(value.to_string()),
         }),
     }
 }
 
-/// Convert a serde_json::Value to UniversalValue.
-fn json_to_generated_value(json: &serde_json::Value) -> UniversalValue {
+/// Convert a serde_json::Value to Value.
+fn json_to_generated_value(json: &serde_json::Value) -> Value {
     match json {
-        serde_json::Value::Null => UniversalValue::Null,
-        serde_json::Value::Bool(b) => UniversalValue::Bool(*b),
+        serde_json::Value::Null => Value::Null,
+        serde_json::Value::Bool(b) => Value::Bool(*b),
         serde_json::Value::Number(n) => {
             if let Some(i) = n.as_i64() {
-                UniversalValue::Int64(i)
+                Value::Int64(i)
             } else if let Some(f) = n.as_f64() {
-                UniversalValue::Float64(f)
+                Value::Float64(f)
             } else {
-                UniversalValue::Text(n.to_string())
+                Value::Text(n.to_string())
             }
         }
-        serde_json::Value::String(s) => UniversalValue::Text(s.clone()),
-        serde_json::Value::Array(arr) => UniversalValue::Array {
+        serde_json::Value::String(s) => Value::Text(s.clone()),
+        serde_json::Value::Array(arr) => Value::Array {
             elements: arr.iter().map(json_to_generated_value).collect(),
-            element_type: Box::new(UniversalType::Text),
+            element_type: Box::new(Type::Text),
         },
         serde_json::Value::Object(obj) => {
-            UniversalValue::Json(Box::new(serde_json::Value::Object(obj.clone())))
+            Value::Json(Box::new(serde_json::Value::Object(obj.clone())))
         }
     }
 }
@@ -487,7 +483,7 @@ fn json_to_generated_value(json: &serde_json::Value) -> UniversalValue {
 /// Tries to parse as: number, boolean, then falls back to string.
 pub fn csv_string_to_typed_value_inferred(value: &str) -> TypedValue {
     if value.is_empty() {
-        return TypedValue::null(UniversalType::Text);
+        return TypedValue::null(Type::Text);
     }
 
     // Try integer
@@ -517,14 +513,14 @@ mod tests {
 
     #[test]
     fn test_reverse_null() {
-        let result = csv_string_to_typed_value("", &UniversalType::Text).unwrap();
+        let result = csv_string_to_typed_value("", &Type::Text).unwrap();
         assert!(result.is_null());
     }
 
     #[test]
     fn test_reverse_bool_true() {
         for input in &["true", "TRUE", "1", "yes", "YES", "t", "T", "y", "Y"] {
-            let result = csv_string_to_typed_value(input, &UniversalType::Bool).unwrap();
+            let result = csv_string_to_typed_value(input, &Type::Bool).unwrap();
             assert_eq!(
                 result.value.as_bool(),
                 Some(true),
@@ -536,7 +532,7 @@ mod tests {
     #[test]
     fn test_reverse_bool_false() {
         for input in &["false", "FALSE", "0", "no", "NO", "f", "F", "n", "N"] {
-            let result = csv_string_to_typed_value(input, &UniversalType::Bool).unwrap();
+            let result = csv_string_to_typed_value(input, &Type::Bool).unwrap();
             assert_eq!(
                 result.value.as_bool(),
                 Some(false),
@@ -547,19 +543,19 @@ mod tests {
 
     #[test]
     fn test_reverse_int() {
-        let result = csv_string_to_typed_value("12345", &UniversalType::Int32).unwrap();
+        let result = csv_string_to_typed_value("12345", &Type::Int32).unwrap();
         assert_eq!(result.value.as_i32(), Some(12345));
     }
 
     #[test]
     fn test_reverse_bigint() {
-        let result = csv_string_to_typed_value("9876543210", &UniversalType::Int64).unwrap();
+        let result = csv_string_to_typed_value("9876543210", &Type::Int64).unwrap();
         assert_eq!(result.value.as_i64(), Some(9876543210i64));
     }
 
     #[test]
     fn test_reverse_float() {
-        let result = csv_string_to_typed_value("1.23", &UniversalType::Float64).unwrap();
+        let result = csv_string_to_typed_value("1.23", &Type::Float64).unwrap();
         assert!((result.value.as_f64().unwrap() - 1.23).abs() < 0.001);
     }
 
@@ -567,21 +563,21 @@ mod tests {
     fn test_reverse_decimal() {
         let result = csv_string_to_typed_value(
             "123.45",
-            &UniversalType::Decimal {
+            &Type::Decimal {
                 precision: 10,
                 scale: 2,
             },
         )
         .unwrap();
         match &result.value {
-            UniversalValue::Decimal { value, .. } => assert_eq!(value, "123.45"),
+            Value::Decimal { value, .. } => assert_eq!(value, "123.45"),
             _ => panic!("Expected Decimal"),
         }
     }
 
     #[test]
     fn test_reverse_text() {
-        let result = csv_string_to_typed_value("hello world", &UniversalType::Text).unwrap();
+        let result = csv_string_to_typed_value("hello world", &Type::Text).unwrap();
         assert_eq!(result.value.as_str(), Some("hello world"));
     }
 
@@ -589,15 +585,14 @@ mod tests {
     fn test_reverse_bytes() {
         let encoded =
             base64::engine::general_purpose::STANDARD.encode(vec![0xDE, 0xAD, 0xBE, 0xEF]);
-        let result = csv_string_to_typed_value(&encoded, &UniversalType::Bytes).unwrap();
+        let result = csv_string_to_typed_value(&encoded, &Type::Bytes).unwrap();
         assert_eq!(result.value.as_bytes(), Some(&[0xDE, 0xAD, 0xBE, 0xEF][..]));
     }
 
     #[test]
     fn test_reverse_uuid() {
         let result =
-            csv_string_to_typed_value("550e8400-e29b-41d4-a716-446655440000", &UniversalType::Uuid)
-                .unwrap();
+            csv_string_to_typed_value("550e8400-e29b-41d4-a716-446655440000", &Type::Uuid).unwrap();
         assert_eq!(
             result.value.as_uuid().unwrap().to_string(),
             "550e8400-e29b-41d4-a716-446655440000"
@@ -606,8 +601,8 @@ mod tests {
 
     #[test]
     fn test_reverse_date() {
-        let result = csv_string_to_typed_value("2024-06-15", &UniversalType::Date).unwrap();
-        if let UniversalValue::Date(dt) = result.value {
+        let result = csv_string_to_typed_value("2024-06-15", &Type::Date).unwrap();
+        if let Value::Date(dt) = result.value {
             assert_eq!(dt.format("%Y-%m-%d").to_string(), "2024-06-15");
         } else {
             panic!("Expected Date, got {:?}", result.value);
@@ -616,8 +611,8 @@ mod tests {
 
     #[test]
     fn test_reverse_time() {
-        let result = csv_string_to_typed_value("14:30:45", &UniversalType::Time).unwrap();
-        if let UniversalValue::Time(dt) = result.value {
+        let result = csv_string_to_typed_value("14:30:45", &Type::Time).unwrap();
+        if let Value::Time(dt) = result.value {
             assert_eq!(dt.format("%H:%M:%S").to_string(), "14:30:45");
         } else {
             panic!("Expected Time, got {:?}", result.value);
@@ -627,8 +622,7 @@ mod tests {
     #[test]
     fn test_reverse_datetime_rfc3339() {
         let result =
-            csv_string_to_typed_value("2024-06-15T10:30:00+00:00", &UniversalType::LocalDateTime)
-                .unwrap();
+            csv_string_to_typed_value("2024-06-15T10:30:00+00:00", &Type::LocalDateTime).unwrap();
         let dt = result.value.as_datetime().unwrap();
         assert_eq!(
             dt.format("%Y-%m-%dT%H:%M:%S").to_string(),
@@ -639,8 +633,7 @@ mod tests {
     #[test]
     fn test_reverse_datetime_no_timezone() {
         let result =
-            csv_string_to_typed_value("2024-06-15T10:30:00", &UniversalType::LocalDateTime)
-                .unwrap();
+            csv_string_to_typed_value("2024-06-15T10:30:00", &Type::LocalDateTime).unwrap();
         let dt = result.value.as_datetime().unwrap();
         assert_eq!(
             dt.format("%Y-%m-%dT%H:%M:%S").to_string(),
@@ -651,10 +644,9 @@ mod tests {
     #[test]
     fn test_reverse_json_object() {
         let result =
-            csv_string_to_typed_value(r#"{"key": "value", "count": 42}"#, &UniversalType::Json)
-                .unwrap();
+            csv_string_to_typed_value(r#"{"key": "value", "count": 42}"#, &Type::Json).unwrap();
         match &result.value {
-            UniversalValue::Json(json_val) => {
+            Value::Json(json_val) => {
                 if let serde_json::Value::Object(map) = json_val.as_ref() {
                     assert_eq!(
                         map.get("key"),
@@ -676,13 +668,13 @@ mod tests {
     fn test_reverse_array_int() {
         let result = csv_string_to_typed_value(
             "[1, 2, 3]",
-            &UniversalType::Array {
-                element_type: Box::new(UniversalType::Int32),
+            &Type::Array {
+                element_type: Box::new(Type::Int32),
             },
         )
         .unwrap();
         match &result.value {
-            UniversalValue::Array { elements, .. } => {
+            Value::Array { elements, .. } => {
                 assert_eq!(elements.len(), 3);
                 assert_eq!(elements[0].as_i32(), Some(1));
                 assert_eq!(elements[1].as_i32(), Some(2));
@@ -696,13 +688,13 @@ mod tests {
     fn test_reverse_set() {
         let result = csv_string_to_typed_value(
             "a,b,c",
-            &UniversalType::Set {
+            &Type::Set {
                 values: vec!["a".to_string(), "b".to_string(), "c".to_string()],
             },
         )
         .unwrap();
         match &result.value {
-            UniversalValue::Set { elements, .. } => {
+            Value::Set { elements, .. } => {
                 assert_eq!(elements.len(), 3);
                 assert_eq!(elements[0], "a");
                 assert_eq!(elements[1], "b");
@@ -716,12 +708,12 @@ mod tests {
     fn test_reverse_enum() {
         let result = csv_string_to_typed_value(
             "active",
-            &UniversalType::Enum {
+            &Type::Enum {
                 values: vec!["active".to_string(), "inactive".to_string()],
             },
         )
         .unwrap();
-        if let UniversalValue::Enum { value, .. } = result.value {
+        if let Value::Enum { value, .. } = result.value {
             assert_eq!(value, "active");
         } else {
             panic!("Expected Enum, got {:?}", result.value);
@@ -733,13 +725,13 @@ mod tests {
         use sync_core::values::GeometryData;
         let result = csv_string_to_typed_value(
             r#"{"type": "Point", "coordinates": [-73.97, 40.77]}"#,
-            &UniversalType::Geometry {
+            &Type::Geometry {
                 geometry_type: GeometryType::Point,
             },
         )
         .unwrap();
         match &result.value {
-            UniversalValue::Geometry { data, .. } => {
+            Value::Geometry { data, .. } => {
                 let GeometryData(geo_json) = data;
                 if let serde_json::Value::Object(map) = geo_json {
                     assert!(map.contains_key("type"));
@@ -773,7 +765,7 @@ mod tests {
 
     #[test]
     fn test_csv_string_with_schema() {
-        let schema_type = UniversalType::Int32;
+        let schema_type = Type::Int32;
         let csv_str = CsvStringWithSchema::new("42", &schema_type);
         let result = csv_str.to_typed_value().unwrap();
         assert_eq!(result.value.as_i32(), Some(42));

--- a/crates/interleaved-snapshot/src/runner.rs
+++ b/crates/interleaved-snapshot/src/runner.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use checkpoint::{InterleavedSnapshotCheckpoint, SnapshotTableProgress};
 use surreal_sink::SurrealSink;
-use sync_core::{UniversalChange, UniversalRow};
+use sync_core::{Change, Row};
 use sync_transform::{
     run_source_runtime_with, ApplyOpts, CheckpointPolicy, Pipeline, PositionedEvent, SourceDriver,
     SourceRuntimeOpts,
@@ -473,7 +473,7 @@ where
     low_id: Uuid,
     high_id: Uuid,
     in_window: bool,
-    buffer: HashMap<String, UniversalRow>,
+    buffer: HashMap<String, Row>,
     last_pk: Option<PkTuple>,
     chunk_len: usize,
     pending: VecDeque<PositionedEvent<u64>>,
@@ -489,7 +489,7 @@ where
     S: WatermarkSource,
     C: SnapshotCheckpointer,
 {
-    fn push_change(&mut self, change: UniversalChange) {
+    fn push_change(&mut self, change: Change) {
         let pos = self.next_pos;
         self.next_pos = self.next_pos.saturating_add(1);
         self.events_emitted = self.events_emitted.saturating_add(1);
@@ -549,9 +549,9 @@ where
     }
 
     fn queue_buffer_rows(&mut self) {
-        let rows: Vec<UniversalRow> = self.buffer.drain().map(|(_, row)| row).collect();
+        let rows: Vec<Row> = self.buffer.drain().map(|(_, row)| row).collect();
         for row in rows {
-            let change = UniversalChange::update(row.table, row.id, row.fields);
+            let change = Change::update(row.table, row.id, row.fields);
             self.push_change(change);
         }
         self.chunk_poll_complete = true;

--- a/crates/interleaved-snapshot/src/source.rs
+++ b/crates/interleaved-snapshot/src/source.rs
@@ -1,7 +1,7 @@
 //! The backend trait each source implements to drive a watermark snapshot.
 
 use anyhow::Result;
-use sync_core::UniversalRow;
+use sync_core::Row;
 use uuid::Uuid;
 
 use crate::types::{
@@ -42,7 +42,7 @@ pub trait WatermarkSource: Send {
         table: &TableSpec,
         after: Option<&PkTuple>,
         limit: usize,
-    ) -> Result<Vec<UniversalRow>>;
+    ) -> Result<Vec<Row>>;
 
     /// Write a watermark row (keyed by `id`) into the source's signal table.
     async fn write_watermark(&self, kind: WatermarkKind, id: Uuid) -> Result<()>;

--- a/crates/interleaved-snapshot/src/tests.rs
+++ b/crates/interleaved-snapshot/src/tests.rs
@@ -10,10 +10,7 @@ use std::sync::Mutex;
 use anyhow::Result;
 use async_trait::async_trait;
 use surreal_sink::SurrealSink;
-use sync_core::{
-    UniversalChange, UniversalChangeOp, UniversalRelation, UniversalRelationChange, UniversalRow,
-    UniversalValue,
-};
+use sync_core::{Change, ChangeOp, Relation, RelationChange, Row, Value};
 use uuid::Uuid;
 
 use crate::{
@@ -33,37 +30,37 @@ struct MockSink {
 #[derive(Default)]
 struct MockSinkState {
     /// (op, table, id) of every sunk change-stream / buffer event.
-    /// Surviving snapshot rows are emitted as [`UniversalChangeOp::Update`]
+    /// Surviving snapshot rows are emitted as [`ChangeOp::Update`]
     /// through the shared `run_source_runtime` window. Homogeneous Update
-    /// batches coalesce to `write_universal_rows`; those are mirrored here as
+    /// batches coalesce to `write_rows`; those are mirrored here as
     /// Updates so observations match per-event apply.
-    changes: Vec<(UniversalChangeOp, String, UniversalValue)>,
+    changes: Vec<(ChangeOp, String, Value)>,
 }
 
 impl MockSink {
-    fn changes(&self) -> Vec<(UniversalChangeOp, String, UniversalValue)> {
+    fn changes(&self) -> Vec<(ChangeOp, String, Value)> {
         self.state.lock().unwrap().changes.clone()
     }
 }
 
 #[async_trait]
 impl SurrealSink for MockSink {
-    async fn write_universal_rows(&self, rows: &[UniversalRow]) -> Result<()> {
+    async fn write_rows(&self, rows: &[Row]) -> Result<()> {
         // Homogeneous Update upserts coalesce here; mirror into `changes`.
         let mut state = self.state.lock().unwrap();
         for row in rows {
             state
                 .changes
-                .push((UniversalChangeOp::Update, row.table.clone(), row.id.clone()));
+                .push((ChangeOp::Update, row.table.clone(), row.id.clone()));
         }
         Ok(())
     }
 
-    async fn write_universal_relations(&self, _relations: &[UniversalRelation]) -> Result<()> {
+    async fn write_relations(&self, _relations: &[Relation]) -> Result<()> {
         Ok(())
     }
 
-    async fn apply_universal_change(&self, change: &UniversalChange) -> Result<()> {
+    async fn apply_change(&self, change: &Change) -> Result<()> {
         let mut state = self.state.lock().unwrap();
         state
             .changes
@@ -71,10 +68,7 @@ impl SurrealSink for MockSink {
         Ok(())
     }
 
-    async fn apply_universal_relation_change(
-        &self,
-        _change: &UniversalRelationChange,
-    ) -> Result<()> {
+    async fn apply_relation_change(&self, _change: &RelationChange) -> Result<()> {
         Ok(())
     }
 }
@@ -88,7 +82,7 @@ impl SurrealSink for MockSink {
 struct DataEvent {
     table: String,
     pk: PkTuple,
-    change: UniversalChange,
+    change: Change,
 }
 
 struct MockState {
@@ -146,21 +140,17 @@ impl MockSource {
         ReconciliationEvent {
             position: state.position,
             table: "surreal_sync_signal".to_string(),
-            pk: PkTuple::new(vec![UniversalValue::Uuid(id)]),
-            change: UniversalChange::create(
-                "surreal_sync_signal",
-                UniversalValue::Uuid(id),
-                HashMap::new(),
-            ),
+            pk: PkTuple::new(vec![Value::Uuid(id)]),
+            change: Change::create("surreal_sync_signal", Value::Uuid(id), HashMap::new()),
         }
     }
 }
 
-fn user_row(i: i64) -> UniversalRow {
+fn user_row(i: i64) -> Row {
     let mut fields = HashMap::new();
-    fields.insert("id".to_string(), UniversalValue::Int64(i));
-    fields.insert("val".to_string(), UniversalValue::Text(format!("v{i}")));
-    UniversalRow::new("users", i as u64, UniversalValue::Int64(i), fields)
+    fields.insert("id".to_string(), Value::Int64(i));
+    fields.insert("val".to_string(), Value::Text(format!("v{i}")));
+    Row::new("users", i as u64, Value::Int64(i), fields)
 }
 
 #[async_trait]
@@ -176,7 +166,7 @@ impl WatermarkSource for MockSource {
         _table: &TableSpec,
         after: Option<&PkTuple>,
         limit: usize,
-    ) -> Result<Vec<UniversalRow>> {
+    ) -> Result<Vec<Row>> {
         let start = after
             .and_then(|pk| pk.0.first().and_then(|v| v.as_i64()))
             .unwrap_or(0);
@@ -268,34 +258,31 @@ impl WatermarkSource for MockSource {
 
 fn update_event(i: i64) -> DataEvent {
     let mut fields = HashMap::new();
-    fields.insert("id".to_string(), UniversalValue::Int64(i));
-    fields.insert(
-        "val".to_string(),
-        UniversalValue::Text(format!("v{i}-updated")),
-    );
+    fields.insert("id".to_string(), Value::Int64(i));
+    fields.insert("val".to_string(), Value::Text(format!("v{i}-updated")));
     DataEvent {
         table: "users".to_string(),
-        pk: PkTuple::new(vec![UniversalValue::Int64(i)]),
-        change: UniversalChange::update("users", UniversalValue::Int64(i), fields),
+        pk: PkTuple::new(vec![Value::Int64(i)]),
+        change: Change::update("users", Value::Int64(i), fields),
     }
 }
 
 fn delete_event(i: i64) -> DataEvent {
     DataEvent {
         table: "users".to_string(),
-        pk: PkTuple::new(vec![UniversalValue::Int64(i)]),
-        change: UniversalChange::delete("users", UniversalValue::Int64(i)),
+        pk: PkTuple::new(vec![Value::Int64(i)]),
+        change: Change::delete("users", Value::Int64(i)),
     }
 }
 
 fn create_event(i: i64) -> DataEvent {
     let mut fields = HashMap::new();
-    fields.insert("id".to_string(), UniversalValue::Int64(i));
-    fields.insert("val".to_string(), UniversalValue::Text(format!("v{i}")));
+    fields.insert("id".to_string(), Value::Int64(i));
+    fields.insert("val".to_string(), Value::Text(format!("v{i}")));
     DataEvent {
         table: "users".to_string(),
-        pk: PkTuple::new(vec![UniversalValue::Int64(i)]),
-        change: UniversalChange::create("users", UniversalValue::Int64(i), fields),
+        pk: PkTuple::new(vec![Value::Int64(i)]),
+        change: Change::create("users", Value::Int64(i), fields),
     }
 }
 
@@ -315,23 +302,23 @@ async fn window_dedup_lets_log_event_win() {
         .await
         .unwrap();
 
-    // Surviving buffer row 1 is sunk as Update (coalesced write_universal_rows);
+    // Surviving buffer row 1 is sunk as Update (coalesced write_rows);
     // CDC events for 2/3/4 are applied as-is. Watermark rows are never applied.
     let changes = sink.changes();
     assert_eq!(changes.len(), 4, "unexpected changes: {changes:?}");
     assert!(changes.iter().all(|(_, table, _)| table == "users"));
     assert!(changes
         .iter()
-        .any(|(op, _, id)| *op == UniversalChangeOp::Update && id.as_i64() == Some(1)));
+        .any(|(op, _, id)| *op == ChangeOp::Update && id.as_i64() == Some(1)));
     assert!(changes
         .iter()
-        .any(|(op, _, id)| *op == UniversalChangeOp::Update && id.as_i64() == Some(2)));
+        .any(|(op, _, id)| *op == ChangeOp::Update && id.as_i64() == Some(2)));
     assert!(changes
         .iter()
-        .any(|(op, _, id)| *op == UniversalChangeOp::Delete && id.as_i64() == Some(3)));
+        .any(|(op, _, id)| *op == ChangeOp::Delete && id.as_i64() == Some(3)));
     assert!(changes
         .iter()
-        .any(|(op, _, id)| *op == UniversalChangeOp::Create && id.as_i64() == Some(4)));
+        .any(|(op, _, id)| *op == ChangeOp::Create && id.as_i64() == Some(4)));
 
     // The chunk held exactly the three read rows at its peak.
     assert_eq!(result.peak_buffered_rows, 3);
@@ -358,16 +345,16 @@ async fn post_high_delete_wins_over_buffer_flush() {
     assert!(
         changes
             .iter()
-            .any(|(op, _, id)| *op == UniversalChangeOp::Update && id.as_i64() == Some(1)),
+            .any(|(op, _, id)| *op == ChangeOp::Update && id.as_i64() == Some(1)),
         "unexpected changes: {changes:?}"
     );
     let delete_pos = changes
         .iter()
-        .position(|(op, _, id)| *op == UniversalChangeOp::Delete && id.as_i64() == Some(2))
+        .position(|(op, _, id)| *op == ChangeOp::Delete && id.as_i64() == Some(2))
         .expect("Delete(2) missing");
     let upsert_2_pos = changes
         .iter()
-        .position(|(op, _, id)| *op == UniversalChangeOp::Update && id.as_i64() == Some(2))
+        .position(|(op, _, id)| *op == ChangeOp::Update && id.as_i64() == Some(2))
         .expect("Update(2) missing");
     assert!(
         upsert_2_pos < delete_pos,
@@ -391,11 +378,7 @@ async fn unchanged_keys_are_emitted_from_buffer() {
     let mut ids: Vec<i64> = sink
         .changes()
         .into_iter()
-        .filter_map(|(op, _, id)| {
-            (op == UniversalChangeOp::Update)
-                .then(|| id.as_i64())
-                .flatten()
-        })
+        .filter_map(|(op, _, id)| (op == ChangeOp::Update).then(|| id.as_i64()).flatten())
         .collect();
     ids.sort_unstable();
     assert_eq!(ids, vec![1, 2, 3, 4, 5]);
@@ -418,7 +401,7 @@ async fn peak_for_table_size(total_rows: i64) -> (usize, usize) {
     let written = sink
         .changes()
         .iter()
-        .filter(|(op, _, _)| *op == UniversalChangeOp::Update)
+        .filter(|(op, _, _)| *op == ChangeOp::Update)
         .count();
     (result.peak_buffered_rows, written)
 }

--- a/crates/interleaved-snapshot/src/types.rs
+++ b/crates/interleaved-snapshot/src/types.rs
@@ -3,7 +3,7 @@
 use anyhow::Result;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use sync_core::{UniversalChange, UniversalRow, UniversalValue};
+use sync_core::{Change, Row, Value};
 use uuid::Uuid;
 
 /// A position in a source's change stream.
@@ -50,11 +50,11 @@ impl TableSpec {
 /// The values are ordered to match the corresponding [`TableSpec::pk_columns`]
 /// so single and composite primary keys are handled uniformly.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct PkTuple(pub Vec<UniversalValue>);
+pub struct PkTuple(pub Vec<Value>);
 
 impl PkTuple {
     /// Create a primary key tuple from ordered values.
-    pub fn new(values: Vec<UniversalValue>) -> Self {
+    pub fn new(values: Vec<Value>) -> Self {
         Self(values)
     }
 
@@ -66,7 +66,7 @@ impl PkTuple {
     /// events that differ only by integer width (`Int32` vs `Int64`) or string
     /// kind (`VarChar` vs `Text`) still collide for window dedup.
     pub fn key(&self) -> String {
-        let canonical: Vec<UniversalValue> = self.0.iter().map(canonicalize_pk_value).collect();
+        let canonical: Vec<Value> = self.0.iter().map(canonicalize_pk_value).collect();
         serde_json::to_string(&canonical).unwrap_or_default()
     }
 
@@ -76,7 +76,7 @@ impl PkTuple {
     /// UUID and recognizes those rows in the change stream via this helper.
     pub fn single_uuid(&self) -> Option<Uuid> {
         match self.0.as_slice() {
-            [UniversalValue::Uuid(u)] => Some(*u),
+            [Value::Uuid(u)] => Some(*u),
             _ => None,
         }
     }
@@ -88,7 +88,7 @@ impl PkTuple {
     /// single-column primary keys, a missing field falls back to the row's
     /// dedicated `id` value. Extracted values are canonicalized so they match
     /// [`Self::key`] used for window dedup.
-    pub fn from_row(row: &UniversalRow, pk_columns: &[String]) -> Result<Self> {
+    pub fn from_row(row: &Row, pk_columns: &[String]) -> Result<Self> {
         let mut values = Vec::with_capacity(pk_columns.len());
         for col in pk_columns {
             if let Some(v) = row.fields.get(col) {
@@ -109,16 +109,16 @@ impl PkTuple {
 /// Reduce a primary-key scalar to the canonical kinds used for buffer dedup
 /// (`Int64` / `Uuid` / `Text`), matching how most CDC backends normalize
 /// stream keys relative to snapshot reads.
-fn canonicalize_pk_value(value: &UniversalValue) -> UniversalValue {
+fn canonicalize_pk_value(value: &Value) -> Value {
     match value {
-        UniversalValue::Int8 { value, .. } => UniversalValue::Int64(*value as i64),
-        UniversalValue::Int16(v) => UniversalValue::Int64(*v as i64),
-        UniversalValue::Int32(v) => UniversalValue::Int64(*v as i64),
-        UniversalValue::Int64(v) => UniversalValue::Int64(*v),
-        UniversalValue::Uuid(u) => UniversalValue::Uuid(*u),
-        UniversalValue::Char { value, .. } => UniversalValue::Text(value.clone()),
-        UniversalValue::VarChar { value, .. } => UniversalValue::Text(value.clone()),
-        UniversalValue::Text(s) => UniversalValue::Text(s.clone()),
+        Value::Int8 { value, .. } => Value::Int64(*value as i64),
+        Value::Int16(v) => Value::Int64(*v as i64),
+        Value::Int32(v) => Value::Int64(*v as i64),
+        Value::Int64(v) => Value::Int64(*v),
+        Value::Uuid(u) => Value::Uuid(*u),
+        Value::Char { value, .. } => Value::Text(value.clone()),
+        Value::VarChar { value, .. } => Value::Text(value.clone()),
+        Value::Text(s) => Value::Text(s.clone()),
         other => other.clone(),
     }
 }
@@ -129,19 +129,19 @@ mod pk_key_tests {
 
     #[test]
     fn key_equates_int_widths() {
-        let i32 = PkTuple::new(vec![UniversalValue::Int32(42)]);
-        let i64 = PkTuple::new(vec![UniversalValue::Int64(42)]);
+        let i32 = PkTuple::new(vec![Value::Int32(42)]);
+        let i64 = PkTuple::new(vec![Value::Int64(42)]);
         assert_eq!(i32.key(), i64.key());
     }
 
     #[test]
     fn key_equates_string_kinds() {
-        let text = PkTuple::new(vec![UniversalValue::Text("acct-001".into())]);
-        let varchar = PkTuple::new(vec![UniversalValue::VarChar {
+        let text = PkTuple::new(vec![Value::Text("acct-001".into())]);
+        let varchar = PkTuple::new(vec![Value::VarChar {
             value: "acct-001".into(),
             length: 32,
         }]);
-        let char_v = PkTuple::new(vec![UniversalValue::Char {
+        let char_v = PkTuple::new(vec![Value::Char {
             value: "acct-001".into(),
             length: 32,
         }]);
@@ -152,11 +152,11 @@ mod pk_key_tests {
     #[test]
     fn from_row_canonicalizes_field_pk() {
         let mut fields = std::collections::HashMap::new();
-        fields.insert("id".to_string(), UniversalValue::Int32(7));
-        let row = UniversalRow::new("users", 0, UniversalValue::Int32(7), fields);
+        fields.insert("id".to_string(), Value::Int32(7));
+        let row = Row::new("users", 0, Value::Int32(7), fields);
         let pk = PkTuple::from_row(&row, &["id".to_string()]).unwrap();
-        assert_eq!(pk.0, vec![UniversalValue::Int64(7)]);
-        assert_eq!(pk.key(), PkTuple::new(vec![UniversalValue::Int64(7)]).key());
+        assert_eq!(pk.0, vec![Value::Int64(7)]);
+        assert_eq!(pk.key(), PkTuple::new(vec![Value::Int64(7)]).key());
     }
 }
 
@@ -184,7 +184,7 @@ pub struct ReconciliationEvent<P: ReconciliationPos> {
     /// Primary key of the affected row.
     pub pk: PkTuple,
     /// The change to apply to the sink.
-    pub change: UniversalChange,
+    pub change: Change,
 }
 
 /// An inbound ad-hoc snapshot signal (e.g. a Debezium-style `execute-snapshot`

--- a/crates/json-types/src/forward.rs
+++ b/crates/json-types/src/forward.rs
@@ -4,7 +4,7 @@
 
 use base64::Engine;
 use serde_json::json;
-use sync_core::{GeometryType, TypedValue, UniversalValue};
+use sync_core::{GeometryType, TypedValue, Value};
 
 /// Wrapper for JSON values.
 #[derive(Debug, Clone)]
@@ -28,65 +28,65 @@ impl From<TypedValue> for JsonValue {
     }
 }
 
-impl From<UniversalValue> for JsonValue {
-    fn from(value: UniversalValue) -> Self {
+impl From<Value> for JsonValue {
+    fn from(value: Value) -> Self {
         match value {
             // Null
-            UniversalValue::Null => JsonValue(serde_json::Value::Null),
+            Value::Null => JsonValue(serde_json::Value::Null),
 
             // Boolean
-            UniversalValue::Bool(b) => JsonValue(json!(b)),
+            Value::Bool(b) => JsonValue(json!(b)),
 
             // Integer types
-            UniversalValue::Int8 { value, .. } => JsonValue(json!(value)),
-            UniversalValue::Int16(i) => JsonValue(json!(i)),
-            UniversalValue::Int32(i) => JsonValue(json!(i)),
-            UniversalValue::Int64(i) => JsonValue(json!(i)),
+            Value::Int8 { value, .. } => JsonValue(json!(value)),
+            Value::Int16(i) => JsonValue(json!(i)),
+            Value::Int32(i) => JsonValue(json!(i)),
+            Value::Int64(i) => JsonValue(json!(i)),
 
             // Floating point
-            UniversalValue::Float32(f) => JsonValue(json!(f)),
-            UniversalValue::Float64(f) => JsonValue(json!(f)),
+            Value::Float32(f) => JsonValue(json!(f)),
+            Value::Float64(f) => JsonValue(json!(f)),
 
             // Decimal - store as string to preserve precision
-            UniversalValue::Decimal { value, .. } => JsonValue(json!(value)),
+            Value::Decimal { value, .. } => JsonValue(json!(value)),
 
             // String types
-            UniversalValue::Char { value, .. } => JsonValue(json!(value)),
-            UniversalValue::VarChar { value, .. } => JsonValue(json!(value)),
-            UniversalValue::Text(s) => JsonValue(json!(s)),
+            Value::Char { value, .. } => JsonValue(json!(value)),
+            Value::VarChar { value, .. } => JsonValue(json!(value)),
+            Value::Text(s) => JsonValue(json!(s)),
 
             // Binary types - base64 encode
-            UniversalValue::Blob(b) => {
+            Value::Blob(b) => {
                 let encoded = base64::engine::general_purpose::STANDARD.encode(b);
                 JsonValue(json!(encoded))
             }
-            UniversalValue::Bytes(b) => {
+            Value::Bytes(b) => {
                 let encoded = base64::engine::general_purpose::STANDARD.encode(b);
                 JsonValue(json!(encoded))
             }
 
             // Date/time types - ISO 8601 format
-            UniversalValue::Date(dt) => JsonValue(json!(dt.format("%Y-%m-%d").to_string())),
+            Value::Date(dt) => JsonValue(json!(dt.format("%Y-%m-%d").to_string())),
             // Note: Using "%H:%M:%S%.f" to preserve fractional seconds from PostgreSQL TIME type.
-            UniversalValue::Time(dt) => JsonValue(json!(dt.format("%H:%M:%S%.f").to_string())),
-            UniversalValue::LocalDateTime(dt) => JsonValue(json!(dt.to_rfc3339())),
-            UniversalValue::LocalDateTimeNano(dt) => JsonValue(json!(dt.to_rfc3339())),
-            UniversalValue::ZonedDateTime(dt) => JsonValue(json!(dt.to_rfc3339())),
+            Value::Time(dt) => JsonValue(json!(dt.format("%H:%M:%S%.f").to_string())),
+            Value::LocalDateTime(dt) => JsonValue(json!(dt.to_rfc3339())),
+            Value::LocalDateTimeNano(dt) => JsonValue(json!(dt.to_rfc3339())),
+            Value::ZonedDateTime(dt) => JsonValue(json!(dt.to_rfc3339())),
             // TIMETZ - stored as string to preserve timezone format
-            UniversalValue::TimeTz(s) => JsonValue(json!(s)),
+            Value::TimeTz(s) => JsonValue(json!(s)),
 
             // UUID
-            UniversalValue::Uuid(u) => JsonValue(json!(u.to_string())),
+            Value::Uuid(u) => JsonValue(json!(u.to_string())),
 
             // ULID
-            UniversalValue::Ulid(u) => JsonValue(json!(u.to_string())),
+            Value::Ulid(u) => JsonValue(json!(u.to_string())),
 
             // JSON types - already serde_json::Value
-            UniversalValue::Json(payload) => JsonValue((*payload).clone()),
-            UniversalValue::Jsonb(payload) => JsonValue((*payload).clone()),
+            Value::Json(payload) => JsonValue((*payload).clone()),
+            Value::Jsonb(payload) => JsonValue((*payload).clone()),
 
             // Array types - recursively convert elements
-            UniversalValue::Array { elements, .. } => {
+            Value::Array { elements, .. } => {
                 let json_arr: Vec<serde_json::Value> = elements
                     .into_iter()
                     .map(|v| JsonValue::from(v).into_inner())
@@ -95,16 +95,16 @@ impl From<UniversalValue> for JsonValue {
             }
 
             // Set - stored as array of strings
-            UniversalValue::Set { elements, .. } => {
+            Value::Set { elements, .. } => {
                 let json_arr: Vec<serde_json::Value> = elements.iter().map(|s| json!(s)).collect();
                 JsonValue(json!(json_arr))
             }
 
             // Enum - stored as string
-            UniversalValue::Enum { value, .. } => JsonValue(json!(value)),
+            Value::Enum { value, .. } => JsonValue(json!(value)),
 
             // Geometry types - GeoJSON format
-            UniversalValue::Geometry {
+            Value::Geometry {
                 data,
                 geometry_type,
             } => {
@@ -128,7 +128,7 @@ impl From<UniversalValue> for JsonValue {
             }
 
             // Duration - ISO 8601 format
-            UniversalValue::Duration(d) => {
+            Value::Duration(d) => {
                 let secs = d.as_secs();
                 let nanos = d.subsec_nanos();
                 if nanos == 0 {
@@ -139,12 +139,12 @@ impl From<UniversalValue> for JsonValue {
             }
 
             // Thing - record reference as "table:id" format
-            UniversalValue::Thing { table, id } => {
+            Value::Thing { table, id } => {
                 let id_str = match id.as_ref() {
-                    UniversalValue::Text(s) => s.clone(),
-                    UniversalValue::Int32(i) => i.to_string(),
-                    UniversalValue::Int64(i) => i.to_string(),
-                    UniversalValue::Uuid(u) => u.to_string(),
+                    Value::Text(s) => s.clone(),
+                    Value::Int32(i) => i.to_string(),
+                    Value::Int64(i) => i.to_string(),
+                    Value::Uuid(u) => u.to_string(),
                     other => panic!(
                         "Unsupported Thing ID type: {other:?}. \
                          Supported types: Text, Int32, Int64, Uuid"
@@ -154,7 +154,7 @@ impl From<UniversalValue> for JsonValue {
             }
 
             // Object - nested document
-            UniversalValue::Object(map) => {
+            Value::Object(map) => {
                 let obj: serde_json::Map<String, serde_json::Value> = map
                     .into_iter()
                     .map(|(k, v)| (k, JsonValue::from(v).into_inner()))
@@ -163,64 +163,63 @@ impl From<UniversalValue> for JsonValue {
             }
 
             // Zero temporal - preserve as MySQL-style literal string
-            UniversalValue::ZeroTemporal {
+            Value::ZeroTemporal {
                 intended_type,
                 source,
             } => {
-                let s = source.unwrap_or_else(|| {
-                    UniversalValue::canonical_zero_literal(&intended_type).to_string()
-                });
+                let s = source
+                    .unwrap_or_else(|| Value::canonical_zero_literal(&intended_type).to_string());
                 JsonValue(json!(s))
             }
         }
     }
 }
 
-/// Convert a UniversalValue to a JSON value (without type context).
+/// Convert a Value to a JSON value (without type context).
 #[allow(dead_code)]
-fn generated_value_to_json(value: &UniversalValue) -> serde_json::Value {
+fn generated_value_to_json(value: &Value) -> serde_json::Value {
     match value {
-        UniversalValue::Null => serde_json::Value::Null,
-        UniversalValue::Bool(b) => json!(*b),
-        UniversalValue::Int8 { value, .. } => json!(*value),
-        UniversalValue::Int16(i) => json!(*i),
-        UniversalValue::Int32(i) => json!(*i),
-        UniversalValue::Int64(i) => json!(*i),
-        UniversalValue::Float32(f) => json!(*f),
-        UniversalValue::Float64(f) => json!(*f),
-        UniversalValue::Char { value, .. } => json!(value),
-        UniversalValue::VarChar { value, .. } => json!(value),
-        UniversalValue::Text(s) => json!(s),
-        UniversalValue::Blob(b) | UniversalValue::Bytes(b) => {
+        Value::Null => serde_json::Value::Null,
+        Value::Bool(b) => json!(*b),
+        Value::Int8 { value, .. } => json!(*value),
+        Value::Int16(i) => json!(*i),
+        Value::Int32(i) => json!(*i),
+        Value::Int64(i) => json!(*i),
+        Value::Float32(f) => json!(*f),
+        Value::Float64(f) => json!(*f),
+        Value::Char { value, .. } => json!(value),
+        Value::VarChar { value, .. } => json!(value),
+        Value::Text(s) => json!(s),
+        Value::Blob(b) | Value::Bytes(b) => {
             let encoded = base64::engine::general_purpose::STANDARD.encode(b);
             json!(encoded)
         }
-        UniversalValue::Uuid(u) => json!(u.to_string()),
-        UniversalValue::Ulid(u) => json!(u.to_string()),
-        UniversalValue::Date(dt) => json!(dt.format("%Y-%m-%d").to_string()),
-        UniversalValue::Time(dt) => json!(dt.format("%H:%M:%S%.f").to_string()),
-        UniversalValue::LocalDateTime(dt)
-        | UniversalValue::LocalDateTimeNano(dt)
-        | UniversalValue::ZonedDateTime(dt) => json!(dt.to_rfc3339()),
-        UniversalValue::TimeTz(s) => json!(s),
-        UniversalValue::Decimal { value, .. } => json!(value),
-        UniversalValue::Array { elements, .. } => {
+        Value::Uuid(u) => json!(u.to_string()),
+        Value::Ulid(u) => json!(u.to_string()),
+        Value::Date(dt) => json!(dt.format("%Y-%m-%d").to_string()),
+        Value::Time(dt) => json!(dt.format("%H:%M:%S%.f").to_string()),
+        Value::LocalDateTime(dt) | Value::LocalDateTimeNano(dt) | Value::ZonedDateTime(dt) => {
+            json!(dt.to_rfc3339())
+        }
+        Value::TimeTz(s) => json!(s),
+        Value::Decimal { value, .. } => json!(value),
+        Value::Array { elements, .. } => {
             json!(elements
                 .iter()
                 .map(generated_value_to_json)
                 .collect::<Vec<_>>())
         }
-        UniversalValue::Set { elements, .. } => {
+        Value::Set { elements, .. } => {
             json!(elements)
         }
-        UniversalValue::Enum { value, .. } => json!(value),
-        UniversalValue::Json(payload) | UniversalValue::Jsonb(payload) => (**payload).clone(),
-        UniversalValue::Geometry { data, .. } => {
+        Value::Enum { value, .. } => json!(value),
+        Value::Json(payload) | Value::Jsonb(payload) => (**payload).clone(),
+        Value::Geometry { data, .. } => {
             use sync_core::values::GeometryData;
             let GeometryData(value) = data;
             value.clone()
         }
-        UniversalValue::Duration(d) => {
+        Value::Duration(d) => {
             let secs = d.as_secs();
             let nanos = d.subsec_nanos();
             if nanos == 0 {
@@ -229,12 +228,12 @@ fn generated_value_to_json(value: &UniversalValue) -> serde_json::Value {
                 json!(format!("PT{secs}.{nanos:09}S"))
             }
         }
-        UniversalValue::Thing { table, id } => {
+        Value::Thing { table, id } => {
             let id_str = match id.as_ref() {
-                UniversalValue::Text(s) => s.clone(),
-                UniversalValue::Int32(i) => i.to_string(),
-                UniversalValue::Int64(i) => i.to_string(),
-                UniversalValue::Uuid(u) => u.to_string(),
+                Value::Text(s) => s.clone(),
+                Value::Int32(i) => i.to_string(),
+                Value::Int64(i) => i.to_string(),
+                Value::Uuid(u) => u.to_string(),
                 other => panic!(
                     "Unsupported Thing ID type: {other:?}. \
                      Supported types: Text, Int32, Int64, Uuid"
@@ -242,20 +241,20 @@ fn generated_value_to_json(value: &UniversalValue) -> serde_json::Value {
             };
             json!(format!("{table}:{id_str}"))
         }
-        UniversalValue::Object(map) => {
+        Value::Object(map) => {
             let obj: serde_json::Map<String, serde_json::Value> = map
                 .iter()
                 .map(|(k, v)| (k.clone(), generated_value_to_json(v)))
                 .collect();
             serde_json::Value::Object(obj)
         }
-        UniversalValue::ZeroTemporal {
+        Value::ZeroTemporal {
             intended_type,
             source,
         } => {
             let s = source
                 .as_deref()
-                .unwrap_or_else(|| UniversalValue::canonical_zero_literal(intended_type));
+                .unwrap_or_else(|| Value::canonical_zero_literal(intended_type));
             json!(s)
         }
     }
@@ -286,11 +285,11 @@ where
 mod tests {
     use super::*;
     use chrono::{TimeZone, Utc};
-    use sync_core::UniversalType;
+    use sync_core::Type;
 
     #[test]
     fn test_null_conversion() {
-        let tv = TypedValue::null(UniversalType::Text);
+        let tv = TypedValue::null(Type::Text);
         let json_val: JsonValue = tv.into();
         assert!(json_val.0.is_null());
     }
@@ -434,12 +433,8 @@ mod tests {
     #[test]
     fn test_array_int_conversion() {
         let tv = TypedValue::array(
-            vec![
-                UniversalValue::Int32(1),
-                UniversalValue::Int32(2),
-                UniversalValue::Int32(3),
-            ],
-            UniversalType::Int32,
+            vec![Value::Int32(1), Value::Int32(2), Value::Int32(3)],
+            Type::Int32,
         );
         let json_val: JsonValue = tv.into();
         assert_eq!(json_val.0, json!([1, 2, 3]));
@@ -448,11 +443,8 @@ mod tests {
     #[test]
     fn test_array_text_conversion() {
         let tv = TypedValue::array(
-            vec![
-                UniversalValue::Text("a".to_string()),
-                UniversalValue::Text("b".to_string()),
-            ],
-            UniversalType::Text,
+            vec![Value::Text("a".to_string()), Value::Text("b".to_string())],
+            Type::Text,
         );
         let json_val: JsonValue = tv.into();
         assert_eq!(json_val.0, json!(["a", "b"]));

--- a/crates/json-types/src/lib.rs
+++ b/crates/json-types/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! ```ignore
 //! use json_types::{JsonValue, JsonValueWithSchema};
-//! use sync_core::{TypedValue, UniversalType};
+//! use sync_core::{TypedValue, Type};
 //!
 //! // Forward: TypedValue → JSON value
 //! let tv = TypedValue::text("hello");
@@ -20,7 +20,7 @@
 //!
 //! // Reverse: JSON value → TypedValue
 //! let json = serde_json::json!(42);
-//! let json_with_schema = JsonValueWithSchema::new(json, &UniversalType::Int32);
+//! let json_with_schema = JsonValueWithSchema::new(json, &Type::Int32);
 //! let tv = json_with_schema.to_typed_value().unwrap();
 //! ```
 
@@ -29,8 +29,7 @@ pub mod reverse;
 
 pub use forward::JsonValue;
 pub use reverse::{
-    convert_id_to_universal_value, convert_id_to_universal_with_database_schema,
-    json_to_generated_value_with_config, json_to_typed_value_with_config,
-    json_to_universal_with_table_schema, json_value_to_universal, JsonConversionConfig,
-    JsonValueWithSchema,
+    convert_id_to_value, convert_id_with_database_schema, json_to_generated_value_with_config,
+    json_to_typed_value_with_config, json_to_universal_with_table_schema, json_value_to_universal,
+    JsonConversionConfig, JsonValueWithSchema,
 };

--- a/crates/json-types/src/reverse.rs
+++ b/crates/json-types/src/reverse.rs
@@ -6,7 +6,7 @@ use base64::Engine;
 use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
 use serde_json;
 use std::collections::HashMap;
-use sync_core::{TypedValue, UniversalType, UniversalValue};
+use sync_core::{Type, TypedValue, Value};
 
 /// Parse an ISO 8601 duration string (PTxS or PTx.xxxxxxxxxS format).
 ///
@@ -80,12 +80,12 @@ pub struct JsonValueWithSchema {
     /// The JSON value.
     pub value: serde_json::Value,
     /// The expected sync type for conversion.
-    pub sync_type: UniversalType,
+    pub sync_type: Type,
 }
 
 impl JsonValueWithSchema {
     /// Create a new JsonValueWithSchema.
-    pub fn new(value: serde_json::Value, sync_type: UniversalType) -> Self {
+    pub fn new(value: serde_json::Value, sync_type: Type) -> Self {
         Self { value, sync_type }
     }
 
@@ -102,146 +102,146 @@ impl From<JsonValueWithSchema> for TypedValue {
             (sync_type, serde_json::Value::Null) => TypedValue::null(sync_type.clone()),
 
             // Boolean
-            (UniversalType::Bool, serde_json::Value::Bool(b)) => TypedValue::bool(*b),
+            (Type::Bool, serde_json::Value::Bool(b)) => TypedValue::bool(*b),
             // MySQL stores TINYINT(1) booleans as 0/1 in JSON_OBJECT
-            (UniversalType::Bool, serde_json::Value::Number(n)) => {
+            (Type::Bool, serde_json::Value::Number(n)) => {
                 if let Some(i) = n.as_i64() {
                     TypedValue::bool(i != 0)
                 } else {
-                    TypedValue::null(UniversalType::Bool)
+                    TypedValue::null(Type::Bool)
                 }
             }
 
             // Integer types
-            (UniversalType::Int8 { width }, serde_json::Value::Number(n)) => {
+            (Type::Int8 { width }, serde_json::Value::Number(n)) => {
                 if let Some(i) = n.as_i64() {
                     TypedValue::int8(i as i8, *width)
                 } else {
-                    TypedValue::null(UniversalType::Int8 { width: *width })
+                    TypedValue::null(Type::Int8 { width: *width })
                 }
             }
-            (UniversalType::Int16, serde_json::Value::Number(n)) => {
+            (Type::Int16, serde_json::Value::Number(n)) => {
                 if let Some(i) = n.as_i64() {
                     TypedValue::int16(i as i16)
                 } else {
-                    TypedValue::null(UniversalType::Int16)
+                    TypedValue::null(Type::Int16)
                 }
             }
-            (UniversalType::Int32, serde_json::Value::Number(n)) => {
+            (Type::Int32, serde_json::Value::Number(n)) => {
                 if let Some(i) = n.as_i64() {
                     TypedValue::int32(i as i32)
                 } else {
-                    TypedValue::null(UniversalType::Int32)
+                    TypedValue::null(Type::Int32)
                 }
             }
-            (UniversalType::Int64, serde_json::Value::Number(n)) => {
+            (Type::Int64, serde_json::Value::Number(n)) => {
                 if let Some(i) = n.as_i64() {
                     TypedValue::int64(i)
                 } else {
-                    TypedValue::null(UniversalType::Int64)
+                    TypedValue::null(Type::Int64)
                 }
             }
 
             // Floating point
-            (UniversalType::Float32, serde_json::Value::Number(n)) => {
+            (Type::Float32, serde_json::Value::Number(n)) => {
                 if let Some(f) = n.as_f64() {
                     TypedValue::float32(f as f32)
                 } else {
-                    TypedValue::null(UniversalType::Float32)
+                    TypedValue::null(Type::Float32)
                 }
             }
-            (UniversalType::Float64, serde_json::Value::Number(n)) => {
+            (Type::Float64, serde_json::Value::Number(n)) => {
                 if let Some(f) = n.as_f64() {
                     TypedValue::float64(f)
                 } else {
-                    TypedValue::null(UniversalType::Float64)
+                    TypedValue::null(Type::Float64)
                 }
             }
 
             // Decimal - stored as string in JSON
-            (UniversalType::Decimal { precision, scale }, serde_json::Value::String(s)) => {
+            (Type::Decimal { precision, scale }, serde_json::Value::String(s)) => {
                 TypedValue::decimal(s, *precision, *scale)
             }
-            (UniversalType::Decimal { precision, scale }, serde_json::Value::Number(n)) => {
+            (Type::Decimal { precision, scale }, serde_json::Value::Number(n)) => {
                 TypedValue::decimal(n.to_string(), *precision, *scale)
             }
 
             // String types
-            (UniversalType::Char { length }, serde_json::Value::String(s)) => {
+            (Type::Char { length }, serde_json::Value::String(s)) => {
                 TypedValue::char_type(s, *length)
             }
-            (UniversalType::VarChar { length }, serde_json::Value::String(s)) => {
+            (Type::VarChar { length }, serde_json::Value::String(s)) => {
                 TypedValue::varchar(s, *length)
             }
-            (UniversalType::Text, serde_json::Value::String(s)) => TypedValue::text(s),
+            (Type::Text, serde_json::Value::String(s)) => TypedValue::text(s),
 
             // Binary types - base64 encoded in JSON
-            (UniversalType::Blob, serde_json::Value::String(s)) => {
+            (Type::Blob, serde_json::Value::String(s)) => {
                 match base64::engine::general_purpose::STANDARD.decode(s) {
                     Ok(bytes) => TypedValue::blob(bytes),
-                    Err(_) => TypedValue::null(UniversalType::Blob),
+                    Err(_) => TypedValue::null(Type::Blob),
                 }
             }
-            (UniversalType::Bytes, serde_json::Value::String(s)) => {
+            (Type::Bytes, serde_json::Value::String(s)) => {
                 match base64::engine::general_purpose::STANDARD.decode(s) {
                     Ok(bytes) => TypedValue::bytes(bytes),
-                    Err(_) => TypedValue::null(UniversalType::Bytes),
+                    Err(_) => TypedValue::null(Type::Bytes),
                 }
             }
 
             // UUID
-            (UniversalType::Uuid, serde_json::Value::String(s)) => {
+            (Type::Uuid, serde_json::Value::String(s)) => {
                 if let Ok(uuid) = uuid::Uuid::parse_str(s) {
                     TypedValue::uuid(uuid)
                 } else {
-                    TypedValue::null(UniversalType::Uuid)
+                    TypedValue::null(Type::Uuid)
                 }
             }
 
             // Date/time types - multiple formats supported
-            (UniversalType::LocalDateTime, serde_json::Value::String(s)) => {
-                if UniversalValue::is_mysql_zero_temporal_literal(s) {
-                    TypedValue::zero_temporal(UniversalType::LocalDateTime, Some(s.clone()))
+            (Type::LocalDateTime, serde_json::Value::String(s)) => {
+                if Value::is_mysql_zero_temporal_literal(s) {
+                    TypedValue::zero_temporal(Type::LocalDateTime, Some(s.clone()))
                 } else if let Some(dt) = parse_datetime_string(s) {
                     TypedValue::datetime(dt)
                 } else {
-                    TypedValue::null(UniversalType::LocalDateTime)
+                    TypedValue::null(Type::LocalDateTime)
                 }
             }
-            (UniversalType::LocalDateTimeNano, serde_json::Value::String(s)) => {
-                if UniversalValue::is_mysql_zero_temporal_literal(s) {
-                    TypedValue::zero_temporal(UniversalType::LocalDateTimeNano, Some(s.clone()))
+            (Type::LocalDateTimeNano, serde_json::Value::String(s)) => {
+                if Value::is_mysql_zero_temporal_literal(s) {
+                    TypedValue::zero_temporal(Type::LocalDateTimeNano, Some(s.clone()))
                 } else if let Some(dt) = parse_datetime_string(s) {
                     TypedValue::datetime_nano(dt)
                 } else {
-                    TypedValue::null(UniversalType::LocalDateTimeNano)
+                    TypedValue::null(Type::LocalDateTimeNano)
                 }
             }
-            (UniversalType::ZonedDateTime, serde_json::Value::String(s)) => {
-                if UniversalValue::is_mysql_zero_temporal_literal(s) {
-                    TypedValue::zero_temporal(UniversalType::ZonedDateTime, Some(s.clone()))
+            (Type::ZonedDateTime, serde_json::Value::String(s)) => {
+                if Value::is_mysql_zero_temporal_literal(s) {
+                    TypedValue::zero_temporal(Type::ZonedDateTime, Some(s.clone()))
                 } else if let Some(dt) = parse_datetime_string(s) {
                     TypedValue::timestamptz(dt)
                 } else {
-                    TypedValue::null(UniversalType::ZonedDateTime)
+                    TypedValue::null(Type::ZonedDateTime)
                 }
             }
 
             // Date stored as string
-            (UniversalType::Date, serde_json::Value::String(s)) => {
-                if UniversalValue::is_mysql_zero_temporal_literal(s) {
-                    TypedValue::zero_temporal(UniversalType::Date, Some(s.clone()))
+            (Type::Date, serde_json::Value::String(s)) => {
+                if Value::is_mysql_zero_temporal_literal(s) {
+                    TypedValue::zero_temporal(Type::Date, Some(s.clone()))
                 } else if let Ok(dt) = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
                     let datetime = dt.and_hms_opt(0, 0, 0).unwrap();
                     let utc_dt = DateTime::<Utc>::from_naive_utc_and_offset(datetime, Utc);
                     TypedValue::date(utc_dt)
                 } else {
-                    TypedValue::null(UniversalType::Date)
+                    TypedValue::null(Type::Date)
                 }
             }
 
             // Time stored as string
-            (UniversalType::Time, serde_json::Value::String(s)) => {
+            (Type::Time, serde_json::Value::String(s)) => {
                 if let Ok(time) = chrono::NaiveTime::parse_from_str(s, "%H:%M:%S") {
                     let datetime = chrono::NaiveDate::from_ymd_opt(1970, 1, 1)
                         .unwrap()
@@ -249,31 +249,31 @@ impl From<JsonValueWithSchema> for TypedValue {
                     let utc_dt = DateTime::<Utc>::from_naive_utc_and_offset(datetime, Utc);
                     TypedValue::time(utc_dt)
                 } else {
-                    TypedValue::null(UniversalType::Time)
+                    TypedValue::null(Type::Time)
                 }
             }
 
             // JSON types - can be objects or arrays
-            (UniversalType::Json, serde_json::Value::Object(obj)) => {
+            (Type::Json, serde_json::Value::Object(obj)) => {
                 let value = json_object_to_universal(obj);
                 TypedValue::json(value)
             }
-            (UniversalType::Json, serde_json::Value::Array(arr)) => {
+            (Type::Json, serde_json::Value::Array(arr)) => {
                 let value = json_array_to_universal(arr);
                 TypedValue::json(value)
             }
-            (UniversalType::Jsonb, serde_json::Value::Object(obj)) => {
+            (Type::Jsonb, serde_json::Value::Object(obj)) => {
                 let value = json_object_to_universal(obj);
                 TypedValue::jsonb(value)
             }
-            (UniversalType::Jsonb, serde_json::Value::Array(arr)) => {
+            (Type::Jsonb, serde_json::Value::Array(arr)) => {
                 let value = json_array_to_universal(arr);
                 TypedValue::jsonb(value)
             }
 
             // Array types
-            (UniversalType::Array { element_type }, serde_json::Value::Array(arr)) => {
-                let values: Vec<UniversalValue> = arr
+            (Type::Array { element_type }, serde_json::Value::Array(arr)) => {
+                let values: Vec<Value> = arr
                     .iter()
                     .map(|v| {
                         let jv = JsonValueWithSchema::new(v.clone(), (**element_type).clone());
@@ -284,7 +284,7 @@ impl From<JsonValueWithSchema> for TypedValue {
             }
 
             // Set - stored as array
-            (UniversalType::Set { values: set_values }, serde_json::Value::Array(arr)) => {
+            (Type::Set { values: set_values }, serde_json::Value::Array(arr)) => {
                 let elements: Vec<String> = arr
                     .iter()
                     .filter_map(|v| {
@@ -300,14 +300,14 @@ impl From<JsonValueWithSchema> for TypedValue {
 
             // Enum - stored as string
             (
-                UniversalType::Enum {
+                Type::Enum {
                     values: enum_values,
                 },
                 serde_json::Value::String(s),
             ) => TypedValue::enum_type(s.clone(), enum_values.clone()),
 
             // Geometry types - GeoJSON format
-            (UniversalType::Geometry { geometry_type }, serde_json::Value::Object(obj)) => {
+            (Type::Geometry { geometry_type }, serde_json::Value::Object(obj)) => {
                 TypedValue::geometry_geojson(
                     serde_json::Value::Object(obj.clone()),
                     geometry_type.clone(),
@@ -315,11 +315,11 @@ impl From<JsonValueWithSchema> for TypedValue {
             }
 
             // Duration - parse ISO 8601 duration string (PTxS or PTx.xxxxxxxxxS format)
-            (UniversalType::Duration, serde_json::Value::String(s)) => {
+            (Type::Duration, serde_json::Value::String(s)) => {
                 if let Some(duration) = parse_iso8601_duration(s) {
                     TypedValue::duration(duration)
                 } else {
-                    TypedValue::null(UniversalType::Duration)
+                    TypedValue::null(Type::Duration)
                 }
             }
 
@@ -329,23 +329,23 @@ impl From<JsonValueWithSchema> for TypedValue {
     }
 }
 
-/// Convert a JSON object to a UniversalValue.
+/// Convert a JSON object to a Value.
 #[allow(dead_code)]
 fn json_object_to_universal(obj: &serde_json::Map<String, serde_json::Value>) -> serde_json::Value {
     serde_json::Value::Object(obj.clone())
 }
 
-/// Convert a JSON array to a UniversalValue.
+/// Convert a JSON array to a Value.
 #[allow(dead_code)]
 fn json_array_to_universal(arr: &[serde_json::Value]) -> serde_json::Value {
     serde_json::Value::Array(arr.to_vec())
 }
 
-/// Convert a JSON object to a HashMap of UniversalValue (for GeoJSON geometry).
+/// Convert a JSON object to a HashMap of Value (for GeoJSON geometry).
 #[allow(dead_code)]
 fn json_object_to_geojson_hashmap(
     obj: &serde_json::Map<String, serde_json::Value>,
-) -> HashMap<String, UniversalValue> {
+) -> HashMap<String, Value> {
     let mut map = HashMap::new();
     for (key, value) in obj {
         map.insert(key.clone(), json_value_to_universal(value));
@@ -353,58 +353,58 @@ fn json_object_to_geojson_hashmap(
     map
 }
 
-/// Convert a JSON value to UniversalValue (without schema information).
+/// Convert a JSON value to Value (without schema information).
 ///
 /// This performs a generic conversion without type hints, inferring types from the JSON values.
-pub fn json_value_to_universal(value: &serde_json::Value) -> UniversalValue {
+pub fn json_value_to_universal(value: &serde_json::Value) -> Value {
     match value {
-        serde_json::Value::Null => UniversalValue::Null,
-        serde_json::Value::Bool(b) => UniversalValue::Bool(*b),
+        serde_json::Value::Null => Value::Null,
+        serde_json::Value::Bool(b) => Value::Bool(*b),
         serde_json::Value::Number(n) => {
             if let Some(i) = n.as_i64() {
-                UniversalValue::Int64(i)
+                Value::Int64(i)
             } else if let Some(f) = n.as_f64() {
-                UniversalValue::Float64(f)
+                Value::Float64(f)
             } else {
-                UniversalValue::Text(n.to_string())
+                Value::Text(n.to_string())
             }
         }
-        serde_json::Value::String(s) => UniversalValue::Text(s.clone()),
-        serde_json::Value::Array(arr) => UniversalValue::Array {
+        serde_json::Value::String(s) => Value::Text(s.clone()),
+        serde_json::Value::Array(arr) => Value::Array {
             elements: arr.iter().map(json_value_to_universal).collect(),
-            element_type: Box::new(UniversalType::Text),
+            element_type: Box::new(Type::Text),
         },
         serde_json::Value::Object(obj) => {
             let mut map = HashMap::new();
             for (key, val) in obj {
                 map.insert(key.clone(), json_value_to_universal(val));
             }
-            UniversalValue::Json(Box::new(serde_json::Value::Object(obj.clone())))
+            Value::Json(Box::new(serde_json::Value::Object(obj.clone())))
         }
     }
 }
 
-/// Convert a JSON value to UniversalValue (without type context).
+/// Convert a JSON value to Value (without type context).
 #[allow(dead_code)]
-fn json_value_to_generated(value: &serde_json::Value) -> UniversalValue {
+fn json_value_to_generated(value: &serde_json::Value) -> Value {
     match value {
-        serde_json::Value::Null => UniversalValue::Null,
-        serde_json::Value::Bool(b) => UniversalValue::Bool(*b),
+        serde_json::Value::Null => Value::Null,
+        serde_json::Value::Bool(b) => Value::Bool(*b),
         serde_json::Value::Number(n) => {
             if let Some(i) = n.as_i64() {
-                UniversalValue::Int64(i)
+                Value::Int64(i)
             } else if let Some(f) = n.as_f64() {
-                UniversalValue::Float64(f)
+                Value::Float64(f)
             } else {
-                UniversalValue::Null
+                Value::Null
             }
         }
-        serde_json::Value::String(s) => UniversalValue::Text(s.clone()),
-        serde_json::Value::Array(arr) => UniversalValue::Array {
+        serde_json::Value::String(s) => Value::Text(s.clone()),
+        serde_json::Value::Array(arr) => Value::Array {
             elements: arr.iter().map(json_value_to_generated).collect(),
-            element_type: Box::new(sync_core::UniversalType::Text),
+            element_type: Box::new(sync_core::Type::Text),
         },
-        serde_json::Value::Object(_obj) => UniversalValue::Json(Box::new(value.clone())),
+        serde_json::Value::Object(_obj) => Value::Json(Box::new(value.clone())),
     }
 }
 
@@ -477,7 +477,7 @@ impl JsonConversionConfig {
 /// # Example
 /// ```
 /// use json_types::{JsonConversionConfig, json_to_typed_value_with_config};
-/// use sync_core::UniversalValue;
+/// use sync_core::Value;
 ///
 /// let config = JsonConversionConfig::new()
 ///     .with_boolean_path("settings.enabled")
@@ -493,8 +493,8 @@ pub fn json_to_typed_value_with_config(
     config: &JsonConversionConfig,
 ) -> TypedValue {
     let gv = json_to_generated_value_with_config(value, current_path, config);
-    // Convert UniversalValue back to serde_json::Value for TypedValue::json
-    let json_value = if let UniversalValue::Json(json_val) = gv {
+    // Convert Value back to serde_json::Value for TypedValue::json
+    let json_value = if let Value::Json(json_val) = gv {
         *json_val
     } else {
         // For other types, convert to JSON
@@ -503,17 +503,17 @@ pub fn json_to_typed_value_with_config(
     TypedValue::json(json_value)
 }
 
-/// Convert JSON to UniversalValue with path-based configuration.
+/// Convert JSON to Value with path-based configuration.
 ///
 /// This is the internal implementation that handles the recursive conversion.
 pub fn json_to_generated_value_with_config(
     value: serde_json::Value,
     current_path: &str,
     config: &JsonConversionConfig,
-) -> UniversalValue {
+) -> Value {
     match value {
-        serde_json::Value::Null => UniversalValue::Null,
-        serde_json::Value::Bool(b) => UniversalValue::Bool(b),
+        serde_json::Value::Null => Value::Null,
+        serde_json::Value::Bool(b) => Value::Bool(b),
         serde_json::Value::Number(n) => {
             // Check if this path should be treated as boolean
             let is_boolean_path = config.boolean_paths.iter().any(|p| p == current_path);
@@ -521,14 +521,14 @@ pub fn json_to_generated_value_with_config(
             if let Some(i) = n.as_i64() {
                 if is_boolean_path && (i == 0 || i == 1) {
                     // Convert 0/1 to boolean for specified paths
-                    UniversalValue::Bool(i == 1)
+                    Value::Bool(i == 1)
                 } else {
-                    UniversalValue::Int64(i)
+                    Value::Int64(i)
                 }
             } else if let Some(f) = n.as_f64() {
-                UniversalValue::Float64(f)
+                Value::Float64(f)
             } else {
-                UniversalValue::Text(n.to_string())
+                Value::Text(n.to_string())
             }
         }
         serde_json::Value::String(s) => {
@@ -538,26 +538,24 @@ pub fn json_to_generated_value_with_config(
             if is_set_path {
                 // Convert comma-separated SET values to array
                 if s.is_empty() {
-                    UniversalValue::Array {
+                    Value::Array {
                         elements: Vec::new(),
-                        element_type: Box::new(sync_core::UniversalType::Text),
+                        element_type: Box::new(sync_core::Type::Text),
                     }
                 } else {
-                    let values: Vec<UniversalValue> = s
-                        .split(',')
-                        .map(|v| UniversalValue::Text(v.to_string()))
-                        .collect();
-                    UniversalValue::Array {
+                    let values: Vec<Value> =
+                        s.split(',').map(|v| Value::Text(v.to_string())).collect();
+                    Value::Array {
                         elements: values,
-                        element_type: Box::new(sync_core::UniversalType::Text),
+                        element_type: Box::new(sync_core::Type::Text),
                     }
                 }
             } else {
-                UniversalValue::Text(s)
+                Value::Text(s)
             }
         }
         serde_json::Value::Array(arr) => {
-            let values: Vec<UniversalValue> = arr
+            let values: Vec<Value> = arr
                 .into_iter()
                 .enumerate()
                 .map(|(idx, item)| {
@@ -565,13 +563,13 @@ pub fn json_to_generated_value_with_config(
                     json_to_generated_value_with_config(item, &item_path, config)
                 })
                 .collect();
-            UniversalValue::Array {
+            Value::Array {
                 elements: values,
-                element_type: Box::new(sync_core::UniversalType::Text),
+                element_type: Box::new(sync_core::Type::Text),
             }
         }
         serde_json::Value::Object(obj) => {
-            let map: HashMap<String, UniversalValue> = obj
+            let map: HashMap<String, Value> = obj
                 .into_iter()
                 .map(|(key, val)| {
                     // Build the nested path for this field
@@ -590,23 +588,23 @@ pub fn json_to_generated_value_with_config(
                 .iter()
                 .map(|(k, v)| (k.clone(), universal_value_to_json(v)))
                 .collect();
-            UniversalValue::Json(Box::new(serde_json::Value::Object(json_obj)))
+            Value::Json(Box::new(serde_json::Value::Object(json_obj)))
         }
     }
 }
 
-/// Convert an UniversalValue to serde_json::Value (helper for config-based conversion).
-fn universal_value_to_json(value: &UniversalValue) -> serde_json::Value {
+/// Convert an Value to serde_json::Value (helper for config-based conversion).
+fn universal_value_to_json(value: &Value) -> serde_json::Value {
     match value {
-        UniversalValue::Null => serde_json::Value::Null,
-        UniversalValue::Bool(b) => serde_json::Value::Bool(*b),
-        UniversalValue::Int64(i) => serde_json::json!(*i),
-        UniversalValue::Float64(f) => serde_json::json!(*f),
-        UniversalValue::Text(s) => serde_json::Value::String(s.clone()),
-        UniversalValue::Array { elements, .. } => {
+        Value::Null => serde_json::Value::Null,
+        Value::Bool(b) => serde_json::Value::Bool(*b),
+        Value::Int64(i) => serde_json::json!(*i),
+        Value::Float64(f) => serde_json::json!(*f),
+        Value::Text(s) => serde_json::Value::String(s.clone()),
+        Value::Array { elements, .. } => {
             serde_json::Value::Array(elements.iter().map(universal_value_to_json).collect())
         }
-        UniversalValue::Json(json_val) => (**json_val).clone(),
+        Value::Json(json_val) => (**json_val).clone(),
         _ => serde_json::Value::Null,
     }
 }
@@ -615,7 +613,7 @@ fn universal_value_to_json(value: &UniversalValue) -> serde_json::Value {
 pub fn extract_field(
     obj: &serde_json::Map<String, serde_json::Value>,
     field: &str,
-    sync_type: &UniversalType,
+    sync_type: &Type,
 ) -> TypedValue {
     match obj.get(field) {
         Some(value) => JsonValueWithSchema::new(value.clone(), sync_type.clone()).to_typed_value(),
@@ -626,7 +624,7 @@ pub fn extract_field(
 /// Convert a complete JSON object to a map of TypedValues using schema.
 pub fn json_object_to_typed_values(
     obj: &serde_json::Map<String, serde_json::Value>,
-    schema: &[(String, UniversalType)],
+    schema: &[(String, Type)],
 ) -> HashMap<String, TypedValue> {
     let mut result = HashMap::new();
     for (field_name, sync_type) in schema {
@@ -639,7 +637,7 @@ pub fn json_object_to_typed_values(
 /// Parse a JSONL line and convert to typed values.
 pub fn parse_jsonl_line(
     line: &str,
-    schema: &[(String, UniversalType)],
+    schema: &[(String, Type)],
 ) -> Result<HashMap<String, TypedValue>, serde_json::Error> {
     let obj: serde_json::Map<String, serde_json::Value> = serde_json::from_str(line)?;
     Ok(json_object_to_typed_values(&obj, schema))
@@ -650,15 +648,15 @@ pub fn parse_jsonl_line(
 // These replace surreal2_types functions to enable decoupling from SurrealDB
 // ============================================================================
 
-/// Convert JSON value to UniversalValue using table schema for type lookup.
+/// Convert JSON value to Value using table schema for type lookup.
 ///
 /// This is the universal equivalent of `surreal2_types::json_to_surreal_with_table_schema`.
-/// Returns UniversalValue instead of surrealdb::sql::Value.
+/// Returns Value instead of surrealdb::sql::Value.
 pub fn json_to_universal_with_table_schema(
     value: serde_json::Value,
     field_name: &str,
     schema: &sync_core::TableDefinition,
-) -> anyhow::Result<UniversalValue> {
+) -> anyhow::Result<Value> {
     // Look up the column type for this field
     let column_type = schema.get_column_type(field_name);
 
@@ -675,16 +673,16 @@ pub fn json_to_universal_with_table_schema(
     }
 }
 
-/// Convert a string ID value to UniversalValue based on schema-defined type.
+/// Convert a string ID value to Value based on schema-defined type.
 ///
 /// This is the universal equivalent of `surreal2_types::convert_id_with_database_schema`.
-/// Returns UniversalValue instead of surrealdb::sql::Id.
-pub fn convert_id_to_universal_with_database_schema(
+/// Returns Value instead of surrealdb::sql::Id.
+pub fn convert_id_with_database_schema(
     id_str: &str,
     table_name: &str,
     id_column: &str,
     schema: &sync_core::DatabaseSchema,
-) -> anyhow::Result<UniversalValue> {
+) -> anyhow::Result<Value> {
     // Look up the table schema
     let table_schema = schema
         .get_table(table_name)
@@ -696,37 +694,34 @@ pub fn convert_id_to_universal_with_database_schema(
     })?;
 
     // Convert based on the schema-defined type
-    convert_id_to_universal_value(id_str, table_name, id_type)
+    convert_id_to_value(id_str, table_name, id_type)
 }
 
-/// Convert a string ID value to UniversalValue using UniversalType.
-pub fn convert_id_to_universal_value(
+/// Convert a string ID value to Value using Type.
+pub fn convert_id_to_value(
     id_str: &str,
     table_name: &str,
-    id_type: &UniversalType,
-) -> anyhow::Result<UniversalValue> {
+    id_type: &Type,
+) -> anyhow::Result<Value> {
     match id_type {
-        UniversalType::Int8 { .. }
-        | UniversalType::Int16
-        | UniversalType::Int32
-        | UniversalType::Int64 => {
+        Type::Int8 { .. } | Type::Int16 | Type::Int32 | Type::Int64 => {
             let id_int: i64 = id_str.parse().map_err(|e| {
                 anyhow::anyhow!(
                     "Failed to parse ID '{id_str}' as integer for table '{table_name}': {e}"
                 )
             })?;
-            Ok(UniversalValue::Int64(id_int))
+            Ok(Value::Int64(id_int))
         }
-        UniversalType::Uuid => {
+        Type::Uuid => {
             let uuid = uuid::Uuid::parse_str(id_str).map_err(|e| {
                 anyhow::anyhow!(
                     "Failed to parse ID '{id_str}' as UUID for table '{table_name}': {e}"
                 )
             })?;
-            Ok(UniversalValue::Uuid(uuid))
+            Ok(Value::Uuid(uuid))
         }
-        UniversalType::Text | UniversalType::VarChar { .. } | UniversalType::Char { .. } => {
-            Ok(UniversalValue::Text(id_str.to_string()))
+        Type::Text | Type::VarChar { .. } | Type::Char { .. } => {
+            Ok(Value::Text(id_str.to_string()))
         }
         other => {
             anyhow::bail!(
@@ -745,61 +740,61 @@ mod tests {
 
     #[test]
     fn test_null_conversion() {
-        let jv = JsonValueWithSchema::new(serde_json::Value::Null, UniversalType::Text);
+        let jv = JsonValueWithSchema::new(serde_json::Value::Null, Type::Text);
         let tv = TypedValue::from(jv);
-        assert!(matches!(tv.value, UniversalValue::Null));
+        assert!(matches!(tv.value, Value::Null));
     }
 
     #[test]
     fn test_bool_conversion() {
-        let jv = JsonValueWithSchema::new(json!(true), UniversalType::Bool);
+        let jv = JsonValueWithSchema::new(json!(true), Type::Bool);
         let tv = TypedValue::from(jv);
-        assert!(matches!(tv.value, UniversalValue::Bool(true)));
+        assert!(matches!(tv.value, Value::Bool(true)));
     }
 
     #[test]
     fn test_bool_from_number_zero() {
         // MySQL stores TINYINT(1) booleans as 0/1 in JSON_OBJECT
-        let jv = JsonValueWithSchema::new(json!(0), UniversalType::Bool);
+        let jv = JsonValueWithSchema::new(json!(0), Type::Bool);
         let tv = TypedValue::from(jv);
-        assert!(matches!(tv.value, UniversalValue::Bool(false)));
+        assert!(matches!(tv.value, Value::Bool(false)));
     }
 
     #[test]
     fn test_bool_from_number_one() {
         // MySQL stores TINYINT(1) booleans as 0/1 in JSON_OBJECT
-        let jv = JsonValueWithSchema::new(json!(1), UniversalType::Bool);
+        let jv = JsonValueWithSchema::new(json!(1), Type::Bool);
         let tv = TypedValue::from(jv);
-        assert!(matches!(tv.value, UniversalValue::Bool(true)));
+        assert!(matches!(tv.value, Value::Bool(true)));
     }
 
     #[test]
     fn test_bool_from_nonzero_number() {
         // Non-zero numbers should be true (like MySQL's boolean semantics)
-        let jv = JsonValueWithSchema::new(json!(42), UniversalType::Bool);
+        let jv = JsonValueWithSchema::new(json!(42), Type::Bool);
         let tv = TypedValue::from(jv);
-        assert!(matches!(tv.value, UniversalValue::Bool(true)));
+        assert!(matches!(tv.value, Value::Bool(true)));
     }
 
     #[test]
     fn test_int_conversion() {
-        let jv = JsonValueWithSchema::new(json!(42), UniversalType::Int32);
+        let jv = JsonValueWithSchema::new(json!(42), Type::Int32);
         let tv = TypedValue::from(jv);
-        assert!(matches!(tv.value, UniversalValue::Int32(42)));
+        assert!(matches!(tv.value, Value::Int32(42)));
     }
 
     #[test]
     fn test_bigint_conversion() {
-        let jv = JsonValueWithSchema::new(json!(9876543210i64), UniversalType::Int64);
+        let jv = JsonValueWithSchema::new(json!(9876543210i64), Type::Int64);
         let tv = TypedValue::from(jv);
-        assert!(matches!(tv.value, UniversalValue::Int64(9876543210)));
+        assert!(matches!(tv.value, Value::Int64(9876543210)));
     }
 
     #[test]
     fn test_float_conversion() {
-        let jv = JsonValueWithSchema::new(json!(1.23456), UniversalType::Float64);
+        let jv = JsonValueWithSchema::new(json!(1.23456), Type::Float64);
         let tv = TypedValue::from(jv);
-        if let UniversalValue::Float64(f) = tv.value {
+        if let Value::Float64(f) = tv.value {
             assert!((f - 1.23456).abs() < 0.00001);
         } else {
             panic!("Expected Float64");
@@ -810,13 +805,13 @@ mod tests {
     fn test_decimal_from_string() {
         let jv = JsonValueWithSchema::new(
             json!("123.456"),
-            UniversalType::Decimal {
+            Type::Decimal {
                 precision: 10,
                 scale: 3,
             },
         );
         let tv = TypedValue::from(jv);
-        if let UniversalValue::Decimal {
+        if let Value::Decimal {
             value,
             precision,
             scale,
@@ -832,20 +827,17 @@ mod tests {
 
     #[test]
     fn test_string_conversion() {
-        let jv = JsonValueWithSchema::new(json!("hello world"), UniversalType::Text);
+        let jv = JsonValueWithSchema::new(json!("hello world"), Type::Text);
         let tv = TypedValue::from(jv);
-        assert!(matches!(tv.value, UniversalValue::Text(ref s) if s == "hello world"));
+        assert!(matches!(tv.value, Value::Text(ref s) if s == "hello world"));
     }
 
     #[test]
     fn test_varchar_conversion() {
-        let jv = JsonValueWithSchema::new(json!("test"), UniversalType::VarChar { length: 100 });
+        let jv = JsonValueWithSchema::new(json!("test"), Type::VarChar { length: 100 });
         let tv = TypedValue::from(jv);
-        assert!(matches!(
-            tv.sync_type,
-            UniversalType::VarChar { length: 100 }
-        ));
-        if let UniversalValue::VarChar { value, length } = tv.value {
+        assert!(matches!(tv.sync_type, Type::VarChar { length: 100 }));
+        if let Value::VarChar { value, length } = tv.value {
             assert_eq!(value, "test");
             assert_eq!(length, 100);
         } else {
@@ -856,19 +848,17 @@ mod tests {
     #[test]
     fn test_bytes_from_base64() {
         let encoded = base64::engine::general_purpose::STANDARD.encode(vec![0x01, 0x02, 0x03]);
-        let jv = JsonValueWithSchema::new(json!(encoded), UniversalType::Bytes);
+        let jv = JsonValueWithSchema::new(json!(encoded), Type::Bytes);
         let tv = TypedValue::from(jv);
-        assert!(matches!(tv.value, UniversalValue::Bytes(ref b) if *b == vec![0x01, 0x02, 0x03]));
+        assert!(matches!(tv.value, Value::Bytes(ref b) if *b == vec![0x01, 0x02, 0x03]));
     }
 
     #[test]
     fn test_uuid_conversion() {
-        let jv = JsonValueWithSchema::new(
-            json!("550e8400-e29b-41d4-a716-446655440000"),
-            UniversalType::Uuid,
-        );
+        let jv =
+            JsonValueWithSchema::new(json!("550e8400-e29b-41d4-a716-446655440000"), Type::Uuid);
         let tv = TypedValue::from(jv);
-        if let UniversalValue::Uuid(u) = tv.value {
+        if let Value::Uuid(u) = tv.value {
             assert_eq!(u.to_string(), "550e8400-e29b-41d4-a716-446655440000");
         } else {
             panic!("Expected Uuid");
@@ -878,9 +868,9 @@ mod tests {
     #[test]
     fn test_datetime_conversion() {
         let dt = Utc.with_ymd_and_hms(2024, 6, 15, 10, 30, 0).unwrap();
-        let jv = JsonValueWithSchema::new(json!(dt.to_rfc3339()), UniversalType::LocalDateTime);
+        let jv = JsonValueWithSchema::new(json!(dt.to_rfc3339()), Type::LocalDateTime);
         let tv = TypedValue::from(jv);
-        if let UniversalValue::LocalDateTime(result_dt) = tv.value {
+        if let Value::LocalDateTime(result_dt) = tv.value {
             assert_eq!(result_dt.year(), 2024);
             assert_eq!(result_dt.month(), 6);
             assert_eq!(result_dt.day(), 15);
@@ -896,12 +886,12 @@ mod tests {
     fn test_datetime_postgresql_to_jsonb_format() {
         // This is the exact format PostgreSQL's to_jsonb() produces for TIMESTAMP columns
         let json_str = "2024-11-13T20:15:33";
-        let jv = JsonValueWithSchema::new(json!(json_str), UniversalType::LocalDateTime);
+        let jv = JsonValueWithSchema::new(json!(json_str), Type::LocalDateTime);
         let tv = TypedValue::from(jv);
 
         // This MUST NOT return null - PostgreSQL timestamps must be parseable
         match &tv.value {
-            UniversalValue::LocalDateTime(dt) => {
+            Value::LocalDateTime(dt) => {
                 assert_eq!(dt.year(), 2024);
                 assert_eq!(dt.month(), 11);
                 assert_eq!(dt.day(), 13);
@@ -909,7 +899,7 @@ mod tests {
                 assert_eq!(dt.minute(), 15);
                 assert_eq!(dt.second(), 33);
             }
-            UniversalValue::Null => {
+            Value::Null => {
                 panic!(
                     "PostgreSQL timestamp format '{json_str}' was not parsed! parse_datetime_string failed."
                 );
@@ -933,9 +923,9 @@ mod tests {
 
     #[test]
     fn test_date_from_string() {
-        let jv = JsonValueWithSchema::new(json!("2024-06-15"), UniversalType::Date);
+        let jv = JsonValueWithSchema::new(json!("2024-06-15"), Type::Date);
         let tv = TypedValue::from(jv);
-        if let UniversalValue::Date(dt) = tv.value {
+        if let Value::Date(dt) = tv.value {
             assert_eq!(dt.format("%Y-%m-%d").to_string(), "2024-06-15");
         } else {
             panic!("Expected Date, got {:?}", tv.value);
@@ -944,12 +934,12 @@ mod tests {
 
     #[test]
     fn test_zero_date_literal_emits_zero_temporal() {
-        let jv = JsonValueWithSchema::new(json!("0000-00-00"), UniversalType::Date);
+        let jv = JsonValueWithSchema::new(json!("0000-00-00"), Type::Date);
         let tv = TypedValue::from(jv);
         assert!(matches!(
             tv.value,
-            UniversalValue::ZeroTemporal {
-                intended_type: UniversalType::Date,
+            Value::ZeroTemporal {
+                intended_type: Type::Date,
                 ..
             }
         ));
@@ -957,13 +947,12 @@ mod tests {
 
     #[test]
     fn test_zero_datetime_literal_emits_zero_temporal() {
-        let jv =
-            JsonValueWithSchema::new(json!("0000-00-00 00:00:00"), UniversalType::LocalDateTime);
+        let jv = JsonValueWithSchema::new(json!("0000-00-00 00:00:00"), Type::LocalDateTime);
         let tv = TypedValue::from(jv);
         assert!(matches!(
             tv.value,
-            UniversalValue::ZeroTemporal {
-                intended_type: UniversalType::LocalDateTime,
+            Value::ZeroTemporal {
+                intended_type: Type::LocalDateTime,
                 ..
             }
         ));
@@ -971,9 +960,9 @@ mod tests {
 
     #[test]
     fn test_time_from_string() {
-        let jv = JsonValueWithSchema::new(json!("14:30:45"), UniversalType::Time);
+        let jv = JsonValueWithSchema::new(json!("14:30:45"), Type::Time);
         let tv = TypedValue::from(jv);
-        if let UniversalValue::Time(dt) = tv.value {
+        if let Value::Time(dt) = tv.value {
             assert_eq!(dt.format("%H:%M:%S").to_string(), "14:30:45");
         } else {
             panic!("Expected Time, got {:?}", tv.value);
@@ -982,10 +971,9 @@ mod tests {
 
     #[test]
     fn test_json_object_conversion() {
-        let jv =
-            JsonValueWithSchema::new(json!({"name": "test", "count": 42}), UniversalType::Json);
+        let jv = JsonValueWithSchema::new(json!({"name": "test", "count": 42}), Type::Json);
         let tv = TypedValue::from(jv);
-        if let UniversalValue::Json(json_val) = tv.value {
+        if let Value::Json(json_val) = tv.value {
             if let serde_json::Value::Object(map) = json_val.as_ref() {
                 assert!(
                     matches!(map.get("name"), Some(serde_json::Value::String(s)) if s == "test")
@@ -1004,9 +992,9 @@ mod tests {
     #[test]
     fn test_json_array_conversion() {
         // JSON columns in MySQL can contain arrays - stored as Json with array content
-        let jv = JsonValueWithSchema::new(json!([1, 2, 3]), UniversalType::Json);
+        let jv = JsonValueWithSchema::new(json!([1, 2, 3]), Type::Json);
         let tv = TypedValue::from(jv);
-        if let UniversalValue::Json(json_val) = tv.value {
+        if let Value::Json(json_val) = tv.value {
             if let serde_json::Value::Array(arr) = json_val.as_ref() {
                 assert_eq!(arr.len(), 3);
                 assert!(
@@ -1029,9 +1017,9 @@ mod tests {
     #[test]
     fn test_json_array_of_strings_conversion() {
         // JSON columns can contain arrays of strings (e.g., tags field) - stored as Json
-        let jv = JsonValueWithSchema::new(json!(["tag1", "tag2", "tag3"]), UniversalType::Json);
+        let jv = JsonValueWithSchema::new(json!(["tag1", "tag2", "tag3"]), Type::Json);
         let tv = TypedValue::from(jv);
-        if let UniversalValue::Json(json_val) = tv.value {
+        if let Value::Json(json_val) = tv.value {
             if let serde_json::Value::Array(arr) = json_val.as_ref() {
                 assert_eq!(arr.len(), 3);
                 assert!(matches!(arr[0], serde_json::Value::String(ref s) if s == "tag1"));
@@ -1048,9 +1036,9 @@ mod tests {
     #[test]
     fn test_jsonb_array_conversion() {
         // JSONB columns can also contain arrays - stored as Jsonb
-        let jv = JsonValueWithSchema::new(json!([1, 2, 3]), UniversalType::Jsonb);
+        let jv = JsonValueWithSchema::new(json!([1, 2, 3]), Type::Jsonb);
         let tv = TypedValue::from(jv);
-        if let UniversalValue::Jsonb(json_val) = tv.value {
+        if let Value::Jsonb(json_val) = tv.value {
             if let serde_json::Value::Array(arr) = json_val.as_ref() {
                 assert_eq!(arr.len(), 3);
                 assert!(
@@ -1068,14 +1056,14 @@ mod tests {
     fn test_array_int_conversion() {
         let jv = JsonValueWithSchema::new(
             json!([1, 2, 3]),
-            UniversalType::Array {
-                element_type: Box::new(UniversalType::Int32),
+            Type::Array {
+                element_type: Box::new(Type::Int32),
             },
         );
         let tv = TypedValue::from(jv);
-        if let UniversalValue::Array { elements, .. } = tv.value {
+        if let Value::Array { elements, .. } = tv.value {
             assert_eq!(elements.len(), 3);
-            assert!(matches!(elements[0], UniversalValue::Int32(1)));
+            assert!(matches!(elements[0], Value::Int32(1)));
         } else {
             panic!("Expected Array");
         }
@@ -1085,12 +1073,12 @@ mod tests {
     fn test_set_conversion() {
         let jv = JsonValueWithSchema::new(
             json!(["a", "b"]),
-            UniversalType::Set {
+            Type::Set {
                 values: vec!["a".to_string(), "b".to_string(), "c".to_string()],
             },
         );
         let tv = TypedValue::from(jv);
-        if let UniversalValue::Set { elements, .. } = tv.value {
+        if let Value::Set { elements, .. } = tv.value {
             assert_eq!(elements.len(), 2);
             assert!(elements.contains(&"a".to_string()));
             assert!(elements.contains(&"b".to_string()));
@@ -1103,12 +1091,12 @@ mod tests {
     fn test_enum_conversion() {
         let jv = JsonValueWithSchema::new(
             json!("active"),
-            UniversalType::Enum {
+            Type::Enum {
                 values: vec!["active".to_string(), "inactive".to_string()],
             },
         );
         let tv = TypedValue::from(jv);
-        if let UniversalValue::Enum { value, .. } = tv.value {
+        if let Value::Enum { value, .. } = tv.value {
             assert_eq!(value, "active");
         } else {
             panic!("Expected Enum, got {:?}", tv.value);
@@ -1119,12 +1107,12 @@ mod tests {
     fn test_geometry_conversion() {
         let jv = JsonValueWithSchema::new(
             json!({"type": "Point", "coordinates": [-73.97, 40.77]}),
-            UniversalType::Geometry {
+            Type::Geometry {
                 geometry_type: GeometryType::Point,
             },
         );
         let tv = TypedValue::from(jv);
-        if let UniversalValue::Geometry { data, .. } = tv.value {
+        if let Value::Geometry { data, .. } = tv.value {
             use sync_core::values::GeometryData;
             let GeometryData(ref geo_json) = data;
             if let serde_json::Value::Object(map) = geo_json {
@@ -1146,42 +1134,42 @@ mod tests {
             .unwrap()
             .clone();
 
-        let name = extract_field(&obj, "name", &UniversalType::Text);
-        assert!(matches!(name.value, UniversalValue::Text(ref s) if s == "Alice"));
+        let name = extract_field(&obj, "name", &Type::Text);
+        assert!(matches!(name.value, Value::Text(ref s) if s == "Alice"));
 
-        let age = extract_field(&obj, "age", &UniversalType::Int32);
-        assert!(matches!(age.value, UniversalValue::Int32(30)));
+        let age = extract_field(&obj, "age", &Type::Int32);
+        assert!(matches!(age.value, Value::Int32(30)));
 
-        let missing = extract_field(&obj, "missing", &UniversalType::Text);
-        assert!(matches!(missing.value, UniversalValue::Null));
+        let missing = extract_field(&obj, "missing", &Type::Text);
+        assert!(matches!(missing.value, Value::Null));
     }
 
     #[test]
     fn test_parse_jsonl_line() {
         let line = r#"{"name": "Bob", "active": true, "score": 95.5}"#;
         let schema = vec![
-            ("name".to_string(), UniversalType::Text),
-            ("active".to_string(), UniversalType::Bool),
-            ("score".to_string(), UniversalType::Float64),
+            ("name".to_string(), Type::Text),
+            ("active".to_string(), Type::Bool),
+            ("score".to_string(), Type::Float64),
         ];
 
         let values = parse_jsonl_line(line, &schema).unwrap();
         assert!(matches!(
             values.get("name").unwrap().value,
-            UniversalValue::Text(ref s) if s == "Bob"
+            Value::Text(ref s) if s == "Bob"
         ));
         assert!(matches!(
             values.get("active").unwrap().value,
-            UniversalValue::Bool(true)
+            Value::Bool(true)
         ));
     }
 
     #[test]
     fn test_duration_conversion() {
         // Test parsing ISO 8601 duration string "PT181S" (181 seconds)
-        let jv = JsonValueWithSchema::new(json!("PT181S"), UniversalType::Duration);
+        let jv = JsonValueWithSchema::new(json!("PT181S"), Type::Duration);
         let tv = TypedValue::from(jv);
-        if let UniversalValue::Duration(d) = tv.value {
+        if let Value::Duration(d) = tv.value {
             assert_eq!(d.as_secs(), 181);
             assert_eq!(d.subsec_nanos(), 0);
         } else {
@@ -1192,9 +1180,9 @@ mod tests {
     #[test]
     fn test_duration_with_nanos_conversion() {
         // Test parsing ISO 8601 duration string "PT60.123456789S" (60 seconds + 123456789 nanoseconds)
-        let jv = JsonValueWithSchema::new(json!("PT60.123456789S"), UniversalType::Duration);
+        let jv = JsonValueWithSchema::new(json!("PT60.123456789S"), Type::Duration);
         let tv = TypedValue::from(jv);
-        if let UniversalValue::Duration(d) = tv.value {
+        if let Value::Duration(d) = tv.value {
             assert_eq!(d.as_secs(), 60);
             assert_eq!(d.subsec_nanos(), 123456789);
         } else {
@@ -1205,9 +1193,9 @@ mod tests {
     #[test]
     fn test_duration_invalid_format() {
         // Test that invalid duration strings return null
-        let jv = JsonValueWithSchema::new(json!("not a duration"), UniversalType::Duration);
+        let jv = JsonValueWithSchema::new(json!("not a duration"), Type::Duration);
         let tv = TypedValue::from(jv);
-        assert!(matches!(tv.value, UniversalValue::Null));
+        assert!(matches!(tv.value, Value::Null));
     }
 
     #[test]
@@ -1217,26 +1205,26 @@ mod tests {
         use sync_core::{ColumnDefinition, TableDefinition};
 
         // Create a table schema with an array column
-        let pk = ColumnDefinition::new("id", UniversalType::Text);
+        let pk = ColumnDefinition::new("id", Type::Text);
         let columns = vec![ColumnDefinition::new(
             "tags",
-            UniversalType::Array {
-                element_type: Box::new(UniversalType::Text),
+            Type::Array {
+                element_type: Box::new(Type::Text),
             },
         )];
         let table_schema = TableDefinition::new("test_table", pk, columns);
 
-        // Test converting a JSON array to UniversalValue::Array
+        // Test converting a JSON array to Value::Array
         let json_array = json!(["tag1", "tag2", "tag3"]);
         let result =
             json_to_universal_with_table_schema(json_array, "tags", &table_schema).unwrap();
 
         match result {
-            UniversalValue::Array { elements, .. } => {
+            Value::Array { elements, .. } => {
                 assert_eq!(elements.len(), 3);
-                assert!(matches!(&elements[0], UniversalValue::Text(s) if s == "tag1"));
-                assert!(matches!(&elements[1], UniversalValue::Text(s) if s == "tag2"));
-                assert!(matches!(&elements[2], UniversalValue::Text(s) if s == "tag3"));
+                assert!(matches!(&elements[0], Value::Text(s) if s == "tag1"));
+                assert!(matches!(&elements[1], Value::Text(s) if s == "tag2"));
+                assert!(matches!(&elements[2], Value::Text(s) if s == "tag3"));
             }
             other => panic!("Expected Array, got {other:?}"),
         }
@@ -1244,14 +1232,14 @@ mod tests {
 
     #[test]
     fn test_json_to_universal_with_table_schema_null_array() {
-        // Test that null JSON values become UniversalValue::Null even for array columns
+        // Test that null JSON values become Value::Null even for array columns
         use sync_core::{ColumnDefinition, TableDefinition};
 
-        let pk = ColumnDefinition::new("id", UniversalType::Text);
+        let pk = ColumnDefinition::new("id", Type::Text);
         let columns = vec![ColumnDefinition::new(
             "tags",
-            UniversalType::Array {
-                element_type: Box::new(UniversalType::Text),
+            Type::Array {
+                element_type: Box::new(Type::Text),
             },
         )];
         let table_schema = TableDefinition::new("test_table", pk, columns);
@@ -1260,7 +1248,7 @@ mod tests {
         let result = json_to_universal_with_table_schema(json_null, "tags", &table_schema).unwrap();
 
         assert!(
-            matches!(result, UniversalValue::Null),
+            matches!(result, Value::Null),
             "Expected Null, got {result:?}"
         );
     }
@@ -1270,7 +1258,7 @@ mod tests {
         // Test that unknown fields fall back to generic conversion
         use sync_core::{ColumnDefinition, TableDefinition};
 
-        let pk = ColumnDefinition::new("id", UniversalType::Text);
+        let pk = ColumnDefinition::new("id", Type::Text);
         let columns = vec![];
         let table_schema = TableDefinition::new("test_table", pk, columns);
 
@@ -1281,7 +1269,7 @@ mod tests {
                 .unwrap();
 
         match result {
-            UniversalValue::Array { elements, .. } => {
+            Value::Array { elements, .. } => {
                 assert_eq!(elements.len(), 2);
             }
             other => panic!("Expected Array from generic conversion, got {other:?}"),

--- a/crates/jsonl-source/src/sync.rs
+++ b/crates/jsonl-source/src/sync.rs
@@ -3,15 +3,13 @@
 use crate::conversion::ConversionRule;
 use anyhow::{anyhow, Context, Result};
 use json_types::JsonValueWithSchema;
-use serde_json::Value;
+use serde_json::Value as JsonValue;
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use surreal_sink::SurrealSink;
 use surreal_sync_file::{FileSource, DEFAULT_BUFFER_SIZE};
-use sync_core::{
-    DatabaseSchema, TableDefinition, TypedValue, UniversalRow, UniversalType, UniversalValue,
-};
+use sync_core::{DatabaseSchema, Row, TableDefinition, Type, TypedValue, Value};
 use sync_transform::{
     run_source_runtime, ApplyOpts, CheckpointPolicy, Pipeline, PositionedEvent, SourceDriver,
     SourceRuntimeOpts,
@@ -43,7 +41,7 @@ pub struct Config {
     pub id_field: String,
 
     /// Multi-column record ID fields (takes precedence over `id_field` when non-empty).
-    /// When two or more are set, the ID is an [`UniversalValue::Array`].
+    /// When two or more are set, the ID is an [`Value::Array`].
     pub id_columns: Vec<String>,
 
     /// Conversion rules for transforming JSON objects to Thing references
@@ -81,25 +79,19 @@ struct DryRunSink;
 
 #[async_trait::async_trait]
 impl SurrealSink for DryRunSink {
-    async fn write_universal_rows(&self, _rows: &[UniversalRow]) -> Result<()> {
+    async fn write_rows(&self, _rows: &[Row]) -> Result<()> {
         Ok(())
     }
 
-    async fn write_universal_relations(
-        &self,
-        _relations: &[sync_core::UniversalRelation],
-    ) -> Result<()> {
+    async fn write_relations(&self, _relations: &[sync_core::Relation]) -> Result<()> {
         Ok(())
     }
 
-    async fn apply_universal_change(&self, _change: &sync_core::UniversalChange) -> Result<()> {
+    async fn apply_change(&self, _change: &sync_core::Change) -> Result<()> {
         Ok(())
     }
 
-    async fn apply_universal_relation_change(
-        &self,
-        _change: &sync_core::UniversalRelationChange,
-    ) -> Result<()> {
+    async fn apply_relation_change(&self, _change: &sync_core::RelationChange) -> Result<()> {
         Ok(())
     }
 }
@@ -142,7 +134,7 @@ impl SourceDriver for JsonlStreamDriver {
                 continue;
             }
 
-            let json_value: Value = serde_json::from_str(&line)
+            let json_value: JsonValue = serde_json::from_str(&line)
                 .map_err(|e| anyhow!("Error parsing JSON at line {}: {e}", self.line_count))?;
 
             let row = convert_json_to_universal_row(
@@ -155,7 +147,7 @@ impl SourceDriver for JsonlStreamDriver {
                 self.line_count,
             )?;
             let pos = self.line_count;
-            let change = sync_core::UniversalChange::update(row.table, row.id, row.fields);
+            let change = sync_core::Change::update(row.table, row.id, row.fields);
             events.push(PositionedEvent::change(change, pos));
         }
         Ok(events)
@@ -183,7 +175,7 @@ impl SourceDriver for JsonlStreamDriver {
 /// This function handles all JSONL parsing, data conversion, and SurrealDB insertion
 /// for a single JSONL source (file, S3, or HTTP).
 ///
-/// [`ConversionRule`]s are applied while building each [`UniversalRow`], before
+/// [`ConversionRule`]s are applied while building each [`Row`], before
 /// the batch is passed through the transform [`Pipeline`].
 async fn process_jsonl_reader<S: SurrealSink>(
     surreal: &S,
@@ -296,7 +288,7 @@ pub async fn sync<S: SurrealSink>(surreal: &S, config: Config) -> Result<()> {
 ///
 /// The driver streams line reads into the apply window (`Config::batch_size`
 /// rows per poll). [`Config::conversion_rules`] still run while decoding each
-/// line into a [`UniversalRow`], before any Pipeline stages. **Multi-file
+/// line into a [`Row`], before any Pipeline stages. **Multi-file
 /// imports start a fresh runtime per file** (intentional — no cross-file
 /// pipelining).
 pub async fn sync_with_transforms<S: SurrealSink>(
@@ -451,33 +443,33 @@ pub async fn sync_with_transforms<S: SurrealSink>(
 }
 
 fn convert_json_to_universal_row(
-    value: &Value,
+    value: &JsonValue,
     table_name: &str,
     id_field: &str,
     id_columns: &[String],
     rules: &[ConversionRule],
     table_schema: Option<&TableDefinition>,
     record_index: u64,
-) -> Result<UniversalRow> {
+) -> Result<Row> {
     let effective_id_cols: Vec<&str> = if id_columns.is_empty() {
         vec![id_field]
     } else {
         id_columns.iter().map(|s| s.as_str()).collect()
     };
 
-    if let Value::Object(obj) = value {
-        let mut fields: HashMap<String, UniversalValue> = HashMap::new();
-        let mut id_parts: Vec<Option<UniversalValue>> = vec![None; effective_id_cols.len()];
+    if let JsonValue::Object(obj) = value {
+        let mut fields: HashMap<String, Value> = HashMap::new();
+        let mut id_parts: Vec<Option<Value>> = vec![None; effective_id_cols.len()];
 
         for (key, val) in obj {
             if let Some(idx) = effective_id_cols.iter().position(|c| *c == key) {
-                let part = if let Value::String(s) = val {
-                    UniversalValue::Text(s.clone())
-                } else if let Value::Number(n) = val {
+                let part = if let JsonValue::String(s) = val {
+                    Value::Text(s.clone())
+                } else if let JsonValue::Number(n) = val {
                     if let Some(i) = n.as_i64() {
-                        UniversalValue::Int64(i)
+                        Value::Int64(i)
                     } else if let Some(u) = n.as_u64() {
-                        UniversalValue::Int64(u as i64)
+                        Value::Int64(u as i64)
                     } else {
                         anyhow::bail!("ID field number must be an integer: {n}");
                     }
@@ -501,34 +493,29 @@ fn convert_json_to_universal_row(
         }
         let id = sync_core::build_composite_record_id(parts);
 
-        Ok(UniversalRow::new(
-            table_name.to_string(),
-            record_index,
-            id,
-            fields,
-        ))
+        Ok(Row::new(table_name.to_string(), record_index, id, fields))
     } else {
         Err(anyhow!("JSONL line must be a JSON object"))
     }
 }
 
-/// Convert a JSON value to UniversalValue with optional schema type hint
+/// Convert a JSON value to Value with optional schema type hint
 fn convert_value_to_universal(
-    value: &Value,
+    value: &JsonValue,
     rules: &[ConversionRule],
-    data_type: Option<&UniversalType>,
-) -> UniversalValue {
+    data_type: Option<&Type>,
+) -> Value {
     // First check if this is an object that matches a conversion rule (Thing reference)
     // Convert Thing references to Text format "table:id"
-    if let Value::Object(obj) = value {
+    if let JsonValue::Object(obj) = value {
         if let Some(type_value) = obj.get("type").and_then(|v| v.as_str()) {
             for rule in rules {
                 if rule.type_value == type_value {
                     // This object matches the rule, convert to Thing reference as text
                     if let Some(id_value) = obj.get(&rule.id_field).and_then(|v| v.as_str()) {
-                        return UniversalValue::Thing {
+                        return Value::Thing {
                             table: rule.target_table.clone(),
-                            id: Box::new(UniversalValue::Text(id_value.to_string())),
+                            id: Box::new(Value::Text(id_value.to_string())),
                         };
                     }
                 }
@@ -550,20 +537,20 @@ fn convert_value_to_universal(
 ///
 /// Note: This function does NOT handle Thing conversion rules.
 /// Thing conversion is handled in convert_value_with_schema before calling this.
-fn convert_value_inferred(value: &Value) -> TypedValue {
+fn convert_value_inferred(value: &JsonValue) -> TypedValue {
     match value {
-        Value::Null => TypedValue::null(UniversalType::Text),
-        Value::Bool(b) => TypedValue::bool(*b),
-        Value::Number(n) => {
+        JsonValue::Null => TypedValue::null(Type::Text),
+        JsonValue::Bool(b) => TypedValue::bool(*b),
+        JsonValue::Number(n) => {
             if let Some(i) = n.as_i64() {
                 TypedValue::int64(i)
             } else if let Some(f) = n.as_f64() {
                 TypedValue::float64(f)
             } else {
-                TypedValue::null(UniversalType::Int64)
+                TypedValue::null(Type::Int64)
             }
         }
-        Value::String(s) => {
+        JsonValue::String(s) => {
             // Try to parse as UUID
             if let Ok(uuid) = uuid::Uuid::parse_str(s) {
                 return TypedValue::uuid(uuid);
@@ -574,18 +561,18 @@ fn convert_value_inferred(value: &Value) -> TypedValue {
             }
             TypedValue::text(s)
         }
-        Value::Array(arr) => {
-            let values: Vec<UniversalValue> = arr
+        JsonValue::Array(arr) => {
+            let values: Vec<Value> = arr
                 .iter()
                 .map(|item| convert_value_inferred(item).value)
                 .collect();
-            TypedValue::array(values, UniversalType::Text)
+            TypedValue::array(values, Type::Text)
         }
-        Value::Object(obj) => {
+        JsonValue::Object(obj) => {
             // Convert as regular object (Thing rules already checked in convert_value_with_schema)
             TypedValue {
-                sync_type: UniversalType::Json,
-                value: UniversalValue::Json(Box::new(serde_json::Value::Object(obj.clone()))),
+                sync_type: Type::Json,
+                value: Value::Json(Box::new(serde_json::Value::Object(obj.clone()))),
             }
         }
     }

--- a/crates/jsonl-source/tests/transforms.rs
+++ b/crates/jsonl-source/tests/transforms.rs
@@ -9,12 +9,12 @@ use std::sync::Mutex;
 
 use surreal_sink::SurrealSink;
 use surreal_sync_jsonl_source::{sync, sync_with_transforms, Config};
-use sync_core::{UniversalChange, UniversalRelation, UniversalRow, UniversalValue};
+use sync_core::{Change, Relation, Row, Value};
 use sync_transform::{ApplyOpts, ChildStdioMode, ExternalTransform, FramerKind, Pipeline};
 use tempfile::NamedTempFile;
 
 struct CaptureSink {
-    rows: Mutex<Vec<UniversalRow>>,
+    rows: Mutex<Vec<Row>>,
 }
 
 impl CaptureSink {
@@ -27,33 +27,30 @@ impl CaptureSink {
 
 #[async_trait::async_trait]
 impl SurrealSink for CaptureSink {
-    async fn write_universal_rows(&self, rows: &[UniversalRow]) -> anyhow::Result<()> {
+    async fn write_rows(&self, rows: &[Row]) -> anyhow::Result<()> {
         self.rows.lock().expect("lock").extend(rows.iter().cloned());
         Ok(())
     }
 
-    async fn write_universal_relations(
-        &self,
-        _relations: &[UniversalRelation],
-    ) -> anyhow::Result<()> {
+    async fn write_relations(&self, _relations: &[Relation]) -> anyhow::Result<()> {
         Ok(())
     }
 
-    async fn apply_universal_change(&self, change: &UniversalChange) -> anyhow::Result<()> {
+    async fn apply_change(&self, change: &Change) -> anyhow::Result<()> {
         let mut rows = self.rows.lock().expect("lock");
         let index = rows.len() as u64;
-        rows.push(UniversalRow::new(
+        rows.push(Row::new(
             change.table.clone(),
             index,
             change.id.clone(),
-            change.data.clone().unwrap_or_default(),
+            change.fields.clone().unwrap_or_default(),
         ));
         Ok(())
     }
 
-    async fn apply_universal_relation_change(
+    async fn apply_relation_change(
         &self,
-        _change: &sync_core::UniversalRelationChange,
+        _change: &sync_core::RelationChange,
     ) -> anyhow::Result<()> {
         Ok(())
     }
@@ -91,18 +88,18 @@ fn ensure_fixture_worker() -> PathBuf {
     path
 }
 
-fn row_name(row: &UniversalRow) -> Option<String> {
+fn row_name(row: &Row) -> Option<String> {
     match row.fields.get("name")? {
-        UniversalValue::Text(value) => Some(value.clone()),
+        Value::Text(value) => Some(value.clone()),
         other => panic!("unexpected name: {other:?}"),
     }
 }
 
-fn row_parent_thing(row: &UniversalRow) -> Option<(String, String)> {
+fn row_parent_thing(row: &Row) -> Option<(String, String)> {
     match row.fields.get("parent")? {
-        UniversalValue::Thing { table, id } => {
+        Value::Thing { table, id } => {
             let id_text = match id.as_ref() {
-                UniversalValue::Text(s) => s.clone(),
+                Value::Text(s) => s.clone(),
                 other => panic!("unexpected thing id: {other:?}"),
             };
             Some((table.clone(), id_text))
@@ -250,6 +247,6 @@ type = "flatten_id"
 
     let rows = sink.rows.lock().expect("lock").clone();
     assert_eq!(rows.len(), 2);
-    assert_eq!(rows[0].id, UniversalValue::Text("a:b".into()));
-    assert_eq!(rows[1].id, UniversalValue::Text("1:2".into()));
+    assert_eq!(rows[0].id, Value::Text("a:b".into()));
+    assert_eq!(rows[1].id, Value::Text("1:2".into()));
 }

--- a/crates/kafka-source/src/sync/incremental.rs
+++ b/crates/kafka-source/src/sync/incremental.rs
@@ -23,7 +23,7 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use surreal_sink::SurrealSink;
-use sync_core::{TableDefinition, TypedValue, UniversalChange, UniversalRow, UniversalValue};
+use sync_core::{Change, Row, TableDefinition, TypedValue, Value};
 use sync_transform::{
     run_source_runtime, ApplyOpts, CheckpointPolicy, Pipeline, PositionedEvent, SourceDriver,
     SourceRuntimeOpts, StopReason,
@@ -305,7 +305,7 @@ struct KafkaSourceDriver {
     ready_to_commit: Vec<Message>,
     /// Message count watermark (advanced only after sink via `note_sunk_events`).
     processed_count: Arc<AtomicU64>,
-    /// Poll-time `UniversalRow.index` allocator (advances on receive, not commit).
+    /// Poll-time `Row.index` allocator (advances on receive, not commit).
     /// Separated from `processed_count` so overlapping polls never reuse indices.
     next_row_index: Arc<AtomicU64>,
     max_messages: Option<u64>,
@@ -430,11 +430,11 @@ impl SourceDriver for KafkaSourceDriver {
     }
 }
 
-fn row_to_upsert_change(row: UniversalRow) -> UniversalChange {
-    UniversalChange::update(row.table, row.id, row.fields)
+fn row_to_upsert_change(row: Row) -> Change {
+    Change::update(row.table, row.id, row.fields)
 }
 
-/// Convert typed values to UniversalRow.
+/// Convert typed values to Row.
 ///
 /// Either uses the message key (base64 encoded) as ID, or extracts the ID from
 /// one or more payload fields (`id_columns` when non-empty, else `id_field`).
@@ -446,13 +446,13 @@ fn typed_values_to_universal_row(
     id_field: &str,
     id_columns: &[String],
     record_index: u64,
-) -> Result<UniversalRow> {
+) -> Result<Row> {
     let id_value = if use_message_key_as_id {
         let key_bytes = message_key.ok_or_else(|| {
             anyhow::anyhow!("use_message_key_as_id is enabled but message has no key")
         })?;
         let base64_str = base64::engine::general_purpose::STANDARD.encode(key_bytes);
-        UniversalValue::Text(base64_str)
+        Value::Text(base64_str)
     } else {
         let cols: Vec<&str> = if id_columns.is_empty() {
             vec![id_field]
@@ -469,12 +469,12 @@ fn typed_values_to_universal_row(
         sync_core::build_composite_record_id(parts)
     };
 
-    let fields: HashMap<String, UniversalValue> = typed_values
+    let fields: HashMap<String, Value> = typed_values
         .into_iter()
         .map(|(k, tv)| (k, tv.value))
         .collect();
 
-    Ok(UniversalRow::new(
+    Ok(Row::new(
         table_name.to_string(),
         record_index,
         id_value,
@@ -482,7 +482,7 @@ fn typed_values_to_universal_row(
     ))
 }
 
-/// Per-message `UniversalRow.index` within one Kafka decode batch.
+/// Per-message `Row.index` within one Kafka decode batch.
 ///
 /// `base` is the poll-time index allocator value at the start of the batch;
 /// `offset` is the message's position in that batch.

--- a/crates/kafka-types/src/forward.rs
+++ b/crates/kafka-types/src/forward.rs
@@ -1,22 +1,20 @@
 //! Forward conversion: TypedValue → Protobuf encoding.
 //!
-//! This module encodes TypedValue/UniversalValue to protobuf binary format
+//! This module encodes TypedValue/Value to protobuf binary format
 //! using the schema information from TableSchema.
 
 use crate::error::{KafkaTypesError, Result};
 use protobuf::CodedOutputStream;
 use std::collections::HashMap;
-use sync_core::{
-    GeneratorTableDefinition, TypedValue, UniversalRow, UniversalType, UniversalValue,
-};
+use sync_core::{GeneratorTableDefinition, Row, Type, TypedValue, Value};
 
-/// Encode an UniversalRow to protobuf binary format.
+/// Encode an Row to protobuf binary format.
 ///
 /// The encoding follows proto3 wire format:
 /// - Each field is encoded as (tag, value) pairs
 /// - Tag = (field_number << 3) | wire_type
 /// - Wire types: 0=varint, 1=64-bit, 2=length-delimited, 5=32-bit
-pub fn encode_row(row: &UniversalRow, table_schema: &GeneratorTableDefinition) -> Result<Vec<u8>> {
+pub fn encode_row(row: &Row, table_schema: &GeneratorTableDefinition) -> Result<Vec<u8>> {
     let mut buffer = Vec::new();
     {
         let mut stream = CodedOutputStream::vec(&mut buffer);
@@ -76,7 +74,7 @@ pub fn encode_typed_values(
 }
 
 /// Get the primary key field name based on the type.
-fn get_pk_field_name(_pk_type: &UniversalType) -> String {
+fn get_pk_field_name(_pk_type: &Type) -> String {
     "id".to_string()
 }
 
@@ -89,17 +87,17 @@ pub fn encode_typed_value(
     encode_generated_value(stream, field_number, &value.value)
 }
 
-/// Encode a single UniversalValue with its field number.
+/// Encode a single Value with its field number.
 pub fn encode_generated_value(
     stream: &mut CodedOutputStream,
     field_number: u32,
-    value: &UniversalValue,
+    value: &Value,
 ) -> Result<()> {
     match value {
-        UniversalValue::Null => {
+        Value::Null => {
             // Skip null values (proto3 default behavior)
         }
-        UniversalValue::Bool(b) => {
+        Value::Bool(b) => {
             // Wire type 0 (varint)
             stream
                 .write_bool(field_number, *b)
@@ -107,23 +105,23 @@ pub fn encode_generated_value(
         }
 
         // Integer types - strict 1:1 matching
-        UniversalValue::Int8 { value: i, .. } => {
+        Value::Int8 { value: i, .. } => {
             stream
                 .write_int64(field_number, *i as i64)
                 .map_err(|e| KafkaTypesError::ProtobufEncode(e.to_string()))?;
         }
-        UniversalValue::Int16(i) => {
+        Value::Int16(i) => {
             stream
                 .write_int64(field_number, *i as i64)
                 .map_err(|e| KafkaTypesError::ProtobufEncode(e.to_string()))?;
         }
-        UniversalValue::Int32(i) => {
+        Value::Int32(i) => {
             // Wire type 0 (varint) - encode as int64 for proto3 compatibility
             stream
                 .write_int64(field_number, *i as i64)
                 .map_err(|e| KafkaTypesError::ProtobufEncode(e.to_string()))?;
         }
-        UniversalValue::Int64(i) => {
+        Value::Int64(i) => {
             // Wire type 0 (varint)
             stream
                 .write_int64(field_number, *i)
@@ -131,18 +129,18 @@ pub fn encode_generated_value(
         }
 
         // Float types - strict 1:1 matching
-        UniversalValue::Float32(f) => {
+        Value::Float32(f) => {
             stream
                 .write_float(field_number, *f)
                 .map_err(|e| KafkaTypesError::ProtobufEncode(e.to_string()))?;
         }
-        UniversalValue::Float64(f) => {
+        Value::Float64(f) => {
             // Wire type 1 (64-bit)
             stream
                 .write_double(field_number, *f)
                 .map_err(|e| KafkaTypesError::ProtobufEncode(e.to_string()))?;
         }
-        UniversalValue::Decimal { value, .. } => {
+        Value::Decimal { value, .. } => {
             // Encode decimal as string to preserve precision
             stream
                 .write_string(field_number, value)
@@ -150,42 +148,42 @@ pub fn encode_generated_value(
         }
 
         // String types - strict 1:1 matching
-        UniversalValue::Text(s) => {
+        Value::Text(s) => {
             stream
                 .write_string(field_number, s)
                 .map_err(|e| KafkaTypesError::ProtobufEncode(e.to_string()))?;
         }
-        UniversalValue::Char { value: s, .. } => {
+        Value::Char { value: s, .. } => {
             stream
                 .write_string(field_number, s)
                 .map_err(|e| KafkaTypesError::ProtobufEncode(e.to_string()))?;
         }
-        UniversalValue::VarChar { value: s, .. } => {
+        Value::VarChar { value: s, .. } => {
             stream
                 .write_string(field_number, s)
                 .map_err(|e| KafkaTypesError::ProtobufEncode(e.to_string()))?;
         }
 
         // Binary types - strict 1:1 matching
-        UniversalValue::Bytes(b) => {
+        Value::Bytes(b) => {
             stream
                 .write_bytes(field_number, b)
                 .map_err(|e| KafkaTypesError::ProtobufEncode(e.to_string()))?;
         }
-        UniversalValue::Blob(b) => {
+        Value::Blob(b) => {
             stream
                 .write_bytes(field_number, b)
                 .map_err(|e| KafkaTypesError::ProtobufEncode(e.to_string()))?;
         }
 
-        UniversalValue::Uuid(u) => {
+        Value::Uuid(u) => {
             // Encode UUID as string
             stream
                 .write_string(field_number, &u.to_string())
                 .map_err(|e| KafkaTypesError::ProtobufEncode(e.to_string()))?;
         }
 
-        UniversalValue::Ulid(u) => {
+        Value::Ulid(u) => {
             // Encode ULID as string
             stream
                 .write_string(field_number, &u.to_string())
@@ -193,9 +191,7 @@ pub fn encode_generated_value(
         }
 
         // DateTime types - strict 1:1 matching
-        UniversalValue::LocalDateTime(dt)
-        | UniversalValue::LocalDateTimeNano(dt)
-        | UniversalValue::ZonedDateTime(dt) => {
+        Value::LocalDateTime(dt) | Value::LocalDateTimeNano(dt) | Value::ZonedDateTime(dt) => {
             // Encode as google.protobuf.Timestamp (nested message)
             let mut timestamp_bytes = Vec::new();
             {
@@ -214,19 +210,19 @@ pub fn encode_generated_value(
                 .write_bytes(field_number, &timestamp_bytes)
                 .map_err(|e| KafkaTypesError::ProtobufEncode(e.to_string()))?;
         }
-        UniversalValue::Date(dt) => {
+        Value::Date(dt) => {
             // Encode date as string
             stream
                 .write_string(field_number, &dt.format("%Y-%m-%d").to_string())
                 .map_err(|e| KafkaTypesError::ProtobufEncode(e.to_string()))?;
         }
-        UniversalValue::Time(dt) => {
+        Value::Time(dt) => {
             // Encode time as string with fractional seconds preserved
             stream
                 .write_string(field_number, &dt.format("%H:%M:%S%.f").to_string())
                 .map_err(|e| KafkaTypesError::ProtobufEncode(e.to_string()))?;
         }
-        UniversalValue::TimeTz(s) => {
+        Value::TimeTz(s) => {
             // Encode timetz as string to preserve timezone format
             stream
                 .write_string(field_number, s)
@@ -234,7 +230,7 @@ pub fn encode_generated_value(
         }
 
         // JSON types - strict 1:1 matching
-        UniversalValue::Json(obj) | UniversalValue::Jsonb(obj) => {
+        Value::Json(obj) | Value::Jsonb(obj) => {
             let json = serde_json::to_string(obj)
                 .map_err(|e| KafkaTypesError::ProtobufEncode(e.to_string()))?;
             stream
@@ -243,14 +239,14 @@ pub fn encode_generated_value(
         }
 
         // Enum type - strict 1:1 matching
-        UniversalValue::Enum { value, .. } => {
+        Value::Enum { value, .. } => {
             stream
                 .write_string(field_number, value)
                 .map_err(|e| KafkaTypesError::ProtobufEncode(e.to_string()))?;
         }
 
         // Set type - encode as repeated strings
-        UniversalValue::Set { elements, .. } => {
+        Value::Set { elements, .. } => {
             for element in elements {
                 stream
                     .write_string(field_number, element)
@@ -259,7 +255,7 @@ pub fn encode_generated_value(
         }
 
         // Geometry type - encode as GeoJSON string
-        UniversalValue::Geometry { data, .. } => {
+        Value::Geometry { data, .. } => {
             use sync_core::GeometryData;
             let GeometryData(json) = data;
             let json_str = serde_json::to_string(&json).unwrap_or_else(|_| "{}".to_string());
@@ -269,7 +265,7 @@ pub fn encode_generated_value(
         }
 
         // Array type - recursive handling
-        UniversalValue::Array { elements: arr, .. } => {
+        Value::Array { elements: arr, .. } => {
             // Encode as repeated field - each element is written separately
             for element in arr {
                 encode_generated_value(stream, field_number, element)?;
@@ -277,7 +273,7 @@ pub fn encode_generated_value(
         }
 
         // Duration type - encode as ISO 8601 duration string
-        UniversalValue::Duration(d) => {
+        Value::Duration(d) => {
             let secs = d.as_secs();
             let nanos = d.subsec_nanos();
             let duration_str = if nanos == 0 {
@@ -291,12 +287,12 @@ pub fn encode_generated_value(
         }
 
         // Thing - encode as string in "table:id" format
-        UniversalValue::Thing { table, id } => {
+        Value::Thing { table, id } => {
             let id_str = match id.as_ref() {
-                UniversalValue::Text(s) => s.clone(),
-                UniversalValue::Int32(i) => i.to_string(),
-                UniversalValue::Int64(i) => i.to_string(),
-                UniversalValue::Uuid(u) => u.to_string(),
+                Value::Text(s) => s.clone(),
+                Value::Int32(i) => i.to_string(),
+                Value::Int64(i) => i.to_string(),
+                Value::Uuid(u) => u.to_string(),
                 other => panic!(
                     "Unsupported Thing ID type for Kafka: {other:?}. \
                      Supported types: Text, Int32, Int64, Uuid"
@@ -309,7 +305,7 @@ pub fn encode_generated_value(
         }
 
         // Object - encode as JSON string
-        UniversalValue::Object(map) => {
+        Value::Object(map) => {
             let obj: serde_json::Map<String, serde_json::Value> = map
                 .iter()
                 .map(|(k, v)| (k.clone(), universal_value_to_json(v)))
@@ -321,13 +317,13 @@ pub fn encode_generated_value(
                 .map_err(|e| KafkaTypesError::ProtobufEncode(e.to_string()))?;
         }
 
-        UniversalValue::ZeroTemporal {
+        Value::ZeroTemporal {
             intended_type,
             source,
         } => {
             let s = source
                 .as_deref()
-                .unwrap_or_else(|| UniversalValue::canonical_zero_literal(intended_type));
+                .unwrap_or_else(|| Value::canonical_zero_literal(intended_type));
             stream
                 .write_string(field_number, s)
                 .map_err(|e| KafkaTypesError::ProtobufEncode(e.to_string()))?;
@@ -336,10 +332,10 @@ pub fn encode_generated_value(
     Ok(())
 }
 
-/// Get the Kafka message key from an UniversalRow.
+/// Get the Kafka message key from an Row.
 ///
 /// Uses the id field value as the message key.
-pub fn get_message_key(row: &UniversalRow) -> Vec<u8> {
+pub fn get_message_key(row: &Row) -> Vec<u8> {
     generated_value_to_key(&row.id)
 }
 
@@ -357,102 +353,102 @@ pub fn get_message_key_from_typed_values(
     }
 }
 
-/// Convert a UniversalValue to message key bytes.
-fn generated_value_to_key(value: &UniversalValue) -> Vec<u8> {
+/// Convert a Value to message key bytes.
+fn generated_value_to_key(value: &Value) -> Vec<u8> {
     match value {
         // Integer types
-        UniversalValue::Int8 { value: i, .. } => i.to_string().into_bytes(),
-        UniversalValue::Int16(i) => i.to_string().into_bytes(),
-        UniversalValue::Int32(i) => i.to_string().into_bytes(),
-        UniversalValue::Int64(i) => i.to_string().into_bytes(),
+        Value::Int8 { value: i, .. } => i.to_string().into_bytes(),
+        Value::Int16(i) => i.to_string().into_bytes(),
+        Value::Int32(i) => i.to_string().into_bytes(),
+        Value::Int64(i) => i.to_string().into_bytes(),
         // String types
-        UniversalValue::Text(s) => s.as_bytes().to_vec(),
-        UniversalValue::Char { value: s, .. } => s.as_bytes().to_vec(),
-        UniversalValue::VarChar { value: s, .. } => s.as_bytes().to_vec(),
+        Value::Text(s) => s.as_bytes().to_vec(),
+        Value::Char { value: s, .. } => s.as_bytes().to_vec(),
+        Value::VarChar { value: s, .. } => s.as_bytes().to_vec(),
         // UUID
-        UniversalValue::Uuid(u) => u.to_string().into_bytes(),
+        Value::Uuid(u) => u.to_string().into_bytes(),
         // Fallback - try to produce meaningful key
         _ => format!("{value:?}").into_bytes(),
     }
 }
 
-/// Map UniversalType to protobuf type string.
+/// Map Type to protobuf type string.
 ///
 /// Used for generating .proto schema files.
-pub fn get_proto_type(sync_type: &UniversalType) -> &'static str {
+pub fn get_proto_type(sync_type: &Type) -> &'static str {
     match sync_type {
-        UniversalType::Bool => "bool",
-        UniversalType::Int8 { .. } | UniversalType::Int16 | UniversalType::Int32 => "int32",
-        UniversalType::Int64 => "int64",
-        UniversalType::Float32 => "float",
-        UniversalType::Float64 => "double",
-        UniversalType::Decimal { .. } => "string",
-        UniversalType::Char { .. }
-        | UniversalType::VarChar { .. }
-        | UniversalType::Text
-        | UniversalType::Uuid
-        | UniversalType::Ulid
-        | UniversalType::Enum { .. } => "string",
-        UniversalType::Bytes | UniversalType::Blob => "bytes",
-        UniversalType::LocalDateTime
-        | UniversalType::LocalDateTimeNano
-        | UniversalType::ZonedDateTime
-        | UniversalType::Date
-        | UniversalType::Time => "google.protobuf.Timestamp",
-        UniversalType::TimeTz => "string", // TIMETZ stored as string to preserve timezone
-        UniversalType::Json | UniversalType::Jsonb => "string", // JSON encoded as string
-        UniversalType::Array { .. } => "repeated", // Caller handles element type
-        UniversalType::Set { .. } => "repeated", // Encode as repeated
-        UniversalType::Geometry { .. } => "string", // GeoJSON string
-        UniversalType::Duration => "string", // ISO 8601 duration string
-        UniversalType::Thing => "string",  // Record reference as table:id
-        UniversalType::Object => "string", // Object encoded as JSON string
+        Type::Bool => "bool",
+        Type::Int8 { .. } | Type::Int16 | Type::Int32 => "int32",
+        Type::Int64 => "int64",
+        Type::Float32 => "float",
+        Type::Float64 => "double",
+        Type::Decimal { .. } => "string",
+        Type::Char { .. }
+        | Type::VarChar { .. }
+        | Type::Text
+        | Type::Uuid
+        | Type::Ulid
+        | Type::Enum { .. } => "string",
+        Type::Bytes | Type::Blob => "bytes",
+        Type::LocalDateTime
+        | Type::LocalDateTimeNano
+        | Type::ZonedDateTime
+        | Type::Date
+        | Type::Time => "google.protobuf.Timestamp",
+        Type::TimeTz => "string", // TIMETZ stored as string to preserve timezone
+        Type::Json | Type::Jsonb => "string", // JSON encoded as string
+        Type::Array { .. } => "repeated", // Caller handles element type
+        Type::Set { .. } => "repeated", // Encode as repeated
+        Type::Geometry { .. } => "string", // GeoJSON string
+        Type::Duration => "string", // ISO 8601 duration string
+        Type::Thing => "string",  // Record reference as table:id
+        Type::Object => "string", // Object encoded as JSON string
     }
 }
 
-/// Convert UniversalValue to serde_json::Value for JSON encoding.
-fn universal_value_to_json(value: &UniversalValue) -> serde_json::Value {
+/// Convert Value to serde_json::Value for JSON encoding.
+fn universal_value_to_json(value: &Value) -> serde_json::Value {
     match value {
-        UniversalValue::Null => serde_json::Value::Null,
-        UniversalValue::Bool(b) => serde_json::Value::Bool(*b),
-        UniversalValue::Int8 { value, .. } => serde_json::json!(*value),
-        UniversalValue::Int16(i) => serde_json::json!(*i),
-        UniversalValue::Int32(i) => serde_json::json!(*i),
-        UniversalValue::Int64(i) => serde_json::json!(*i),
-        UniversalValue::Float32(f) => serde_json::json!(*f),
-        UniversalValue::Float64(f) => serde_json::json!(*f),
-        UniversalValue::Decimal { value, .. } => serde_json::json!(value),
-        UniversalValue::Char { value, .. } => serde_json::json!(value),
-        UniversalValue::VarChar { value, .. } => serde_json::json!(value),
-        UniversalValue::Text(s) => serde_json::json!(s),
-        UniversalValue::Blob(b) | UniversalValue::Bytes(b) => {
+        Value::Null => serde_json::Value::Null,
+        Value::Bool(b) => serde_json::Value::Bool(*b),
+        Value::Int8 { value, .. } => serde_json::json!(*value),
+        Value::Int16(i) => serde_json::json!(*i),
+        Value::Int32(i) => serde_json::json!(*i),
+        Value::Int64(i) => serde_json::json!(*i),
+        Value::Float32(f) => serde_json::json!(*f),
+        Value::Float64(f) => serde_json::json!(*f),
+        Value::Decimal { value, .. } => serde_json::json!(value),
+        Value::Char { value, .. } => serde_json::json!(value),
+        Value::VarChar { value, .. } => serde_json::json!(value),
+        Value::Text(s) => serde_json::json!(s),
+        Value::Blob(b) | Value::Bytes(b) => {
             serde_json::json!(base64::Engine::encode(
                 &base64::engine::general_purpose::STANDARD,
                 b
             ))
         }
-        UniversalValue::Uuid(u) => serde_json::json!(u.to_string()),
-        UniversalValue::Ulid(u) => serde_json::json!(u.to_string()),
-        UniversalValue::Date(dt) => serde_json::json!(dt.format("%Y-%m-%d").to_string()),
-        UniversalValue::Time(dt) => serde_json::json!(dt.format("%H:%M:%S%.f").to_string()),
-        UniversalValue::LocalDateTime(dt)
-        | UniversalValue::LocalDateTimeNano(dt)
-        | UniversalValue::ZonedDateTime(dt) => serde_json::json!(dt.to_rfc3339()),
-        UniversalValue::TimeTz(s) => serde_json::json!(s),
-        UniversalValue::Json(v) | UniversalValue::Jsonb(v) => (**v).clone(),
-        UniversalValue::Array { elements, .. } => {
+        Value::Uuid(u) => serde_json::json!(u.to_string()),
+        Value::Ulid(u) => serde_json::json!(u.to_string()),
+        Value::Date(dt) => serde_json::json!(dt.format("%Y-%m-%d").to_string()),
+        Value::Time(dt) => serde_json::json!(dt.format("%H:%M:%S%.f").to_string()),
+        Value::LocalDateTime(dt) | Value::LocalDateTimeNano(dt) | Value::ZonedDateTime(dt) => {
+            serde_json::json!(dt.to_rfc3339())
+        }
+        Value::TimeTz(s) => serde_json::json!(s),
+        Value::Json(v) | Value::Jsonb(v) => (**v).clone(),
+        Value::Array { elements, .. } => {
             serde_json::Value::Array(elements.iter().map(universal_value_to_json).collect())
         }
-        UniversalValue::Set { elements, .. } => {
+        Value::Set { elements, .. } => {
             serde_json::Value::Array(elements.iter().map(|s| serde_json::json!(s)).collect())
         }
-        UniversalValue::Enum { value, .. } => serde_json::json!(value),
-        UniversalValue::Geometry { data, .. } => {
+        Value::Enum { value, .. } => serde_json::json!(value),
+        Value::Geometry { data, .. } => {
             use sync_core::values::GeometryData;
             let GeometryData(v) = data;
             v.clone()
         }
-        UniversalValue::Duration(d) => {
+        Value::Duration(d) => {
             let secs = d.as_secs();
             let nanos = d.subsec_nanos();
             if nanos == 0 {
@@ -461,30 +457,30 @@ fn universal_value_to_json(value: &UniversalValue) -> serde_json::Value {
                 serde_json::json!(format!("PT{secs}.{nanos:09}S"))
             }
         }
-        UniversalValue::Thing { table, id } => {
+        Value::Thing { table, id } => {
             let id_str = match id.as_ref() {
-                UniversalValue::Text(s) => s.clone(),
-                UniversalValue::Int32(i) => i.to_string(),
-                UniversalValue::Int64(i) => i.to_string(),
-                UniversalValue::Uuid(u) => u.to_string(),
+                Value::Text(s) => s.clone(),
+                Value::Int32(i) => i.to_string(),
+                Value::Int64(i) => i.to_string(),
+                Value::Uuid(u) => u.to_string(),
                 other => format!("{other:?}"),
             };
             serde_json::json!(format!("{table}:{id_str}"))
         }
-        UniversalValue::Object(map) => {
+        Value::Object(map) => {
             let obj: serde_json::Map<String, serde_json::Value> = map
                 .iter()
                 .map(|(k, v)| (k.clone(), universal_value_to_json(v)))
                 .collect();
             serde_json::Value::Object(obj)
         }
-        UniversalValue::ZeroTemporal {
+        Value::ZeroTemporal {
             intended_type,
             source,
         } => {
             let s = source
                 .as_deref()
-                .unwrap_or_else(|| UniversalValue::canonical_zero_literal(intended_type));
+                .unwrap_or_else(|| Value::canonical_zero_literal(intended_type));
             serde_json::Value::String(s.to_string())
         }
     }
@@ -501,13 +497,13 @@ mod tests {
         GeneratorTableDefinition {
             name: "users".to_string(),
             id: IDDefinition {
-                id_type: UniversalType::Int64,
+                id_type: Type::Int64,
                 generator: GeneratorConfig::Sequential { start: 1 },
             },
             fields: vec![
                 FieldDefinition {
                     name: "email".to_string(),
-                    field_type: UniversalType::VarChar { length: 255 },
+                    field_type: Type::VarChar { length: 255 },
                     generator: GeneratorConfig::Pattern {
                         pattern: "user_{index}@test.com".to_string(),
                     },
@@ -515,13 +511,13 @@ mod tests {
                 },
                 FieldDefinition {
                     name: "age".to_string(),
-                    field_type: UniversalType::Int32,
+                    field_type: Type::Int32,
                     generator: GeneratorConfig::IntRange { min: 18, max: 80 },
                     nullable: false,
                 },
                 FieldDefinition {
                     name: "is_active".to_string(),
-                    field_type: UniversalType::Bool,
+                    field_type: Type::Bool,
                     generator: GeneratorConfig::WeightedBool { true_weight: 0.8 },
                     nullable: false,
                 },
@@ -535,12 +531,12 @@ mod tests {
         let mut fields = HashMap::new();
         fields.insert(
             "email".to_string(),
-            UniversalValue::Text("test@example.com".to_string()),
+            Value::Text("test@example.com".to_string()),
         );
-        fields.insert("age".to_string(), UniversalValue::Int32(25));
-        fields.insert("is_active".to_string(), UniversalValue::Bool(true));
+        fields.insert("age".to_string(), Value::Int32(25));
+        fields.insert("is_active".to_string(), Value::Bool(true));
 
-        let row = UniversalRow::new("users", 0, UniversalValue::Int64(1), fields);
+        let row = Row::new("users", 0, Value::Int64(1), fields);
 
         let encoded = encode_row(&row, &schema).unwrap();
         assert!(!encoded.is_empty());
@@ -560,12 +556,12 @@ mod tests {
         let schema = GeneratorTableDefinition {
             name: "events".to_string(),
             id: IDDefinition {
-                id_type: UniversalType::Int64,
+                id_type: Type::Int64,
                 generator: GeneratorConfig::Sequential { start: 1 },
             },
             fields: vec![FieldDefinition {
                 name: "created_at".to_string(),
-                field_type: UniversalType::LocalDateTime,
+                field_type: Type::LocalDateTime,
                 generator: GeneratorConfig::TimestampRange {
                     start: "2024-01-01T00:00:00Z".to_string(),
                     end: "2024-12-31T23:59:59Z".to_string(),
@@ -576,9 +572,9 @@ mod tests {
 
         let dt = Utc.with_ymd_and_hms(2024, 6, 15, 12, 30, 45).unwrap();
         let mut fields = HashMap::new();
-        fields.insert("created_at".to_string(), UniversalValue::LocalDateTime(dt));
+        fields.insert("created_at".to_string(), Value::LocalDateTime(dt));
 
-        let row = UniversalRow::new("events", 0, UniversalValue::Int64(1), fields);
+        let row = Row::new("events", 0, Value::Int64(1), fields);
         let encoded = encode_row(&row, &schema).unwrap();
         assert!(!encoded.is_empty());
     }
@@ -588,13 +584,13 @@ mod tests {
         let schema = GeneratorTableDefinition {
             name: "products".to_string(),
             id: IDDefinition {
-                id_type: UniversalType::Int64,
+                id_type: Type::Int64,
                 generator: GeneratorConfig::Sequential { start: 1 },
             },
             fields: vec![FieldDefinition {
                 name: "tags".to_string(),
-                field_type: UniversalType::Array {
-                    element_type: Box::new(UniversalType::Text),
+                field_type: Type::Array {
+                    element_type: Box::new(Type::Text),
                 },
                 generator: GeneratorConfig::SampleArray {
                     pool: vec!["a".to_string(), "b".to_string()],
@@ -608,23 +604,23 @@ mod tests {
         let mut fields = HashMap::new();
         fields.insert(
             "tags".to_string(),
-            UniversalValue::Array {
+            Value::Array {
                 elements: vec![
-                    UniversalValue::Text("tag1".to_string()),
-                    UniversalValue::Text("tag2".to_string()),
+                    Value::Text("tag1".to_string()),
+                    Value::Text("tag2".to_string()),
                 ],
-                element_type: Box::new(UniversalType::Text),
+                element_type: Box::new(Type::Text),
             },
         );
 
-        let row = UniversalRow::new("products", 0, UniversalValue::Int64(1), fields);
+        let row = Row::new("products", 0, Value::Int64(1), fields);
         let encoded = encode_row(&row, &schema).unwrap();
         assert!(!encoded.is_empty());
     }
 
     #[test]
     fn test_get_message_key_int() {
-        let row = UniversalRow::new("test", 0, UniversalValue::Int64(42), HashMap::new());
+        let row = Row::new("test", 0, Value::Int64(42), HashMap::new());
         let key = get_message_key(&row);
         assert_eq!(key, b"42");
     }
@@ -632,7 +628,7 @@ mod tests {
     #[test]
     fn test_get_message_key_uuid() {
         let uuid = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
-        let row = UniversalRow::new("test", 0, UniversalValue::Uuid(uuid), HashMap::new());
+        let row = Row::new("test", 0, Value::Uuid(uuid), HashMap::new());
         let key = get_message_key(&row);
         assert_eq!(
             String::from_utf8(key).unwrap(),
@@ -642,12 +638,7 @@ mod tests {
 
     #[test]
     fn test_get_message_key_string() {
-        let row = UniversalRow::new(
-            "test",
-            0,
-            UniversalValue::Text("my-key".to_string()),
-            HashMap::new(),
-        );
+        let row = Row::new("test", 0, Value::Text("my-key".to_string()), HashMap::new());
         let key = get_message_key(&row);
         assert_eq!(key, b"my-key");
     }

--- a/crates/kafka-types/src/lib.rs
+++ b/crates/kafka-types/src/lib.rs
@@ -41,7 +41,7 @@
 //!
 //! ```ignore
 //! use kafka_types::forward::{encode_row, get_message_key};
-//! use sync_core::UniversalRow;
+//! use sync_core::Row;
 //!
 //! let encoded = encode_row(&row, &table_schema)?;
 //! let key = get_message_key(&row);

--- a/crates/kafka-types/src/reverse.rs
+++ b/crates/kafka-types/src/reverse.rs
@@ -8,7 +8,7 @@ use crate::proto::{ProtoFieldValue, ProtoType};
 use crate::{Message, Payload};
 use json_types::JsonValueWithSchema;
 use std::collections::HashMap;
-use sync_core::{ColumnDefinition, TableDefinition, TypedValue, UniversalType, UniversalValue};
+use sync_core::{ColumnDefinition, TableDefinition, Type, TypedValue, Value};
 use tracing::debug;
 
 /// Convert a Kafka message to TypedValue key-value pairs.
@@ -84,7 +84,7 @@ pub fn message_to_typed_values(
                                 // For repeated fields without TableDefinition, default to Text element type
                                 kvs.insert(
                                     field_name.clone(),
-                                    TypedValue::array(Vec::new(), UniversalType::Text),
+                                    TypedValue::array(Vec::new(), Type::Text),
                                 );
                             }
                             // Note: Other scalar types (int, string, etc.) default to 0/""
@@ -100,7 +100,7 @@ pub fn message_to_typed_values(
                 for column in &schema.columns {
                     if !kvs.contains_key(&column.name) {
                         match &column.column_type {
-                            UniversalType::Array { element_type } => {
+                            Type::Array { element_type } => {
                                 // Override with more precise element type from TableDefinition
                                 debug!(
                                     "Adding empty array for missing field '{}' based on TableDefinition schema",
@@ -111,7 +111,7 @@ pub fn message_to_typed_values(
                                     TypedValue::array(Vec::new(), (**element_type).clone()),
                                 );
                             }
-                            UniversalType::Bool => {
+                            Type::Bool => {
                                 // Proto3 default: false
                                 debug!(
                                     "Adding default 'false' for missing bool field '{}' (Proto3 default via TableDefinition)",
@@ -139,7 +139,7 @@ pub fn proto_to_typed_value_with_schema(
         ProtoFieldValue::String(s) => {
             // Check if this is actually a JSON/Object field encoded as string
             if let Some(col) = column_schema {
-                if matches!(col.column_type, UniversalType::Json | UniversalType::Jsonb) {
+                if matches!(col.column_type, Type::Json | Type::Jsonb) {
                     debug!(
                         "Parsing string field '{}' as JSON based on schema",
                         col.name
@@ -157,7 +157,7 @@ pub fn proto_to_typed_value_with_schema(
                 }
 
                 // Check if this is a Decimal field encoded as string (protobuf doesn't have native decimal)
-                if let UniversalType::Decimal { precision, scale } = &col.column_type {
+                if let Type::Decimal { precision, scale } = &col.column_type {
                     debug!(
                         "Parsing string field '{}' as Decimal based on schema (precision={}, scale={})",
                         col.name, precision, scale
@@ -251,60 +251,60 @@ pub fn proto_to_typed_value(value: ProtoFieldValue) -> Result<TypedValue> {
             let element_type = typed_values
                 .first()
                 .map(|tv| tv.sync_type.clone())
-                .unwrap_or(UniversalType::Text);
+                .unwrap_or(Type::Text);
 
-            // Extract just the UniversalValues for the array
-            let arr: Vec<UniversalValue> = typed_values.into_iter().map(|tv| tv.value).collect();
+            // Extract just the Values for the array
+            let arr: Vec<Value> = typed_values.into_iter().map(|tv| tv.value).collect();
 
             Ok(TypedValue::array(arr, element_type))
         }
-        ProtoFieldValue::Null => Ok(TypedValue::null(UniversalType::Text)),
+        ProtoFieldValue::Null => Ok(TypedValue::null(Type::Text)),
     }
 }
 
-/// Convert a UniversalValue to serde_json::Value.
-fn universal_value_to_json(value: &UniversalValue) -> serde_json::Value {
+/// Convert a Value to serde_json::Value.
+fn universal_value_to_json(value: &Value) -> serde_json::Value {
     use base64::Engine;
     match value {
-        UniversalValue::Null => serde_json::Value::Null,
-        UniversalValue::Bool(b) => serde_json::json!(*b),
-        UniversalValue::Int8 { value, .. } => serde_json::json!(*value),
-        UniversalValue::Int16(i) => serde_json::json!(*i),
-        UniversalValue::Int32(i) => serde_json::json!(*i),
-        UniversalValue::Int64(i) => serde_json::json!(*i),
-        UniversalValue::Float32(f) => serde_json::json!(*f),
-        UniversalValue::Float64(f) => serde_json::json!(*f),
-        UniversalValue::Char { value, .. } => serde_json::json!(value),
-        UniversalValue::VarChar { value, .. } => serde_json::json!(value),
-        UniversalValue::Text(s) => serde_json::json!(s),
-        UniversalValue::Blob(b) | UniversalValue::Bytes(b) => {
+        Value::Null => serde_json::Value::Null,
+        Value::Bool(b) => serde_json::json!(*b),
+        Value::Int8 { value, .. } => serde_json::json!(*value),
+        Value::Int16(i) => serde_json::json!(*i),
+        Value::Int32(i) => serde_json::json!(*i),
+        Value::Int64(i) => serde_json::json!(*i),
+        Value::Float32(f) => serde_json::json!(*f),
+        Value::Float64(f) => serde_json::json!(*f),
+        Value::Char { value, .. } => serde_json::json!(value),
+        Value::VarChar { value, .. } => serde_json::json!(value),
+        Value::Text(s) => serde_json::json!(s),
+        Value::Blob(b) | Value::Bytes(b) => {
             let encoded = base64::engine::general_purpose::STANDARD.encode(b);
             serde_json::json!(encoded)
         }
-        UniversalValue::Uuid(u) => serde_json::json!(u.to_string()),
-        UniversalValue::Ulid(u) => serde_json::json!(u.to_string()),
-        UniversalValue::Date(dt) => serde_json::json!(dt.format("%Y-%m-%d").to_string()),
-        UniversalValue::Time(dt) => serde_json::json!(dt.format("%H:%M:%S%.f").to_string()),
-        UniversalValue::LocalDateTime(dt)
-        | UniversalValue::LocalDateTimeNano(dt)
-        | UniversalValue::ZonedDateTime(dt) => serde_json::json!(dt.to_rfc3339()),
-        UniversalValue::TimeTz(s) => serde_json::json!(s),
-        UniversalValue::Decimal { value, .. } => serde_json::json!(value),
-        UniversalValue::Array { elements, .. } => {
+        Value::Uuid(u) => serde_json::json!(u.to_string()),
+        Value::Ulid(u) => serde_json::json!(u.to_string()),
+        Value::Date(dt) => serde_json::json!(dt.format("%Y-%m-%d").to_string()),
+        Value::Time(dt) => serde_json::json!(dt.format("%H:%M:%S%.f").to_string()),
+        Value::LocalDateTime(dt) | Value::LocalDateTimeNano(dt) | Value::ZonedDateTime(dt) => {
+            serde_json::json!(dt.to_rfc3339())
+        }
+        Value::TimeTz(s) => serde_json::json!(s),
+        Value::Decimal { value, .. } => serde_json::json!(value),
+        Value::Array { elements, .. } => {
             serde_json::json!(elements
                 .iter()
                 .map(universal_value_to_json)
                 .collect::<Vec<_>>())
         }
-        UniversalValue::Set { elements, .. } => serde_json::json!(elements),
-        UniversalValue::Enum { value, .. } => serde_json::json!(value),
-        UniversalValue::Json(payload) | UniversalValue::Jsonb(payload) => (**payload).clone(),
-        UniversalValue::Geometry { data, .. } => {
+        Value::Set { elements, .. } => serde_json::json!(elements),
+        Value::Enum { value, .. } => serde_json::json!(value),
+        Value::Json(payload) | Value::Jsonb(payload) => (**payload).clone(),
+        Value::Geometry { data, .. } => {
             use sync_core::values::GeometryData;
             let GeometryData(json) = data;
             json.clone()
         }
-        UniversalValue::Duration(d) => {
+        Value::Duration(d) => {
             let secs = d.as_secs();
             let nanos = d.subsec_nanos();
             if nanos == 0 {
@@ -313,12 +313,12 @@ fn universal_value_to_json(value: &UniversalValue) -> serde_json::Value {
                 serde_json::json!(format!("PT{secs}.{nanos:09}S"))
             }
         }
-        UniversalValue::Thing { table, id } => {
+        Value::Thing { table, id } => {
             let id_str = match id.as_ref() {
-                UniversalValue::Text(s) => s.clone(),
-                UniversalValue::Int32(i) => i.to_string(),
-                UniversalValue::Int64(i) => i.to_string(),
-                UniversalValue::Uuid(u) => u.to_string(),
+                Value::Text(s) => s.clone(),
+                Value::Int32(i) => i.to_string(),
+                Value::Int64(i) => i.to_string(),
+                Value::Uuid(u) => u.to_string(),
                 other => panic!(
                     "Unsupported Thing ID type for Kafka: {other:?}. \
                      Supported types: Text, Int32, Int64, Uuid"
@@ -326,20 +326,20 @@ fn universal_value_to_json(value: &UniversalValue) -> serde_json::Value {
             };
             serde_json::json!(format!("{table}:{id_str}"))
         }
-        UniversalValue::Object(map) => {
+        Value::Object(map) => {
             let obj: serde_json::Map<String, serde_json::Value> = map
                 .iter()
                 .map(|(k, v)| (k.clone(), universal_value_to_json(v)))
                 .collect();
             serde_json::Value::Object(obj)
         }
-        UniversalValue::ZeroTemporal {
+        Value::ZeroTemporal {
             intended_type,
             source,
         } => {
             let s = source
                 .as_deref()
-                .unwrap_or_else(|| UniversalValue::canonical_zero_literal(intended_type));
+                .unwrap_or_else(|| Value::canonical_zero_literal(intended_type));
             serde_json::Value::String(s.to_string())
         }
     }
@@ -362,32 +362,32 @@ mod tests {
     fn test_proto_to_typed_value_int32() {
         let value = ProtoFieldValue::Int32(42);
         let result = proto_to_typed_value(value).unwrap();
-        assert_eq!(result.sync_type, UniversalType::Int32);
-        assert!(matches!(result.value, UniversalValue::Int32(42)));
+        assert_eq!(result.sync_type, Type::Int32);
+        assert!(matches!(result.value, Value::Int32(42)));
     }
 
     #[test]
     fn test_proto_to_typed_value_int64() {
         let value = ProtoFieldValue::Int64(123456789);
         let result = proto_to_typed_value(value).unwrap();
-        assert_eq!(result.sync_type, UniversalType::Int64);
-        assert!(matches!(result.value, UniversalValue::Int64(123456789)));
+        assert_eq!(result.sync_type, Type::Int64);
+        assert!(matches!(result.value, Value::Int64(123456789)));
     }
 
     #[test]
     fn test_proto_to_typed_value_string() {
         let value = ProtoFieldValue::String("hello".to_string());
         let result = proto_to_typed_value(value).unwrap();
-        assert_eq!(result.sync_type, UniversalType::Text);
-        assert!(matches!(result.value, UniversalValue::Text(s) if s == "hello"));
+        assert_eq!(result.sync_type, Type::Text);
+        assert!(matches!(result.value, Value::Text(s) if s == "hello"));
     }
 
     #[test]
     fn test_proto_to_typed_value_bool() {
         let value = ProtoFieldValue::Bool(true);
         let result = proto_to_typed_value(value).unwrap();
-        assert_eq!(result.sync_type, UniversalType::Bool);
-        assert!(matches!(result.value, UniversalValue::Bool(true)));
+        assert_eq!(result.sync_type, Type::Bool);
+        assert!(matches!(result.value, Value::Bool(true)));
     }
 
     #[test]
@@ -404,8 +404,8 @@ mod tests {
 
         let value = ProtoFieldValue::Message(Box::new(msg));
         let result = proto_to_typed_value(value).unwrap();
-        assert_eq!(result.sync_type, UniversalType::LocalDateTime);
-        assert!(matches!(result.value, UniversalValue::LocalDateTime(_)));
+        assert_eq!(result.sync_type, Type::LocalDateTime);
+        assert!(matches!(result.value, Value::LocalDateTime(_)));
     }
 
     #[test]
@@ -415,26 +415,24 @@ mod tests {
             ProtoFieldValue::String("b".to_string()),
         ]);
         let result = proto_to_typed_value(value).unwrap();
-        assert!(matches!(result.sync_type, UniversalType::Array { .. }));
-        assert!(
-            matches!(result.value, UniversalValue::Array { ref elements, .. } if elements.len() == 2)
-        );
+        assert!(matches!(result.sync_type, Type::Array { .. }));
+        assert!(matches!(result.value, Value::Array { ref elements, .. } if elements.len() == 2));
     }
 
     #[test]
     fn test_proto_to_typed_value_null() {
         let value = ProtoFieldValue::Null;
         let result = proto_to_typed_value(value).unwrap();
-        assert!(matches!(result.value, UniversalValue::Null));
+        assert!(matches!(result.value, Value::Null));
     }
 
     #[test]
     fn test_proto_to_typed_value_with_schema_json() {
-        let column_schema = sync_core::ColumnDefinition::nullable("metadata", UniversalType::Json);
+        let column_schema = sync_core::ColumnDefinition::nullable("metadata", Type::Json);
 
         let value = ProtoFieldValue::String(r#"{"key": "value"}"#.to_string());
         let result = proto_to_typed_value_with_schema(value, Some(&column_schema)).unwrap();
-        assert_eq!(result.sync_type, UniversalType::Json);
-        assert!(matches!(result.value, UniversalValue::Json(_)));
+        assert_eq!(result.sync_type, Type::Json);
+        assert!(matches!(result.value, Value::Json(_)));
     }
 }

--- a/crates/loadtest-generator/src/generator.rs
+++ b/crates/loadtest-generator/src/generator.rs
@@ -4,7 +4,7 @@ use crate::generators::generate_value_typed;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use std::collections::HashMap;
-use sync_core::{Schema, UniversalRow, UniversalValue};
+use sync_core::{Row, Schema, Value};
 
 /// Error type for generator operations.
 #[derive(Debug, thiserror::Error)]
@@ -74,7 +74,7 @@ impl DataGenerator {
     }
 
     /// Generate the next internal row for the given table.
-    pub fn next_internal_row(&mut self, table: &str) -> Result<UniversalRow, GeneratorError> {
+    pub fn next_internal_row(&mut self, table: &str) -> Result<Row, GeneratorError> {
         // Verify table exists
         let table_schema = self
             .schema
@@ -94,7 +94,7 @@ impl DataGenerator {
         );
 
         // Generate all fields with type-aware generation
-        let fields: HashMap<String, UniversalValue> = table_schema
+        let fields: HashMap<String, Value> = table_schema
             .fields
             .iter()
             .map(|field| {
@@ -111,7 +111,7 @@ impl DataGenerator {
 
         self.index += 1;
 
-        Ok(UniversalRow::new(table_name, index, id, fields))
+        Ok(Row::new(table_name, index, id, fields))
     }
 
     /// Generate multiple internal rows for the given table.
@@ -121,13 +121,13 @@ impl DataGenerator {
         &mut self,
         table: &str,
         count: u64,
-    ) -> Result<UniversalRowIterator<'_>, GeneratorError> {
+    ) -> Result<RowIterator<'_>, GeneratorError> {
         // Verify the table exists
         if self.schema.get_table(table).is_none() {
             return Err(GeneratorError::TableNotFound(table.to_string()));
         }
 
-        Ok(UniversalRowIterator {
+        Ok(RowIterator {
             generator: self,
             table: table.to_string(),
             remaining: count,
@@ -141,14 +141,14 @@ impl DataGenerator {
 }
 
 /// Iterator that lazily generates internal rows.
-pub struct UniversalRowIterator<'a> {
+pub struct RowIterator<'a> {
     generator: &'a mut DataGenerator,
     table: String,
     remaining: u64,
 }
 
-impl Iterator for UniversalRowIterator<'_> {
-    type Item = UniversalRow;
+impl Iterator for RowIterator<'_> {
+    type Item = Row;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.remaining == 0 {
@@ -167,7 +167,7 @@ impl Iterator for UniversalRowIterator<'_> {
     }
 }
 
-impl ExactSizeIterator for UniversalRowIterator<'_> {}
+impl ExactSizeIterator for RowIterator<'_> {}
 
 #[cfg(test)]
 mod tests {
@@ -219,9 +219,9 @@ tables:
 
         assert_eq!(row.table, "users");
         assert_eq!(row.index, 0);
-        assert!(matches!(row.id, UniversalValue::Uuid(_)));
+        assert!(matches!(row.id, Value::Uuid(_)));
         // Email is VarChar(255), so it should be a VarChar value
-        if let Some(UniversalValue::VarChar { value, .. }) = row.get_field("email") {
+        if let Some(Value::VarChar { value, .. }) = row.get_field("email") {
             assert_eq!(value, "user_0@example.com");
         } else {
             panic!(
@@ -231,7 +231,7 @@ tables:
         }
 
         // Age should be in range - field type is Int so should be Int value
-        if let Some(UniversalValue::Int32(age)) = row.get_field("age") {
+        if let Some(Value::Int32(age)) = row.get_field("age") {
             assert!(*age >= 18 && *age <= 80);
         } else {
             panic!("Expected Int for age, got {:?}", row.get_field("age"));
@@ -270,7 +270,7 @@ tables:
 
         // Verify emails contain correct indices
         for (i, row) in rows.iter().enumerate() {
-            if let Some(UniversalValue::VarChar { value: email, .. }) = row.get_field("email") {
+            if let Some(Value::VarChar { value: email, .. }) = row.get_field("email") {
                 assert!(email.contains(&format!("user_{i}")));
             }
         }
@@ -295,7 +295,7 @@ tables:
         assert_eq!(row1.index, 5);
 
         // Email should use index 5
-        if let Some(UniversalValue::VarChar { value: email, .. }) = row1.get_field("email") {
+        if let Some(Value::VarChar { value: email, .. }) = row1.get_field("email") {
             assert!(email.contains("user_5"));
         } else {
             panic!(

--- a/crates/loadtest-generator/src/generators/array.rs
+++ b/crates/loadtest-generator/src/generators/array.rs
@@ -2,64 +2,64 @@
 
 use rand::seq::{IndexedRandom, SliceRandom};
 use rand::RngExt;
-use sync_core::{UniversalType, UniversalValue};
+use sync_core::{Type, Value};
 
-/// Convert a string value to the appropriate UniversalValue based on the target type.
-fn string_to_typed_value(s: &str, target_type: &UniversalType) -> UniversalValue {
+/// Convert a string value to the appropriate Value based on the target type.
+fn string_to_typed_value(s: &str, target_type: &Type) -> Value {
     match target_type {
-        UniversalType::Int32 => match s.parse::<i32>() {
-            Ok(i) => UniversalValue::Int32(i),
-            Err(_) => UniversalValue::Text(s.to_string()),
+        Type::Int32 => match s.parse::<i32>() {
+            Ok(i) => Value::Int32(i),
+            Err(_) => Value::Text(s.to_string()),
         },
-        UniversalType::Int16 => match s.parse::<i16>() {
-            Ok(i) => UniversalValue::Int16(i),
-            Err(_) => UniversalValue::Text(s.to_string()),
+        Type::Int16 => match s.parse::<i16>() {
+            Ok(i) => Value::Int16(i),
+            Err(_) => Value::Text(s.to_string()),
         },
-        UniversalType::Int64 => match s.parse::<i64>() {
-            Ok(i) => UniversalValue::Int64(i),
-            Err(_) => UniversalValue::Text(s.to_string()),
+        Type::Int64 => match s.parse::<i64>() {
+            Ok(i) => Value::Int64(i),
+            Err(_) => Value::Text(s.to_string()),
         },
-        UniversalType::Int8 { width: 1 } => {
+        Type::Int8 { width: 1 } => {
             // TinyInt(1) is often used as boolean
             match s.to_lowercase().as_str() {
-                "true" | "1" | "yes" => UniversalValue::Bool(true),
-                "false" | "0" | "no" => UniversalValue::Bool(false),
+                "true" | "1" | "yes" => Value::Bool(true),
+                "false" | "0" | "no" => Value::Bool(false),
                 _ => match s.parse::<i8>() {
-                    Ok(i) => UniversalValue::Int8 { value: i, width: 1 },
-                    Err(_) => UniversalValue::Text(s.to_string()),
+                    Ok(i) => Value::Int8 { value: i, width: 1 },
+                    Err(_) => Value::Text(s.to_string()),
                 },
             }
         }
-        UniversalType::Int8 { width } => match s.parse::<i8>() {
-            Ok(i) => UniversalValue::Int8 {
+        Type::Int8 { width } => match s.parse::<i8>() {
+            Ok(i) => Value::Int8 {
                 value: i,
                 width: *width,
             },
-            Err(_) => UniversalValue::Text(s.to_string()),
+            Err(_) => Value::Text(s.to_string()),
         },
-        UniversalType::Float32 => match s.parse::<f32>() {
-            Ok(f) => UniversalValue::Float32(f),
-            Err(_) => UniversalValue::Text(s.to_string()),
+        Type::Float32 => match s.parse::<f32>() {
+            Ok(f) => Value::Float32(f),
+            Err(_) => Value::Text(s.to_string()),
         },
-        UniversalType::Float64 => match s.parse::<f64>() {
-            Ok(f) => UniversalValue::Float64(f),
-            Err(_) => UniversalValue::Text(s.to_string()),
+        Type::Float64 => match s.parse::<f64>() {
+            Ok(f) => Value::Float64(f),
+            Err(_) => Value::Text(s.to_string()),
         },
-        UniversalType::Decimal { precision, scale } => match s.parse::<f64>() {
-            Ok(_) => UniversalValue::Decimal {
+        Type::Decimal { precision, scale } => match s.parse::<f64>() {
+            Ok(_) => Value::Decimal {
                 value: s.to_string(),
                 precision: *precision,
                 scale: *scale,
             },
-            Err(_) => UniversalValue::Text(s.to_string()),
+            Err(_) => Value::Text(s.to_string()),
         },
-        UniversalType::Bool => match s.to_lowercase().as_str() {
-            "true" | "1" | "yes" => UniversalValue::Bool(true),
-            "false" | "0" | "no" => UniversalValue::Bool(false),
-            _ => UniversalValue::Text(s.to_string()),
+        Type::Bool => match s.to_lowercase().as_str() {
+            "true" | "1" | "yes" => Value::Bool(true),
+            "false" | "0" | "no" => Value::Bool(false),
+            _ => Value::Text(s.to_string()),
         },
         // For text types and all others, keep as string
-        _ => UniversalValue::Text(s.to_string()),
+        _ => Value::Text(s.to_string()),
     }
 }
 
@@ -69,9 +69,9 @@ pub fn generate_sample_array<R: RngExt>(
     pool: &[String],
     min_length: usize,
     max_length: usize,
-) -> UniversalValue {
+) -> Value {
     // Default to string element type
-    generate_sample_array_typed(rng, pool, min_length, max_length, &UniversalType::Text)
+    generate_sample_array_typed(rng, pool, min_length, max_length, &Type::Text)
 }
 
 /// Generate an array by sampling from a pool of values with type-aware conversion.
@@ -80,10 +80,10 @@ pub fn generate_sample_array_typed<R: RngExt>(
     pool: &[String],
     min_length: usize,
     max_length: usize,
-    element_type: &UniversalType,
-) -> UniversalValue {
+    element_type: &Type,
+) -> Value {
     if pool.is_empty() || max_length == 0 {
-        return UniversalValue::Array {
+        return Value::Array {
             elements: vec![],
             element_type: Box::new(element_type.clone()),
         };
@@ -92,14 +92,14 @@ pub fn generate_sample_array_typed<R: RngExt>(
     let length = rng.random_range(min_length..=max_length);
 
     // Randomly select `length` items from the pool (with potential duplicates)
-    let items: Vec<UniversalValue> = (0..length)
+    let items: Vec<Value> = (0..length)
         .map(|_| {
             let item = pool.choose(rng).unwrap();
             string_to_typed_value(item, element_type)
         })
         .collect();
 
-    UniversalValue::Array {
+    Value::Array {
         elements: items,
         element_type: Box::new(element_type.clone()),
     }
@@ -111,11 +111,11 @@ pub fn generate_unique_sample_array<R: RngExt>(
     pool: &[String],
     min_length: usize,
     max_length: usize,
-) -> UniversalValue {
+) -> Value {
     if pool.is_empty() || max_length == 0 {
-        return UniversalValue::Array {
+        return Value::Array {
             elements: vec![],
-            element_type: Box::new(UniversalType::Text),
+            element_type: Box::new(Type::Text),
         };
     }
 
@@ -129,15 +129,11 @@ pub fn generate_unique_sample_array<R: RngExt>(
     let mut shuffled = pool.to_vec();
     shuffled.shuffle(rng);
 
-    let items: Vec<UniversalValue> = shuffled
-        .into_iter()
-        .take(length)
-        .map(UniversalValue::Text)
-        .collect();
+    let items: Vec<Value> = shuffled.into_iter().take(length).map(Value::Text).collect();
 
-    UniversalValue::Array {
+    Value::Array {
         elements: items,
-        element_type: Box::new(UniversalType::Text),
+        element_type: Box::new(Type::Text),
     }
 }
 
@@ -154,7 +150,7 @@ mod tests {
 
         for _ in 0..10 {
             let value = generate_sample_array(&mut rng, &pool, 1, 3);
-            if let UniversalValue::Array { elements, .. } = value {
+            if let Value::Array { elements, .. } = value {
                 assert!(!elements.is_empty());
                 assert!(elements.len() <= 3);
             } else {
@@ -171,7 +167,7 @@ mod tests {
         let value = generate_sample_array(&mut rng, &pool, 0, 3);
         assert!(matches!(
             value,
-            UniversalValue::Array {
+            Value::Array {
                 elements,
                 ..
             } if elements.is_empty()
@@ -190,13 +186,13 @@ mod tests {
         ];
 
         let value = generate_unique_sample_array(&mut rng, &pool, 3, 3);
-        if let UniversalValue::Array { elements, .. } = value {
+        if let Value::Array { elements, .. } = value {
             assert_eq!(elements.len(), 3);
             // Check uniqueness
             let strings: Vec<&String> = elements
                 .iter()
                 .filter_map(|v| {
-                    if let UniversalValue::Text(s) = v {
+                    if let Value::Text(s) = v {
                         Some(s)
                     } else {
                         None

--- a/crates/loadtest-generator/src/generators/mod.rs
+++ b/crates/loadtest-generator/src/generators/mod.rs
@@ -11,12 +11,12 @@ pub mod timestamp;
 pub mod uuid;
 
 use rand::RngExt;
-use sync_core::{GeneratorConfig, UniversalType, UniversalValue};
+use sync_core::{GeneratorConfig, Type, Value};
 
 /// Trait for generating values.
 pub trait ValueGenerator {
     /// Generate a value using the given RNG and row index.
-    fn generate<R: RngExt>(&self, rng: &mut R, index: u64) -> UniversalValue;
+    fn generate<R: RngExt>(&self, rng: &mut R, index: u64) -> Value;
 }
 
 /// Generate a value based on the generator configuration.
@@ -26,7 +26,7 @@ pub fn generate_value<R: RngExt>(
     rng: &mut R,
     seed: u64,
     index: u64,
-) -> UniversalValue {
+) -> Value {
     generate_value_typed(config, rng, seed, index, None)
 }
 
@@ -37,12 +37,12 @@ pub fn generate_value_typed<R: RngExt>(
     rng: &mut R,
     seed: u64,
     index: u64,
-    target_type: Option<&UniversalType>,
-) -> UniversalValue {
+    target_type: Option<&Type>,
+) -> Value {
     let raw_value = match config {
         GeneratorConfig::UuidV4 => uuid::generate_uuid_v4(rng),
 
-        GeneratorConfig::Sequential { start } => UniversalValue::Int64(start + index as i64),
+        GeneratorConfig::Sequential { start } => Value::Int64(start + index as i64),
 
         GeneratorConfig::Pattern { pattern } => pattern::generate_pattern(pattern, rng, index),
 
@@ -60,13 +60,11 @@ pub fn generate_value_typed<R: RngExt>(
 
         GeneratorConfig::TimestampNow => timestamp::generate_timestamp_now(rng, seed, index),
 
-        GeneratorConfig::WeightedBool { true_weight } => {
-            UniversalValue::Bool(rng.random_bool(*true_weight))
-        }
+        GeneratorConfig::WeightedBool { true_weight } => Value::Bool(rng.random_bool(*true_weight)),
 
         GeneratorConfig::OneOf { values } => {
             if values.is_empty() {
-                UniversalValue::Null
+                Value::Null
             } else {
                 let idx = rng.random_range(0..values.len());
                 static_value::yaml_to_generated_value(&values[idx])
@@ -80,15 +78,15 @@ pub fn generate_value_typed<R: RngExt>(
         } => {
             // Extract element type from target type if available
             let element_type = match target_type {
-                Some(UniversalType::Array { element_type }) => element_type.as_ref(),
-                _ => &UniversalType::Text,
+                Some(Type::Array { element_type }) => element_type.as_ref(),
+                _ => &Type::Text,
             };
             array::generate_sample_array_typed(rng, pool, *min_length, *max_length, element_type)
         }
 
         GeneratorConfig::Static { value } => static_value::yaml_to_generated_value(value),
 
-        GeneratorConfig::Null => UniversalValue::Null,
+        GeneratorConfig::Null => Value::Null,
 
         GeneratorConfig::DurationRange { min_secs, max_secs } => {
             numeric::generate_duration_range(rng, *min_secs, *max_secs)
@@ -99,81 +97,68 @@ pub fn generate_value_typed<R: RngExt>(
     convert_to_strict_type(raw_value, target_type)
 }
 
-/// Convert a raw UniversalValue to the strict 1:1 matching value for the target type.
-fn convert_to_strict_type(
-    value: UniversalValue,
-    target_type: Option<&UniversalType>,
-) -> UniversalValue {
+/// Convert a raw Value to the strict 1:1 matching value for the target type.
+fn convert_to_strict_type(value: Value, target_type: Option<&Type>) -> Value {
     match (target_type, value) {
         // Keep null as-is
-        (_, UniversalValue::Null) => UniversalValue::Null,
+        (_, Value::Null) => Value::Null,
 
         // String type conversions - strict 1:1 matching
-        (Some(UniversalType::Char { length }), UniversalValue::Text(s)) => UniversalValue::Char {
+        (Some(Type::Char { length }), Value::Text(s)) => Value::Char {
             value: s,
             length: *length,
         },
-        (Some(UniversalType::VarChar { length }), UniversalValue::Text(s)) => {
-            UniversalValue::VarChar {
-                value: s,
-                length: *length,
-            }
-        }
+        (Some(Type::VarChar { length }), Value::Text(s)) => Value::VarChar {
+            value: s,
+            length: *length,
+        },
 
         // Integer type conversions - strict 1:1 matching
-        (Some(UniversalType::Int8 { width }), UniversalValue::Int64(i)) => UniversalValue::Int8 {
+        (Some(Type::Int8 { width }), Value::Int64(i)) => Value::Int8 {
             value: i as i8,
             width: *width,
         },
-        (Some(UniversalType::Int16), UniversalValue::Int64(i)) => UniversalValue::Int16(i as i16),
-        (Some(UniversalType::Int32), UniversalValue::Int64(i)) => UniversalValue::Int32(i as i32),
+        (Some(Type::Int16), Value::Int64(i)) => Value::Int16(i as i16),
+        (Some(Type::Int32), Value::Int64(i)) => Value::Int32(i as i32),
 
         // Float type conversions - strict 1:1 matching
-        (Some(UniversalType::Float32), UniversalValue::Float64(f)) => {
-            UniversalValue::Float32(f as f32)
-        }
+        (Some(Type::Float32), Value::Float64(f)) => Value::Float32(f as f32),
 
         // Decimal conversion
-        (Some(UniversalType::Decimal { precision, scale }), UniversalValue::Float64(f)) => {
-            UniversalValue::Decimal {
-                value: f.to_string(),
-                precision: *precision,
-                scale: *scale,
-            }
-        }
+        (Some(Type::Decimal { precision, scale }), Value::Float64(f)) => Value::Decimal {
+            value: f.to_string(),
+            precision: *precision,
+            scale: *scale,
+        },
 
         // Date/time conversions - strict 1:1 matching
-        (Some(UniversalType::Date), UniversalValue::LocalDateTime(dt)) => UniversalValue::Date(dt),
-        (Some(UniversalType::Time), UniversalValue::LocalDateTime(dt)) => UniversalValue::Time(dt),
-        (Some(UniversalType::LocalDateTimeNano), UniversalValue::LocalDateTime(dt)) => {
-            UniversalValue::LocalDateTimeNano(dt)
-        }
-        (Some(UniversalType::ZonedDateTime), UniversalValue::LocalDateTime(dt)) => {
-            UniversalValue::ZonedDateTime(dt)
-        }
+        (Some(Type::Date), Value::LocalDateTime(dt)) => Value::Date(dt),
+        (Some(Type::Time), Value::LocalDateTime(dt)) => Value::Time(dt),
+        (Some(Type::LocalDateTimeNano), Value::LocalDateTime(dt)) => Value::LocalDateTimeNano(dt),
+        (Some(Type::ZonedDateTime), Value::LocalDateTime(dt)) => Value::ZonedDateTime(dt),
 
         // Binary type conversions
-        (Some(UniversalType::Blob), UniversalValue::Bytes(b)) => UniversalValue::Blob(b),
+        (Some(Type::Blob), Value::Bytes(b)) => Value::Blob(b),
 
         // Enum conversion - strict 1:1 matching
-        (Some(UniversalType::Enum { values }), UniversalValue::Text(s)) => UniversalValue::Enum {
+        (Some(Type::Enum { values }), Value::Text(s)) => Value::Enum {
             value: s,
             allowed_values: values.clone(),
         },
 
         // Set conversion - strict 1:1 matching
-        (Some(UniversalType::Set { values }), UniversalValue::Array { elements, .. }) => {
+        (Some(Type::Set { values }), Value::Array { elements, .. }) => {
             let set_elements: Vec<String> = elements
                 .into_iter()
                 .filter_map(|v| {
-                    if let UniversalValue::Text(s) = v {
+                    if let Value::Text(s) = v {
                         Some(s)
                     } else {
                         None
                     }
                 })
                 .collect();
-            UniversalValue::Set {
+            Value::Set {
                 elements: set_elements,
                 allowed_values: values.clone(),
             }

--- a/crates/loadtest-generator/src/generators/numeric.rs
+++ b/crates/loadtest-generator/src/generators/numeric.rs
@@ -1,25 +1,25 @@
 //! Numeric value generators.
 
 use rand::RngExt;
-use sync_core::UniversalValue;
+use sync_core::Value;
 
 /// Generate a random integer in the given range (inclusive).
-pub fn generate_int_range<R: RngExt>(rng: &mut R, min: i64, max: i64) -> UniversalValue {
-    UniversalValue::Int64(rng.random_range(min..=max))
+pub fn generate_int_range<R: RngExt>(rng: &mut R, min: i64, max: i64) -> Value {
+    Value::Int64(rng.random_range(min..=max))
 }
 
 /// Generate a random float in the given range (inclusive).
-pub fn generate_float_range<R: RngExt>(rng: &mut R, min: f64, max: f64) -> UniversalValue {
-    UniversalValue::Float64(rng.random_range(min..=max))
+pub fn generate_float_range<R: RngExt>(rng: &mut R, min: f64, max: f64) -> Value {
+    Value::Float64(rng.random_range(min..=max))
 }
 
 /// Generate a random decimal in the given range.
 ///
 /// The decimal is stored as a string with 2 decimal places.
-pub fn generate_decimal_range<R: RngExt>(rng: &mut R, min: f64, max: f64) -> UniversalValue {
+pub fn generate_decimal_range<R: RngExt>(rng: &mut R, min: f64, max: f64) -> Value {
     let value = rng.random_range(min..=max);
     // Format with 2 decimal places by default
-    UniversalValue::Decimal {
+    Value::Decimal {
         value: format!("{value:.2}"),
         precision: 10,
         scale: 2,
@@ -27,13 +27,9 @@ pub fn generate_decimal_range<R: RngExt>(rng: &mut R, min: f64, max: f64) -> Uni
 }
 
 /// Generate a random duration in the given range (in seconds).
-pub fn generate_duration_range<R: RngExt>(
-    rng: &mut R,
-    min_secs: u64,
-    max_secs: u64,
-) -> UniversalValue {
+pub fn generate_duration_range<R: RngExt>(rng: &mut R, min_secs: u64, max_secs: u64) -> Value {
     let secs = rng.random_range(min_secs..=max_secs);
-    UniversalValue::Duration(std::time::Duration::from_secs(secs))
+    Value::Duration(std::time::Duration::from_secs(secs))
 }
 
 #[cfg(test)]
@@ -48,7 +44,7 @@ mod tests {
 
         for _ in 0..100 {
             let value = generate_int_range(&mut rng, 10, 20);
-            if let UniversalValue::Int64(v) = value {
+            if let Value::Int64(v) = value {
                 assert!((10..=20).contains(&v));
             } else {
                 panic!("Expected BigInt value");
@@ -62,7 +58,7 @@ mod tests {
 
         for _ in 0..100 {
             let value = generate_float_range(&mut rng, 0.0, 100.0);
-            if let UniversalValue::Float64(v) = value {
+            if let Value::Float64(v) = value {
                 assert!((0.0..=100.0).contains(&v));
             } else {
                 panic!("Expected Double value");
@@ -75,7 +71,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
 
         let value = generate_decimal_range(&mut rng, 0.0, 100.0);
-        if let UniversalValue::Decimal {
+        if let Value::Decimal {
             value,
             precision,
             scale,
@@ -97,7 +93,7 @@ mod tests {
 
         for _ in 0..100 {
             let value = generate_duration_range(&mut rng, 60, 3600);
-            if let UniversalValue::Duration(d) = value {
+            if let Value::Duration(d) = value {
                 assert!(d.as_secs() >= 60 && d.as_secs() <= 3600);
             } else {
                 panic!("Expected Duration value");

--- a/crates/loadtest-generator/src/generators/pattern.rs
+++ b/crates/loadtest-generator/src/generators/pattern.rs
@@ -6,11 +6,11 @@
 //! - `{rand:N}` - random N-digit number
 
 use rand::RngExt;
-use sync_core::UniversalValue;
+use sync_core::Value;
 use uuid::Uuid;
 
 /// Generate a string based on a pattern with placeholders.
-pub fn generate_pattern<R: RngExt>(pattern: &str, rng: &mut R, index: u64) -> UniversalValue {
+pub fn generate_pattern<R: RngExt>(pattern: &str, rng: &mut R, index: u64) -> Value {
     let mut result = pattern.to_string();
 
     // Replace {index}
@@ -38,7 +38,7 @@ pub fn generate_pattern<R: RngExt>(pattern: &str, rng: &mut R, index: u64) -> Un
         }
     }
 
-    UniversalValue::Text(result)
+    Value::Text(result)
 }
 
 /// Generate a random number with exactly N digits.
@@ -71,10 +71,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
         let value = generate_pattern("user_{index}@example.com", &mut rng, 123);
 
-        assert_eq!(
-            value,
-            UniversalValue::Text("user_123@example.com".to_string())
-        );
+        assert_eq!(value, Value::Text("user_123@example.com".to_string()));
     }
 
     #[test]
@@ -82,7 +79,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
         let value = generate_pattern("id-{uuid}", &mut rng, 0);
 
-        if let UniversalValue::Text(s) = value {
+        if let Value::Text(s) = value {
             assert!(s.starts_with("id-"));
             assert_eq!(s.len(), 3 + 36); // "id-" + UUID
         } else {
@@ -95,7 +92,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
         let value = generate_pattern("code-{rand:6}", &mut rng, 0);
 
-        if let UniversalValue::Text(s) = value {
+        if let Value::Text(s) = value {
             assert!(s.starts_with("code-"));
             assert_eq!(s.len(), 5 + 6); // "code-" + 6 digits
                                         // Check that the random part is all digits
@@ -111,7 +108,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
         let value = generate_pattern("user_{index}_code_{rand:4}", &mut rng, 42);
 
-        if let UniversalValue::Text(s) = value {
+        if let Value::Text(s) = value {
             assert!(s.starts_with("user_42_code_"));
             // Total length: "user_42_code_" (13) + 4 digits
             assert_eq!(s.len(), 13 + 4);

--- a/crates/loadtest-generator/src/generators/static_value.rs
+++ b/crates/loadtest-generator/src/generators/static_value.rs
@@ -1,7 +1,7 @@
-//! Static value generator and YAML to UniversalValue conversion.
+//! Static value generator and YAML to Value conversion.
 
 use serde_yaml::Value as YamlValue;
-use sync_core::UniversalValue;
+use sync_core::Value;
 
 /// Convert a YAML value to a serde_json::Value.
 fn yaml_to_json_value(yaml: &YamlValue) -> serde_json::Value {
@@ -41,27 +41,27 @@ fn yaml_to_json_value(yaml: &YamlValue) -> serde_json::Value {
     }
 }
 
-/// Convert a YAML value to a UniversalValue.
-pub fn yaml_to_generated_value(yaml: &YamlValue) -> UniversalValue {
+/// Convert a YAML value to a Value.
+pub fn yaml_to_generated_value(yaml: &YamlValue) -> Value {
     match yaml {
-        YamlValue::Null => UniversalValue::Null,
-        YamlValue::Bool(b) => UniversalValue::Bool(*b),
+        YamlValue::Null => Value::Null,
+        YamlValue::Bool(b) => Value::Bool(*b),
         YamlValue::Number(n) => {
             if let Some(i) = n.as_i64() {
-                UniversalValue::Int64(i)
+                Value::Int64(i)
             } else if let Some(f) = n.as_f64() {
-                UniversalValue::Float64(f)
+                Value::Float64(f)
             } else {
-                UniversalValue::Text(n.to_string())
+                Value::Text(n.to_string())
             }
         }
-        YamlValue::String(s) => UniversalValue::Text(s.clone()),
+        YamlValue::String(s) => Value::Text(s.clone()),
         YamlValue::Sequence(arr) => {
-            let values: Vec<UniversalValue> = arr.iter().map(yaml_to_generated_value).collect();
+            let values: Vec<Value> = arr.iter().map(yaml_to_generated_value).collect();
             // Use Text as default element type for YAML arrays
-            UniversalValue::Array {
+            Value::Array {
                 elements: values,
-                element_type: Box::new(sync_core::UniversalType::Text),
+                element_type: Box::new(sync_core::Type::Text),
             }
         }
         YamlValue::Mapping(map) => {
@@ -75,7 +75,7 @@ pub fn yaml_to_generated_value(yaml: &YamlValue) -> UniversalValue {
                     Some((key, yaml_to_json_value(v)))
                 })
                 .collect();
-            UniversalValue::Json(Box::new(serde_json::Value::Object(values)))
+            Value::Json(Box::new(serde_json::Value::Object(values)))
         }
         YamlValue::Tagged(tagged) => yaml_to_generated_value(&tagged.value),
     }
@@ -88,25 +88,25 @@ mod tests {
     #[test]
     fn test_yaml_null() {
         let yaml = YamlValue::Null;
-        assert_eq!(yaml_to_generated_value(&yaml), UniversalValue::Null);
+        assert_eq!(yaml_to_generated_value(&yaml), Value::Null);
     }
 
     #[test]
     fn test_yaml_bool() {
         let yaml = YamlValue::Bool(true);
-        assert_eq!(yaml_to_generated_value(&yaml), UniversalValue::Bool(true));
+        assert_eq!(yaml_to_generated_value(&yaml), Value::Bool(true));
     }
 
     #[test]
     fn test_yaml_int() {
         let yaml: YamlValue = serde_yaml::from_str("42").unwrap();
-        assert_eq!(yaml_to_generated_value(&yaml), UniversalValue::Int64(42));
+        assert_eq!(yaml_to_generated_value(&yaml), Value::Int64(42));
     }
 
     #[test]
     fn test_yaml_float() {
         let yaml: YamlValue = serde_yaml::from_str("1.234").unwrap();
-        if let UniversalValue::Float64(f) = yaml_to_generated_value(&yaml) {
+        if let Value::Float64(f) = yaml_to_generated_value(&yaml) {
             assert!((f - 1.234).abs() < 0.001);
         } else {
             panic!("Expected Double");
@@ -118,16 +118,16 @@ mod tests {
         let yaml = YamlValue::String("hello".to_string());
         assert_eq!(
             yaml_to_generated_value(&yaml),
-            UniversalValue::Text("hello".to_string())
+            Value::Text("hello".to_string())
         );
     }
 
     #[test]
     fn test_yaml_array() {
         let yaml: YamlValue = serde_yaml::from_str("[1, 2, 3]").unwrap();
-        if let UniversalValue::Array { elements, .. } = yaml_to_generated_value(&yaml) {
+        if let Value::Array { elements, .. } = yaml_to_generated_value(&yaml) {
             assert_eq!(elements.len(), 3);
-            assert_eq!(elements[0], UniversalValue::Int64(1));
+            assert_eq!(elements[0], Value::Int64(1));
         } else {
             panic!("Expected Array");
         }
@@ -136,7 +136,7 @@ mod tests {
     #[test]
     fn test_yaml_object() {
         let yaml: YamlValue = serde_yaml::from_str("{ version: 1, name: test }").unwrap();
-        if let UniversalValue::Json(payload) = yaml_to_generated_value(&yaml) {
+        if let Value::Json(payload) = yaml_to_generated_value(&yaml) {
             if let serde_json::Value::Object(obj) = &*payload {
                 assert_eq!(obj.get("version"), Some(&serde_json::json!(1)));
                 assert_eq!(obj.get("name"), Some(&serde_json::json!("test")));

--- a/crates/loadtest-generator/src/generators/timestamp.rs
+++ b/crates/loadtest-generator/src/generators/timestamp.rs
@@ -2,7 +2,7 @@
 
 use chrono::{DateTime, Utc};
 use rand::RngExt;
-use sync_core::UniversalValue;
+use sync_core::Value;
 
 // Hardcoded increment range (can be made configurable later)
 const DEFAULT_MIN_INCREMENT_MS: i64 = 1;
@@ -13,7 +13,7 @@ const DEFAULT_MAX_INCREMENT_MS: i64 = 1000;
 /// Generates: seed_derived_base + cumulative_random_increments[0..index]
 /// - Base timestamp derived from seed (2024-01-01 + seed % 10 years)
 /// - Increments: hardcoded 1-1000ms per row (can be made configurable later)
-pub fn generate_timestamp_now<R: RngExt>(rng: &mut R, seed: u64, index: u64) -> UniversalValue {
+pub fn generate_timestamp_now<R: RngExt>(rng: &mut R, seed: u64, index: u64) -> Value {
     // Derive base timestamp from seed (deterministic)
     // Use a fixed epoch (2024-01-01) and add seed modulo ~10 years in seconds
     // This gives a range of timestamps around 2024-2034 depending on seed
@@ -37,7 +37,7 @@ pub fn generate_timestamp_now<R: RngExt>(rng: &mut R, seed: u64, index: u64) -> 
     }
 
     let timestamp = base_dt + chrono::Duration::milliseconds(total_ms);
-    UniversalValue::LocalDateTime(timestamp)
+    Value::LocalDateTime(timestamp)
 }
 
 /// Generate timestamp in a range (deterministic, monotonically increasing).
@@ -54,7 +54,7 @@ pub fn generate_timestamp_range<R: RngExt>(
     start: &str,
     _end: &str, // Ignored for now - kept for API compatibility
     index: u64,
-) -> UniversalValue {
+) -> Value {
     // Parse base timestamp from start parameter
     let start_dt = parse_timestamp(start).expect("Invalid start timestamp in schema");
 
@@ -75,7 +75,7 @@ pub fn generate_timestamp_range<R: RngExt>(
     }
 
     let timestamp = base_dt + chrono::Duration::milliseconds(total_ms);
-    UniversalValue::LocalDateTime(timestamp)
+    Value::LocalDateTime(timestamp)
 }
 
 /// Parse a timestamp string in various formats.
@@ -112,7 +112,7 @@ mod tests {
             5,
         );
 
-        if let UniversalValue::LocalDateTime(dt) = value {
+        if let Value::LocalDateTime(dt) = value {
             assert!(dt.year() >= 2020);
         } else {
             panic!("Expected DateTime value");
@@ -125,7 +125,7 @@ mod tests {
 
         let value = generate_timestamp_range(&mut rng, 42, "2020-01-01", "2024-12-31", 5);
 
-        if let UniversalValue::LocalDateTime(dt) = value {
+        if let Value::LocalDateTime(dt) = value {
             assert!(dt.year() >= 2020);
         } else {
             panic!("Expected DateTime value");
@@ -178,11 +178,8 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
         let ts2 = generate_timestamp_now(&mut rng, 42, 2);
 
-        if let (
-            UniversalValue::LocalDateTime(t0),
-            UniversalValue::LocalDateTime(t1),
-            UniversalValue::LocalDateTime(t2),
-        ) = (ts0, ts1, ts2)
+        if let (Value::LocalDateTime(t0), Value::LocalDateTime(t1), Value::LocalDateTime(t2)) =
+            (ts0, ts1, ts2)
         {
             assert!(t0 < t1, "Timestamps should increase");
             assert!(t1 < t2, "Timestamps should increase");
@@ -198,7 +195,7 @@ mod tests {
         for i in 0..100 {
             let mut rng = StdRng::seed_from_u64(42);
             let ts = generate_timestamp_now(&mut rng, 42, i);
-            if let UniversalValue::LocalDateTime(dt) = ts {
+            if let Value::LocalDateTime(dt) = ts {
                 timestamps.push(dt);
             }
         }

--- a/crates/loadtest-generator/src/generators/uuid.rs
+++ b/crates/loadtest-generator/src/generators/uuid.rs
@@ -1,11 +1,11 @@
 //! UUID value generator.
 
 use rand::RngExt;
-use sync_core::UniversalValue;
+use sync_core::Value;
 use uuid::Uuid;
 
 /// Generate a random UUID v4 using the provided RNG.
-pub fn generate_uuid_v4<R: RngExt>(rng: &mut R) -> UniversalValue {
+pub fn generate_uuid_v4<R: RngExt>(rng: &mut R) -> Value {
     // Generate 16 random bytes
     let mut bytes = [0u8; 16];
     rng.fill(&mut bytes);
@@ -14,7 +14,7 @@ pub fn generate_uuid_v4<R: RngExt>(rng: &mut R) -> UniversalValue {
     bytes[6] = (bytes[6] & 0x0f) | 0x40; // Version 4
     bytes[8] = (bytes[8] & 0x3f) | 0x80; // Variant RFC 4122
 
-    UniversalValue::Uuid(Uuid::from_bytes(bytes))
+    Value::Uuid(Uuid::from_bytes(bytes))
 }
 
 #[cfg(test)]
@@ -27,7 +27,7 @@ mod tests {
     fn test_generate_uuid_v4() {
         let mut rng = StdRng::seed_from_u64(42);
         let value = generate_uuid_v4(&mut rng);
-        assert!(matches!(value, UniversalValue::Uuid(_)));
+        assert!(matches!(value, Value::Uuid(_)));
 
         // Ensure uniqueness
         let value2 = generate_uuid_v4(&mut rng);
@@ -50,7 +50,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
         let value = generate_uuid_v4(&mut rng);
 
-        if let UniversalValue::Uuid(uuid) = value {
+        if let Value::Uuid(uuid) = value {
             assert_eq!(uuid.get_version_num(), 4);
         } else {
             panic!("Expected UUID");

--- a/crates/loadtest-generator/src/lib.rs
+++ b/crates/loadtest-generator/src/lib.rs
@@ -19,7 +19,7 @@
 //! └────────┬────────┘
 //!          │
 //!          ▼
-//!    UniversalRow { table, index, id, fields }
+//!    Row { table, index, id, fields }
 //! ```
 //!
 //! # Example
@@ -71,4 +71,4 @@ pub mod generator;
 pub mod generators;
 
 // Re-exports for convenience
-pub use generator::{DataGenerator, GeneratorError, UniversalRowIterator};
+pub use generator::{DataGenerator, GeneratorError, RowIterator};

--- a/crates/loadtest-populate-csv/src/populator.rs
+++ b/crates/loadtest-populate-csv/src/populator.rs
@@ -8,7 +8,7 @@ use std::fs::File;
 use std::io::BufWriter;
 use std::path::Path;
 use std::time::{Duration, Instant};
-use sync_core::{GeneratorTableDefinition, Schema, TypedValue, UniversalRow};
+use sync_core::{GeneratorTableDefinition, Row, Schema, TypedValue};
 use tracing::{debug, info};
 
 /// Default buffer size for CSV writing.
@@ -293,11 +293,8 @@ fn get_column_names(table_schema: &GeneratorTableDefinition) -> Vec<String> {
     columns
 }
 
-/// Convert an UniversalRow to a CSV record (vector of strings).
-fn internal_row_to_csv_record(
-    row: &UniversalRow,
-    table_schema: &GeneratorTableDefinition,
-) -> Vec<String> {
+/// Convert an Row to a CSV record (vector of strings).
+fn internal_row_to_csv_record(row: &Row, table_schema: &GeneratorTableDefinition) -> Vec<String> {
     let mut record = Vec::new();
 
     // Add the ID
@@ -326,7 +323,7 @@ fn internal_row_to_csv_record(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sync_core::UniversalValue;
+    use sync_core::Value;
     use tempfile::TempDir;
 
     fn test_schema() -> Schema {
@@ -385,22 +382,20 @@ tables:
         let schema = test_schema();
         let table_schema = schema.get_table("users").unwrap();
 
-        let row = UniversalRow::new(
+        let row = Row::new(
             "users".to_string(),
             0,
-            UniversalValue::Uuid(
-                uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap(),
-            ),
+            Value::Uuid(uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap()),
             [
                 (
                     "email".to_string(),
                     // Use VarChar to match schema (strict 1:1 type-value matching)
-                    UniversalValue::VarChar {
+                    Value::VarChar {
                         value: "test@example.com".to_string(),
                         length: 255,
                     },
                 ),
-                ("age".to_string(), UniversalValue::Int32(25)),
+                ("age".to_string(), Value::Int32(25)),
             ]
             .into_iter()
             .collect(),

--- a/crates/loadtest-populate-jsonl/src/populator.rs
+++ b/crates/loadtest-populate-jsonl/src/populator.rs
@@ -7,7 +7,7 @@ use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::Path;
 use std::time::{Duration, Instant};
-use sync_core::{GeneratorTableDefinition, Schema, TypedValue, UniversalRow};
+use sync_core::{GeneratorTableDefinition, Row, Schema, TypedValue};
 use tracing::{debug, info};
 
 /// Default buffer size for JSONL writing.
@@ -270,9 +270,9 @@ impl JsonlPopulator {
     }
 }
 
-/// Convert an UniversalRow to a JSON object.
+/// Convert an Row to a JSON object.
 fn internal_row_to_json(
-    row: &UniversalRow,
+    row: &Row,
     table_schema: &GeneratorTableDefinition,
 ) -> serde_json::Map<String, serde_json::Value> {
     let mut obj = serde_json::Map::new();
@@ -303,7 +303,7 @@ fn internal_row_to_json(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sync_core::UniversalValue;
+    use sync_core::Value;
     use tempfile::TempDir;
 
     fn test_schema() -> Schema {
@@ -353,22 +353,20 @@ tables:
         let schema = test_schema();
         let table_schema = schema.get_table("users").unwrap();
 
-        let row = UniversalRow::new(
+        let row = Row::new(
             "users".to_string(),
             0,
-            UniversalValue::Uuid(
-                uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap(),
-            ),
+            Value::Uuid(uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap()),
             [
                 (
                     "email".to_string(),
                     // Use VarChar to match schema (strict 1:1 type-value matching)
-                    UniversalValue::VarChar {
+                    Value::VarChar {
                         value: "test@example.com".to_string(),
                         length: 255,
                     },
                 ),
-                ("age".to_string(), UniversalValue::Int32(25)),
+                ("age".to_string(), Value::Int32(25)),
             ]
             .into_iter()
             .collect(),

--- a/crates/loadtest-populate-kafka/src/encoder.rs
+++ b/crates/loadtest-populate-kafka/src/encoder.rs
@@ -1,4 +1,4 @@
-//! Protobuf encoder for UniversalRow to wire format.
+//! Protobuf encoder for Row to wire format.
 //!
 //! This module re-exports encoding functions from kafka-types crate.
 

--- a/crates/loadtest-populate-kafka/src/lib.rs
+++ b/crates/loadtest-populate-kafka/src/lib.rs
@@ -16,7 +16,7 @@
 //! │  DataGenerator  │     │  proto_gen.rs   │
 //! │                 │     │                 │
 //! │ - generates     │     │ - generates     │
-//! │   UniversalRow   │     │   .proto files  │
+//! │   Row   │     │   .proto files  │
 //! └────────┬────────┘     └────────┬────────┘
 //!          │                       │
 //!          │                       ▼

--- a/crates/loadtest-populate-kafka/src/populator.rs
+++ b/crates/loadtest-populate-kafka/src/populator.rs
@@ -13,7 +13,7 @@ use rdkafka::producer::{FutureProducer, FutureRecord};
 use rdkafka::ClientConfig;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
-use sync_core::{Schema, UniversalRow};
+use sync_core::{Row, Schema};
 use tempfile::TempDir;
 use tracing::{debug, info};
 
@@ -292,7 +292,7 @@ impl KafkaPopulator {
 
             // Generate rows
             let gen_start = Instant::now();
-            let rows: Vec<UniversalRow> = self
+            let rows: Vec<Row> = self
                 .generator
                 .internal_rows(table_name, batch_count)
                 .map_err(|e| KafkaPopulatorError::Generator(e.to_string()))?
@@ -333,7 +333,7 @@ impl KafkaPopulator {
         &self,
         topic: &str,
         table_schema: &sync_core::GeneratorTableDefinition,
-        rows: &[UniversalRow],
+        rows: &[Row],
     ) -> Result<u64, KafkaPopulatorError> {
         // First, encode all messages (key + payload pairs)
         let encoded_messages: Vec<(Vec<u8>, Vec<u8>)> = rows

--- a/crates/loadtest-populate-kafka/src/proto_gen.rs
+++ b/crates/loadtest-populate-kafka/src/proto_gen.rs
@@ -3,7 +3,7 @@
 //! This module generates .proto file content from a Schema table definition,
 //! enabling dynamic protobuf schema generation for Kafka loadtesting.
 
-use sync_core::{GeneratorTableDefinition, UniversalType};
+use sync_core::{GeneratorTableDefinition, Type};
 
 /// Information about a proto field type.
 struct ProtoTypeInfo {
@@ -30,9 +30,7 @@ pub fn generate_proto_for_table(
     let needs_timestamp = table_schema.fields.iter().any(|f| {
         matches!(
             f.field_type,
-            UniversalType::LocalDateTime
-                | UniversalType::LocalDateTimeNano
-                | UniversalType::ZonedDateTime
+            Type::LocalDateTime | Type::LocalDateTimeNano | Type::ZonedDateTime
         )
     });
 
@@ -70,88 +68,81 @@ pub fn generate_proto_for_table(
     proto
 }
 
-/// Convert a UniversalType to protobuf type information.
-fn sync_type_to_proto_type(sync_type: &UniversalType) -> ProtoTypeInfo {
+/// Convert a Type to protobuf type information.
+fn sync_type_to_proto_type(sync_type: &Type) -> ProtoTypeInfo {
     match sync_type {
         // Boolean
-        UniversalType::Bool => ProtoTypeInfo {
+        Type::Bool => ProtoTypeInfo {
             type_name: "bool".to_string(),
             requires_timestamp_import: false,
         },
 
         // Integer types -> int64 (safest for all integer ranges)
-        UniversalType::Int8 { .. }
-        | UniversalType::Int16
-        | UniversalType::Int32
-        | UniversalType::Int64 => ProtoTypeInfo {
+        Type::Int8 { .. } | Type::Int16 | Type::Int32 | Type::Int64 => ProtoTypeInfo {
             type_name: "int64".to_string(),
             requires_timestamp_import: false,
         },
 
         // Floating point
-        UniversalType::Float32 => ProtoTypeInfo {
+        Type::Float32 => ProtoTypeInfo {
             type_name: "float".to_string(),
             requires_timestamp_import: false,
         },
-        UniversalType::Float64 => ProtoTypeInfo {
+        Type::Float64 => ProtoTypeInfo {
             type_name: "double".to_string(),
             requires_timestamp_import: false,
         },
 
         // Decimal -> string (preserve precision)
-        UniversalType::Decimal { .. } => ProtoTypeInfo {
+        Type::Decimal { .. } => ProtoTypeInfo {
             type_name: "string".to_string(),
             requires_timestamp_import: false,
         },
 
         // String types
-        UniversalType::Char { .. } | UniversalType::VarChar { .. } | UniversalType::Text => {
-            ProtoTypeInfo {
-                type_name: "string".to_string(),
-                requires_timestamp_import: false,
-            }
-        }
+        Type::Char { .. } | Type::VarChar { .. } | Type::Text => ProtoTypeInfo {
+            type_name: "string".to_string(),
+            requires_timestamp_import: false,
+        },
 
         // Binary types
-        UniversalType::Blob | UniversalType::Bytes => ProtoTypeInfo {
+        Type::Blob | Type::Bytes => ProtoTypeInfo {
             type_name: "bytes".to_string(),
             requires_timestamp_import: false,
         },
 
         // Temporal types -> google.protobuf.Timestamp
-        UniversalType::LocalDateTime
-        | UniversalType::LocalDateTimeNano
-        | UniversalType::ZonedDateTime => ProtoTypeInfo {
+        Type::LocalDateTime | Type::LocalDateTimeNano | Type::ZonedDateTime => ProtoTypeInfo {
             type_name: "google.protobuf.Timestamp".to_string(),
             requires_timestamp_import: true,
         },
 
         // Date and Time -> string (ISO format)
-        UniversalType::Date | UniversalType::Time => ProtoTypeInfo {
+        Type::Date | Type::Time => ProtoTypeInfo {
             type_name: "string".to_string(),
             requires_timestamp_import: false,
         },
 
         // UUID -> string
-        UniversalType::Uuid => ProtoTypeInfo {
+        Type::Uuid => ProtoTypeInfo {
             type_name: "string".to_string(),
             requires_timestamp_import: false,
         },
 
         // ULID -> string
-        UniversalType::Ulid => ProtoTypeInfo {
+        Type::Ulid => ProtoTypeInfo {
             type_name: "string".to_string(),
             requires_timestamp_import: false,
         },
 
         // JSON types -> string (serialized JSON)
-        UniversalType::Json | UniversalType::Jsonb => ProtoTypeInfo {
+        Type::Json | Type::Jsonb => ProtoTypeInfo {
             type_name: "string".to_string(),
             requires_timestamp_import: false,
         },
 
         // Array -> repeated
-        UniversalType::Array { element_type } => {
+        Type::Array { element_type } => {
             let inner = sync_type_to_proto_type(element_type);
             ProtoTypeInfo {
                 type_name: format!("repeated {}", inner.type_name),
@@ -160,37 +151,37 @@ fn sync_type_to_proto_type(sync_type: &UniversalType) -> ProtoTypeInfo {
         }
 
         // Set and Enum -> string
-        UniversalType::Set { .. } | UniversalType::Enum { .. } => ProtoTypeInfo {
+        Type::Set { .. } | Type::Enum { .. } => ProtoTypeInfo {
             type_name: "string".to_string(),
             requires_timestamp_import: false,
         },
 
         // Geometry -> string (GeoJSON or WKT)
-        UniversalType::Geometry { .. } => ProtoTypeInfo {
+        Type::Geometry { .. } => ProtoTypeInfo {
             type_name: "string".to_string(),
             requires_timestamp_import: false,
         },
 
         // Duration -> string (ISO 8601 duration format)
-        UniversalType::Duration => ProtoTypeInfo {
+        Type::Duration => ProtoTypeInfo {
             type_name: "string".to_string(),
             requires_timestamp_import: false,
         },
 
         // Thing -> string (table:id format)
-        UniversalType::Thing => ProtoTypeInfo {
+        Type::Thing => ProtoTypeInfo {
             type_name: "string".to_string(),
             requires_timestamp_import: false,
         },
 
         // Object -> string (serialized JSON)
-        UniversalType::Object => ProtoTypeInfo {
+        Type::Object => ProtoTypeInfo {
             type_name: "string".to_string(),
             requires_timestamp_import: false,
         },
 
         // TimeTz -> string (time with timezone preserved as string)
-        UniversalType::TimeTz => ProtoTypeInfo {
+        Type::TimeTz => ProtoTypeInfo {
             type_name: "string".to_string(),
             requires_timestamp_import: false,
         },
@@ -284,26 +275,26 @@ tables:
     #[test]
     fn test_proto_type_mapping() {
         // Boolean
-        let info = sync_type_to_proto_type(&UniversalType::Bool);
+        let info = sync_type_to_proto_type(&Type::Bool);
         assert_eq!(info.type_name, "bool");
         assert!(!info.requires_timestamp_import);
 
         // Integer types
-        let info = sync_type_to_proto_type(&UniversalType::Int64);
+        let info = sync_type_to_proto_type(&Type::Int64);
         assert_eq!(info.type_name, "int64");
 
         // Float
-        let info = sync_type_to_proto_type(&UniversalType::Float32);
+        let info = sync_type_to_proto_type(&Type::Float32);
         assert_eq!(info.type_name, "float");
 
         // DateTime
-        let info = sync_type_to_proto_type(&UniversalType::LocalDateTime);
+        let info = sync_type_to_proto_type(&Type::LocalDateTime);
         assert_eq!(info.type_name, "google.protobuf.Timestamp");
         assert!(info.requires_timestamp_import);
 
         // Array<Int>
-        let info = sync_type_to_proto_type(&UniversalType::Array {
-            element_type: Box::new(UniversalType::Int32),
+        let info = sync_type_to_proto_type(&Type::Array {
+            element_type: Box::new(Type::Int32),
         });
         assert_eq!(info.type_name, "repeated int64");
     }

--- a/crates/loadtest-populate-mongodb/src/insert.rs
+++ b/crates/loadtest-populate-mongodb/src/insert.rs
@@ -4,7 +4,7 @@ use crate::error::MongoDBPopulatorError;
 use bson::{doc, Document};
 use mongodb::Collection;
 use mongodb_types::forward::BsonValue;
-use sync_core::{GeneratorTableDefinition, TypedValue, UniversalRow};
+use sync_core::{GeneratorTableDefinition, Row, TypedValue};
 
 /// Default batch size for INSERT operations.
 pub const DEFAULT_BATCH_SIZE: usize = 100;
@@ -13,13 +13,13 @@ pub const DEFAULT_BATCH_SIZE: usize = 100;
 pub async fn insert_batch(
     collection: &Collection<Document>,
     table_schema: &GeneratorTableDefinition,
-    rows: &[UniversalRow],
+    rows: &[Row],
 ) -> Result<u64, MongoDBPopulatorError> {
     if rows.is_empty() {
         return Ok(0);
     }
 
-    // Convert UniversalRows to BSON documents
+    // Convert Rows to BSON documents
     let documents: Vec<Document> = rows
         .iter()
         .map(|row| internal_row_to_document(row, table_schema))
@@ -31,11 +31,8 @@ pub async fn insert_batch(
     Ok(result.inserted_ids.len() as u64)
 }
 
-/// Convert an UniversalRow to a BSON Document.
-fn internal_row_to_document(
-    row: &UniversalRow,
-    table_schema: &GeneratorTableDefinition,
-) -> Document {
+/// Convert an Row to a BSON Document.
+fn internal_row_to_document(row: &Row, table_schema: &GeneratorTableDefinition) -> Document {
     let mut doc = Document::new();
 
     // Add the _id field
@@ -66,7 +63,7 @@ fn internal_row_to_document(
 pub async fn insert_single(
     collection: &Collection<Document>,
     table_schema: &GeneratorTableDefinition,
-    row: &UniversalRow,
+    row: &Row,
 ) -> Result<u64, MongoDBPopulatorError> {
     let doc = internal_row_to_document(row, table_schema);
     collection.insert_one(doc).await?;
@@ -92,7 +89,7 @@ pub async fn count_documents(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sync_core::{Schema, UniversalValue};
+    use sync_core::{Schema, Value};
 
     fn test_schema() -> Schema {
         let yaml = r#"
@@ -127,20 +124,20 @@ tables:
         let schema = test_schema();
         let table_schema = schema.get_table("users").unwrap();
 
-        let row = UniversalRow::new(
+        let row = Row::new(
             "users".to_string(),
             0,
-            UniversalValue::Uuid(uuid::Uuid::new_v4()),
+            Value::Uuid(uuid::Uuid::new_v4()),
             [
                 (
                     "email".to_string(),
                     // Use VarChar to match schema (strict 1:1 type-value matching)
-                    UniversalValue::VarChar {
+                    Value::VarChar {
                         value: "test@example.com".to_string(),
                         length: 255,
                     },
                 ),
-                ("age".to_string(), UniversalValue::Int32(25)),
+                ("age".to_string(), Value::Int32(25)),
             ]
             .into_iter()
             .collect(),

--- a/crates/loadtest-populate-mongodb/src/populator.rs
+++ b/crates/loadtest-populate-mongodb/src/populator.rs
@@ -6,7 +6,7 @@ use bson::Document;
 use loadtest_generator::DataGenerator;
 use mongodb::{Client, Collection, Database};
 use std::time::{Duration, Instant};
-use sync_core::{Schema, UniversalRow};
+use sync_core::{Row, Schema};
 use tracing::{debug, info};
 
 /// Metrics from a populate operation.
@@ -204,7 +204,7 @@ impl MongoDBPopulator {
 
             // Generate rows
             let gen_start = Instant::now();
-            let rows: Vec<UniversalRow> = self
+            let rows: Vec<Row> = self
                 .generator
                 .internal_rows(collection_name, batch_count)
                 .map_err(|e| MongoDBPopulatorError::Generator(e.to_string()))?

--- a/crates/loadtest-populate-mysql/src/insert.rs
+++ b/crates/loadtest-populate-mysql/src/insert.rs
@@ -3,7 +3,7 @@
 use crate::error::MySQLPopulatorError;
 use mysql_async::{prelude::*, Params, Pool, Value};
 use mysql_types::forward::MySQLValue;
-use sync_core::{GeneratorTableDefinition, Schema, TypedValue, UniversalRow};
+use sync_core::{GeneratorTableDefinition, Row, Schema, TypedValue};
 
 /// Default batch size for INSERT operations.
 pub const DEFAULT_BATCH_SIZE: usize = 100;
@@ -12,7 +12,7 @@ pub const DEFAULT_BATCH_SIZE: usize = 100;
 pub async fn insert_batch(
     pool: &Pool,
     table_schema: &GeneratorTableDefinition,
-    rows: &[UniversalRow],
+    rows: &[Row],
 ) -> Result<u64, MySQLPopulatorError> {
     if rows.is_empty() {
         return Ok(0);
@@ -76,7 +76,7 @@ pub async fn insert_batch(
 pub async fn insert_single(
     pool: &Pool,
     table_schema: &GeneratorTableDefinition,
-    row: &UniversalRow,
+    row: &Row,
 ) -> Result<u64, MySQLPopulatorError> {
     let mut conn = pool.get_conn().await?;
 
@@ -131,7 +131,7 @@ pub fn generate_create_table(schema: &Schema, table_name: &str) -> Option<String
     let table_schema = schema.get_table(table_name)?;
 
     // Build column definitions
-    let columns: Vec<(String, sync_core::UniversalType, bool)> = table_schema
+    let columns: Vec<(String, sync_core::Type, bool)> = table_schema
         .fields
         .iter()
         .map(|f| (f.name.clone(), f.field_type.clone(), f.nullable))

--- a/crates/loadtest-populate-mysql/src/populator.rs
+++ b/crates/loadtest-populate-mysql/src/populator.rs
@@ -5,7 +5,7 @@ use crate::insert::{generate_create_table, generate_drop_table, insert_batch, DE
 use loadtest_generator::DataGenerator;
 use mysql_async::{prelude::*, Pool};
 use std::time::{Duration, Instant};
-use sync_core::{Schema, UniversalRow};
+use sync_core::{Row, Schema};
 use tracing::{debug, info, warn};
 
 /// Default number of connection retry attempts
@@ -261,7 +261,7 @@ impl MySQLPopulator {
 
             // Generate rows
             let gen_start = Instant::now();
-            let rows: Vec<UniversalRow> = self
+            let rows: Vec<Row> = self
                 .generator
                 .internal_rows(table_name, batch_count)
                 .map_err(|e| MySQLPopulatorError::Generator(e.to_string()))?

--- a/crates/loadtest-populate-neo4j/src/insert.rs
+++ b/crates/loadtest-populate-neo4j/src/insert.rs
@@ -2,9 +2,7 @@
 
 use crate::error::Neo4jPopulatorError;
 use neo4rs::{query, Graph, Query};
-use sync_core::{
-    GeneratorTableDefinition, TypedValue, UniversalRow, UniversalType, UniversalValue,
-};
+use sync_core::{GeneratorTableDefinition, Row, Type, TypedValue, Value};
 use tracing::debug;
 
 /// Default batch size for INSERT operations.
@@ -16,7 +14,7 @@ pub const DEFAULT_BATCH_SIZE: usize = 100;
 pub async fn insert_batch(
     graph: &Graph,
     table_schema: &GeneratorTableDefinition,
-    rows: &[UniversalRow],
+    rows: &[Row],
 ) -> Result<u64, Neo4jPopulatorError> {
     if rows.is_empty() {
         return Ok(0);
@@ -39,7 +37,7 @@ pub async fn insert_batch(
 /// Build a CREATE query for a single node.
 fn build_create_node_query(
     label: &str,
-    row: &UniversalRow,
+    row: &Row,
     table_schema: &GeneratorTableDefinition,
 ) -> Result<Query, Neo4jPopulatorError> {
     // Build property map for the node
@@ -48,14 +46,14 @@ fn build_create_node_query(
     // Add the id field - always as string since Neo4j full sync expects string IDs
     // The Neo4j full sync uses the 'id' property to create SurrealDB record IDs
     let id_string = match &row.id {
-        UniversalValue::Int8 { value, .. } => value.to_string(),
-        UniversalValue::Int16(i) => i.to_string(),
-        UniversalValue::Int32(i) => i.to_string(),
-        UniversalValue::Int64(i) => i.to_string(),
-        UniversalValue::Text(s) => s.clone(),
-        UniversalValue::Char { value, .. } => value.clone(),
-        UniversalValue::VarChar { value, .. } => value.clone(),
-        UniversalValue::Uuid(u) => u.to_string(),
+        Value::Int8 { value, .. } => value.to_string(),
+        Value::Int16(i) => i.to_string(),
+        Value::Int32(i) => i.to_string(),
+        Value::Int64(i) => i.to_string(),
+        Value::Text(s) => s.clone(),
+        Value::Char { value, .. } => value.clone(),
+        Value::VarChar { value, .. } => value.clone(),
+        Value::Uuid(u) => u.to_string(),
         other => panic!(
             "Unsupported ID type for Neo4j node: {other:?}. \
              Supported types: Int8, Int16, Int32, Int64, Text, Char, VarChar, Uuid"
@@ -88,95 +86,95 @@ fn build_create_node_query(
 /// Convert a TypedValue to a Neo4j literal string for use in Cypher queries.
 fn typed_to_neo4j_literal(typed: &TypedValue) -> String {
     match &typed.value {
-        UniversalValue::Null => "null".to_string(),
-        UniversalValue::Bool(b) => b.to_string(),
+        Value::Null => "null".to_string(),
+        Value::Bool(b) => b.to_string(),
 
         // Integer types - strict 1:1 matching
-        UniversalValue::Int8 { value, .. } => value.to_string(),
-        UniversalValue::Int16(i) => i.to_string(),
-        UniversalValue::Int32(i) => i.to_string(),
-        UniversalValue::Int64(i) => i.to_string(),
+        Value::Int8 { value, .. } => value.to_string(),
+        Value::Int16(i) => i.to_string(),
+        Value::Int32(i) => i.to_string(),
+        Value::Int64(i) => i.to_string(),
 
         // Float types - strict 1:1 matching
-        UniversalValue::Float32(f) => {
+        Value::Float32(f) => {
             if f.is_nan() {
                 "null".to_string()
             } else {
                 f.to_string()
             }
         }
-        UniversalValue::Float64(f) => {
+        Value::Float64(f) => {
             if f.is_nan() {
                 "null".to_string() // Neo4j doesn't support NaN
             } else {
                 f.to_string()
             }
         }
-        UniversalValue::Decimal { value, .. } => {
+        Value::Decimal { value, .. } => {
             // Store decimal as numeric string in Neo4j
             value.to_string()
         }
 
         // String types - strict 1:1 matching
-        UniversalValue::Text(s) => escape_neo4j_string(s),
-        UniversalValue::Char { value, .. } => escape_neo4j_string(value),
-        UniversalValue::VarChar { value, .. } => escape_neo4j_string(value),
+        Value::Text(s) => escape_neo4j_string(s),
+        Value::Char { value, .. } => escape_neo4j_string(value),
+        Value::VarChar { value, .. } => escape_neo4j_string(value),
 
-        UniversalValue::Uuid(u) => escape_neo4j_string(&u.to_string()),
+        Value::Uuid(u) => escape_neo4j_string(&u.to_string()),
 
         // ULID - encode as string
-        UniversalValue::Ulid(u) => escape_neo4j_string(&u.to_string()),
+        Value::Ulid(u) => escape_neo4j_string(&u.to_string()),
 
         // DateTime types - strict 1:1 matching
-        UniversalValue::LocalDateTime(dt) => {
+        Value::LocalDateTime(dt) => {
             format!("datetime('{}')", dt.format("%Y-%m-%dT%H:%M:%S%.fZ"))
         }
-        UniversalValue::LocalDateTimeNano(dt) => {
+        Value::LocalDateTimeNano(dt) => {
             format!("datetime('{}')", dt.format("%Y-%m-%dT%H:%M:%S%.fZ"))
         }
-        UniversalValue::ZonedDateTime(dt) => {
+        Value::ZonedDateTime(dt) => {
             format!("datetime('{}')", dt.format("%Y-%m-%dT%H:%M:%S%.fZ"))
         }
-        UniversalValue::Date(dt) => {
+        Value::Date(dt) => {
             format!("date('{}')", dt.format("%Y-%m-%d"))
         }
-        UniversalValue::Time(dt) => {
+        Value::Time(dt) => {
             format!("time('{}')", dt.format("%H:%M:%S"))
         }
 
         // Binary types - strict 1:1 matching
-        UniversalValue::Bytes(b) => {
+        Value::Bytes(b) => {
             // Neo4j doesn't have native bytes, store as hex string
             let hex: String = b.iter().map(|byte| format!("{byte:02x}")).collect();
             escape_neo4j_string(&hex)
         }
-        UniversalValue::Blob(b) => {
+        Value::Blob(b) => {
             let hex: String = b.iter().map(|byte| format!("{byte:02x}")).collect();
             escape_neo4j_string(&hex)
         }
 
         // JSON types - strict 1:1 matching
-        UniversalValue::Json(json_val) => {
+        Value::Json(json_val) => {
             let json_str = serde_json::to_string(&json_val).unwrap_or_else(|_| "{}".to_string());
             escape_neo4j_string(&json_str)
         }
-        UniversalValue::Jsonb(json_val) => {
+        Value::Jsonb(json_val) => {
             let json_str = serde_json::to_string(&json_val).unwrap_or_else(|_| "{}".to_string());
             escape_neo4j_string(&json_str)
         }
 
         // Enum type - strict 1:1 matching
-        UniversalValue::Enum { value, .. } => escape_neo4j_string(value),
+        Value::Enum { value, .. } => escape_neo4j_string(value),
 
         // Set type - strict 1:1 matching
-        UniversalValue::Set { elements, .. } => {
+        Value::Set { elements, .. } => {
             let element_strs: Vec<String> =
                 elements.iter().map(|s| escape_neo4j_string(s)).collect();
             format!("[{}]", element_strs.join(", "))
         }
 
         // Geometry type - store as GeoJSON string
-        UniversalValue::Geometry { data, .. } => {
+        Value::Geometry { data, .. } => {
             use sync_core::GeometryData;
             let GeometryData(json) = data;
             let json_str = serde_json::to_string(&json).unwrap_or_else(|_| "{}".to_string());
@@ -184,7 +182,7 @@ fn typed_to_neo4j_literal(typed: &TypedValue) -> String {
         }
 
         // Array type - recursive handling
-        UniversalValue::Array { elements, .. } => {
+        Value::Array { elements, .. } => {
             // Neo4j lists
             let element_strs: Vec<String> = elements
                 .iter()
@@ -197,7 +195,7 @@ fn typed_to_neo4j_literal(typed: &TypedValue) -> String {
         }
 
         // Duration type - Neo4j duration
-        UniversalValue::Duration(d) => {
+        Value::Duration(d) => {
             let secs = d.as_secs();
             let nanos = d.subsec_nanos();
             if nanos == 0 {
@@ -208,12 +206,12 @@ fn typed_to_neo4j_literal(typed: &TypedValue) -> String {
         }
 
         // Thing - record reference as string in "table:id" format
-        UniversalValue::Thing { table, id } => {
+        Value::Thing { table, id } => {
             let id_str = match id.as_ref() {
-                UniversalValue::Text(s) => s.clone(),
-                UniversalValue::Int32(i) => i.to_string(),
-                UniversalValue::Int64(i) => i.to_string(),
-                UniversalValue::Uuid(u) => u.to_string(),
+                Value::Text(s) => s.clone(),
+                Value::Int32(i) => i.to_string(),
+                Value::Int64(i) => i.to_string(),
+                Value::Uuid(u) => u.to_string(),
                 other => panic!(
                     "Unsupported Thing ID type for Neo4j: {other:?}. \
                      Supported types: Text, Int32, Int64, Uuid"
@@ -223,7 +221,7 @@ fn typed_to_neo4j_literal(typed: &TypedValue) -> String {
         }
 
         // Object - serialize as JSON string
-        UniversalValue::Object(map) => {
+        Value::Object(map) => {
             let obj: serde_json::Map<String, serde_json::Value> = map
                 .iter()
                 .map(|(k, v)| (k.clone(), universal_to_json(v)))
@@ -234,26 +232,26 @@ fn typed_to_neo4j_literal(typed: &TypedValue) -> String {
         }
 
         // TimeTz - stored as string to preserve timezone format
-        UniversalValue::TimeTz(s) => escape_neo4j_string(s),
+        Value::TimeTz(s) => escape_neo4j_string(s),
 
-        UniversalValue::ZeroTemporal {
+        Value::ZeroTemporal {
             intended_type,
             source,
         } => {
             let s = source
                 .as_deref()
-                .unwrap_or_else(|| UniversalValue::canonical_zero_literal(intended_type));
+                .unwrap_or_else(|| Value::canonical_zero_literal(intended_type));
             escape_neo4j_string(s)
         }
     }
 }
 
-/// Convert a UniversalValue to a Neo4j literal (for array elements).
-fn generated_to_neo4j_literal(value: &UniversalValue, parent_type: &UniversalType) -> String {
+/// Convert a Value to a Neo4j literal (for array elements).
+fn generated_to_neo4j_literal(value: &Value, parent_type: &Type) -> String {
     // Get element type if this is an array
     let element_type = match parent_type {
-        UniversalType::Array { element_type } => element_type.as_ref().clone(),
-        _ => UniversalType::Text, // Fallback
+        Type::Array { element_type } => element_type.as_ref().clone(),
+        _ => Type::Text, // Fallback
     };
 
     let typed = TypedValue::try_with_type(element_type, value.clone())
@@ -261,46 +259,46 @@ fn generated_to_neo4j_literal(value: &UniversalValue, parent_type: &UniversalTyp
     typed_to_neo4j_literal(&typed)
 }
 
-/// Convert a UniversalValue to a serde_json::Value for Object serialization.
-fn universal_to_json(value: &UniversalValue) -> serde_json::Value {
+/// Convert a Value to a serde_json::Value for Object serialization.
+fn universal_to_json(value: &Value) -> serde_json::Value {
     match value {
-        UniversalValue::Null => serde_json::Value::Null,
-        UniversalValue::Bool(b) => serde_json::json!(*b),
-        UniversalValue::Int8 { value, .. } => serde_json::json!(*value),
-        UniversalValue::Int16(i) => serde_json::json!(*i),
-        UniversalValue::Int32(i) => serde_json::json!(*i),
-        UniversalValue::Int64(i) => serde_json::json!(*i),
-        UniversalValue::Float32(f) => serde_json::json!(*f),
-        UniversalValue::Float64(f) => serde_json::json!(*f),
-        UniversalValue::Text(s) => serde_json::json!(s),
-        UniversalValue::Char { value, .. } => serde_json::json!(value),
-        UniversalValue::VarChar { value, .. } => serde_json::json!(value),
-        UniversalValue::Uuid(u) => serde_json::json!(u.to_string()),
-        UniversalValue::Ulid(u) => serde_json::json!(u.to_string()),
-        UniversalValue::LocalDateTime(dt)
-        | UniversalValue::LocalDateTimeNano(dt)
-        | UniversalValue::ZonedDateTime(dt) => serde_json::json!(dt.to_rfc3339()),
-        UniversalValue::Date(dt) => serde_json::json!(dt.format("%Y-%m-%d").to_string()),
-        UniversalValue::Time(dt) => serde_json::json!(dt.format("%H:%M:%S").to_string()),
-        UniversalValue::Bytes(b) | UniversalValue::Blob(b) => {
+        Value::Null => serde_json::Value::Null,
+        Value::Bool(b) => serde_json::json!(*b),
+        Value::Int8 { value, .. } => serde_json::json!(*value),
+        Value::Int16(i) => serde_json::json!(*i),
+        Value::Int32(i) => serde_json::json!(*i),
+        Value::Int64(i) => serde_json::json!(*i),
+        Value::Float32(f) => serde_json::json!(*f),
+        Value::Float64(f) => serde_json::json!(*f),
+        Value::Text(s) => serde_json::json!(s),
+        Value::Char { value, .. } => serde_json::json!(value),
+        Value::VarChar { value, .. } => serde_json::json!(value),
+        Value::Uuid(u) => serde_json::json!(u.to_string()),
+        Value::Ulid(u) => serde_json::json!(u.to_string()),
+        Value::LocalDateTime(dt) | Value::LocalDateTimeNano(dt) | Value::ZonedDateTime(dt) => {
+            serde_json::json!(dt.to_rfc3339())
+        }
+        Value::Date(dt) => serde_json::json!(dt.format("%Y-%m-%d").to_string()),
+        Value::Time(dt) => serde_json::json!(dt.format("%H:%M:%S").to_string()),
+        Value::Bytes(b) | Value::Blob(b) => {
             serde_json::json!(b
                 .iter()
                 .map(|byte| format!("{byte:02x}"))
                 .collect::<String>())
         }
-        UniversalValue::Json(j) | UniversalValue::Jsonb(j) => (**j).clone(),
-        UniversalValue::Decimal { value, .. } => serde_json::json!(value),
-        UniversalValue::Enum { value, .. } => serde_json::json!(value),
-        UniversalValue::Set { elements, .. } => serde_json::json!(elements),
-        UniversalValue::Array { elements, .. } => {
+        Value::Json(j) | Value::Jsonb(j) => (**j).clone(),
+        Value::Decimal { value, .. } => serde_json::json!(value),
+        Value::Enum { value, .. } => serde_json::json!(value),
+        Value::Set { elements, .. } => serde_json::json!(elements),
+        Value::Array { elements, .. } => {
             serde_json::Value::Array(elements.iter().map(universal_to_json).collect())
         }
-        UniversalValue::Geometry { data, .. } => {
+        Value::Geometry { data, .. } => {
             use sync_core::GeometryData;
             let GeometryData(json) = data;
             json.clone()
         }
-        UniversalValue::Duration(d) => {
+        Value::Duration(d) => {
             let secs = d.as_secs();
             let nanos = d.subsec_nanos();
             if nanos == 0 {
@@ -309,17 +307,17 @@ fn universal_to_json(value: &UniversalValue) -> serde_json::Value {
                 serde_json::json!(format!("PT{secs}.{nanos:09}S"))
             }
         }
-        UniversalValue::Thing { table, id } => {
+        Value::Thing { table, id } => {
             let id_str = match id.as_ref() {
-                UniversalValue::Text(s) => s.clone(),
-                UniversalValue::Int32(i) => i.to_string(),
-                UniversalValue::Int64(i) => i.to_string(),
-                UniversalValue::Uuid(u) => u.to_string(),
+                Value::Text(s) => s.clone(),
+                Value::Int32(i) => i.to_string(),
+                Value::Int64(i) => i.to_string(),
+                Value::Uuid(u) => u.to_string(),
                 _ => "unknown".to_string(),
             };
             serde_json::json!(format!("{table}:{id_str}"))
         }
-        UniversalValue::Object(map) => {
+        Value::Object(map) => {
             let obj: serde_json::Map<String, serde_json::Value> = map
                 .iter()
                 .map(|(k, v)| (k.clone(), universal_to_json(v)))
@@ -327,14 +325,14 @@ fn universal_to_json(value: &UniversalValue) -> serde_json::Value {
             serde_json::Value::Object(obj)
         }
         // TimeTz - stored as string to preserve timezone format
-        UniversalValue::TimeTz(s) => serde_json::json!(s),
-        UniversalValue::ZeroTemporal {
+        Value::TimeTz(s) => serde_json::json!(s),
+        Value::ZeroTemporal {
             intended_type,
             source,
         } => {
             let s = source
                 .as_deref()
-                .unwrap_or_else(|| UniversalValue::canonical_zero_literal(intended_type));
+                .unwrap_or_else(|| Value::canonical_zero_literal(intended_type));
             serde_json::json!(s)
         }
     }
@@ -396,7 +394,7 @@ mod tests {
         let bool_val = TypedValue::bool(true);
         assert_eq!(typed_to_neo4j_literal(&bool_val), "true");
 
-        let null_val = TypedValue::null(UniversalType::Text);
+        let null_val = TypedValue::null(Type::Text);
         assert_eq!(typed_to_neo4j_literal(&null_val), "null");
     }
 }

--- a/crates/loadtest-populate-neo4j/src/populator.rs
+++ b/crates/loadtest-populate-neo4j/src/populator.rs
@@ -5,7 +5,7 @@ use crate::insert::{count_nodes, delete_all_nodes, insert_batch, DEFAULT_BATCH_S
 use loadtest_generator::DataGenerator;
 use neo4rs::{ConfigBuilder, Graph};
 use std::time::{Duration, Instant};
-use sync_core::{Schema, UniversalRow};
+use sync_core::{Row, Schema};
 use tracing::{debug, info};
 
 /// Metrics from a populate operation.
@@ -189,7 +189,7 @@ impl Neo4jPopulator {
 
             // Generate rows
             let gen_start = Instant::now();
-            let rows: Vec<UniversalRow> = self
+            let rows: Vec<Row> = self
                 .generator
                 .internal_rows(label, batch_count)
                 .map_err(|e| Neo4jPopulatorError::Generator(e.to_string()))?

--- a/crates/loadtest-populate-postgresql/src/insert.rs
+++ b/crates/loadtest-populate-postgresql/src/insert.rs
@@ -2,7 +2,7 @@
 
 use crate::error::PostgreSQLPopulatorError;
 use postgresql_types::forward::PostgreSQLValue;
-use sync_core::{GeneratorTableDefinition, Schema, TypedValue, UniversalRow};
+use sync_core::{GeneratorTableDefinition, Row, Schema, TypedValue};
 use tokio_postgres::types::ToSql;
 use tokio_postgres::Client;
 
@@ -13,7 +13,7 @@ pub const DEFAULT_BATCH_SIZE: usize = 100;
 pub async fn insert_batch(
     client: &Client,
     table_schema: &GeneratorTableDefinition,
-    rows: &[UniversalRow],
+    rows: &[Row],
 ) -> Result<u64, PostgreSQLPopulatorError> {
     if rows.is_empty() {
         return Ok(0);
@@ -124,7 +124,7 @@ fn pg_value_to_boxed(value: PostgreSQLValue) -> Box<dyn ToSql + Sync + Send> {
 pub async fn insert_single(
     client: &Client,
     table_schema: &GeneratorTableDefinition,
-    row: &UniversalRow,
+    row: &Row,
 ) -> Result<u64, PostgreSQLPopulatorError> {
     // Build column list: id + all fields
     let mut columns: Vec<String> = vec!["id".to_string()];
@@ -184,7 +184,7 @@ pub fn generate_create_table(schema: &Schema, table_name: &str) -> Option<String
     let table_schema = schema.get_table(table_name)?;
 
     // Build column definitions
-    let columns: Vec<(String, sync_core::UniversalType, bool)> = table_schema
+    let columns: Vec<(String, sync_core::Type, bool)> = table_schema
         .fields
         .iter()
         .map(|f| (f.name.clone(), f.field_type.clone(), f.nullable))

--- a/crates/loadtest-populate-postgresql/src/populator.rs
+++ b/crates/loadtest-populate-postgresql/src/populator.rs
@@ -5,7 +5,7 @@ use crate::insert::{generate_create_table, generate_drop_table, insert_batch, DE
 use loadtest_generator::DataGenerator;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use sync_core::{Schema, UniversalRow};
+use sync_core::{Row, Schema};
 use tokio::sync::Mutex;
 use tokio_postgres::{Client, NoTls};
 use tracing::{debug, info};
@@ -203,7 +203,7 @@ impl PostgreSQLPopulator {
 
             // Generate rows
             let gen_start = Instant::now();
-            let rows: Vec<UniversalRow> = self
+            let rows: Vec<Row> = self
                 .generator
                 .internal_rows(table_name, batch_count)
                 .map_err(|e| PostgreSQLPopulatorError::Generator(e.to_string()))?

--- a/crates/loadtest-verify-surreal2/src/compare.rs
+++ b/crates/loadtest-verify-surreal2/src/compare.rs
@@ -1,7 +1,7 @@
 //! Field comparison logic.
 
 use surrealdb2::sql::Value as SurrealValue;
-use sync_core::{GeometryData, UniversalValue};
+use sync_core::{GeometryData, Value};
 
 /// Result of comparing two values.
 #[derive(Debug, Clone, PartialEq)]
@@ -15,14 +15,14 @@ pub enum CompareResult {
 }
 
 /// Compare a generated value with a SurrealDB value.
-pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> CompareResult {
+pub fn compare_values(expected: &Value, actual: &SurrealValue) -> CompareResult {
     match (expected, actual) {
         // Null comparison
-        (UniversalValue::Null, SurrealValue::None) => CompareResult::Match,
-        (UniversalValue::Null, SurrealValue::Null) => CompareResult::Match,
+        (Value::Null, SurrealValue::None) => CompareResult::Match,
+        (Value::Null, SurrealValue::Null) => CompareResult::Match,
 
         // Boolean comparison
-        (UniversalValue::Bool(e), SurrealValue::Bool(a)) => {
+        (Value::Bool(e), SurrealValue::Bool(a)) => {
             if e == a {
                 CompareResult::Match
             } else {
@@ -34,7 +34,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
         }
 
         // Integer comparisons
-        (UniversalValue::Int8 { value: e, .. }, SurrealValue::Number(n)) => {
+        (Value::Int8 { value: e, .. }, SurrealValue::Number(n)) => {
             let a = n.as_int();
             if *e as i64 == a {
                 CompareResult::Match
@@ -45,7 +45,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
                 }
             }
         }
-        (UniversalValue::Int16(e), SurrealValue::Number(n)) => {
+        (Value::Int16(e), SurrealValue::Number(n)) => {
             let a = n.as_int();
             if *e as i64 == a {
                 CompareResult::Match
@@ -56,7 +56,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
                 }
             }
         }
-        (UniversalValue::Int32(e), SurrealValue::Number(n)) => {
+        (Value::Int32(e), SurrealValue::Number(n)) => {
             let a = n.as_int();
             if *e as i64 == a {
                 CompareResult::Match
@@ -67,7 +67,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
                 }
             }
         }
-        (UniversalValue::Int64(e), SurrealValue::Number(n)) => {
+        (Value::Int64(e), SurrealValue::Number(n)) => {
             let a = n.as_int();
             if *e == a {
                 CompareResult::Match
@@ -80,7 +80,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
         }
 
         // Float comparison (with tolerance)
-        (UniversalValue::Float32(e), SurrealValue::Number(n)) => {
+        (Value::Float32(e), SurrealValue::Number(n)) => {
             let a = n.as_float();
             let tolerance = 1e-6_f64;
             if ((*e as f64) - a).abs() < tolerance {
@@ -92,7 +92,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
                 }
             }
         }
-        (UniversalValue::Float64(e), SurrealValue::Number(n)) => {
+        (Value::Float64(e), SurrealValue::Number(n)) => {
             let a = n.as_float();
             let tolerance = 1e-10;
             if (e - a).abs() < tolerance {
@@ -106,7 +106,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
         }
 
         // String comparison
-        (UniversalValue::Text(e), SurrealValue::Strand(a)) => {
+        (Value::Text(e), SurrealValue::Strand(a)) => {
             if e == a.as_str() {
                 CompareResult::Match
             } else {
@@ -117,7 +117,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
             }
         }
         // Char comparison (strict 1:1)
-        (UniversalValue::Char { value: e, .. }, SurrealValue::Strand(a)) => {
+        (Value::Char { value: e, .. }, SurrealValue::Strand(a)) => {
             if e == a.as_str() {
                 CompareResult::Match
             } else {
@@ -128,7 +128,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
             }
         }
         // VarChar comparison (strict 1:1)
-        (UniversalValue::VarChar { value: e, .. }, SurrealValue::Strand(a)) => {
+        (Value::VarChar { value: e, .. }, SurrealValue::Strand(a)) => {
             if e == a.as_str() {
                 CompareResult::Match
             } else {
@@ -140,7 +140,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
         }
 
         // Bytes comparison
-        (UniversalValue::Bytes(e), SurrealValue::Bytes(a)) => {
+        (Value::Bytes(e), SurrealValue::Bytes(a)) => {
             if e == a.as_slice() {
                 CompareResult::Match
             } else {
@@ -151,7 +151,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
             }
         }
         // Blob comparison (strict 1:1)
-        (UniversalValue::Blob(e), SurrealValue::Bytes(a)) => {
+        (Value::Blob(e), SurrealValue::Bytes(a)) => {
             if e == a.as_slice() {
                 CompareResult::Match
             } else {
@@ -163,7 +163,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
         }
 
         // UUID comparison
-        (UniversalValue::Uuid(e), SurrealValue::Uuid(a)) => {
+        (Value::Uuid(e), SurrealValue::Uuid(a)) => {
             // Convert SurrealDB UUID to standard uuid for comparison
             let expected_uuid = *e;
             let actual_uuid: uuid::Uuid = (*a).into();
@@ -177,7 +177,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
             }
         }
         // UUID stored as string
-        (UniversalValue::Uuid(e), SurrealValue::Strand(a)) => {
+        (Value::Uuid(e), SurrealValue::Strand(a)) => {
             let expected_uuid = e.to_string();
             if expected_uuid == a.as_str() {
                 CompareResult::Match
@@ -190,7 +190,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
         }
 
         // DateTime comparison
-        (UniversalValue::LocalDateTime(e), SurrealValue::Datetime(a)) => {
+        (Value::LocalDateTime(e), SurrealValue::Datetime(a)) => {
             // Compare timestamps (allowing for microsecond precision differences)
             let e_ts = e.timestamp_micros();
             let a_ts = a.timestamp_micros();
@@ -204,7 +204,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
             }
         }
         // Date comparison (strict 1:1) - stored as string in SurrealDB
-        (UniversalValue::Date(e), SurrealValue::Strand(a)) => {
+        (Value::Date(e), SurrealValue::Strand(a)) => {
             let expected = e.format("%Y-%m-%d").to_string();
             if expected == a.as_str() {
                 CompareResult::Match
@@ -216,7 +216,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
             }
         }
         // Time comparison (strict 1:1) - stored as string in SurrealDB
-        (UniversalValue::Time(e), SurrealValue::Strand(a)) => {
+        (Value::Time(e), SurrealValue::Strand(a)) => {
             let expected = e.format("%H:%M:%S").to_string();
             if expected == a.as_str() {
                 CompareResult::Match
@@ -228,7 +228,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
             }
         }
         // DateTimeNano comparison (strict 1:1)
-        (UniversalValue::LocalDateTimeNano(e), SurrealValue::Datetime(a)) => {
+        (Value::LocalDateTimeNano(e), SurrealValue::Datetime(a)) => {
             let e_ts = e.timestamp_micros();
             let a_ts = a.timestamp_micros();
             if e_ts == a_ts {
@@ -241,7 +241,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
             }
         }
         // TimestampTz comparison (strict 1:1)
-        (UniversalValue::ZonedDateTime(e), SurrealValue::Datetime(a)) => {
+        (Value::ZonedDateTime(e), SurrealValue::Datetime(a)) => {
             let e_ts = e.timestamp_micros();
             let a_ts = a.timestamp_micros();
             if e_ts == a_ts {
@@ -255,7 +255,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
         }
 
         // Decimal comparison
-        (UniversalValue::Decimal { value: e, .. }, SurrealValue::Number(n)) => {
+        (Value::Decimal { value: e, .. }, SurrealValue::Number(n)) => {
             // Parse expected decimal string and compare as float with tolerance
             let expected_f64: f64 = match e.parse() {
                 Ok(v) => v,
@@ -281,15 +281,13 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
         // Decimal stored as string is NOT valid - must be stored as Number (Decimal or Float)
         // TODO: could consider adding a verifier option to allow this, so that some sources without the schema files
         // that store decimals as strings can be verified using this verifier.
-        (UniversalValue::Decimal { value: e, .. }, SurrealValue::Strand(a)) => {
-            CompareResult::Mismatch {
-                expected: format!("{e} (as Decimal or Float, not String)"),
-                actual: format!("\"{}\" (String)", a.as_str()),
-            }
-        }
+        (Value::Decimal { value: e, .. }, SurrealValue::Strand(a)) => CompareResult::Mismatch {
+            expected: format!("{e} (as Decimal or Float, not String)"),
+            actual: format!("\"{}\" (String)", a.as_str()),
+        },
 
         // Array comparison
-        (UniversalValue::Array { elements: e, .. }, SurrealValue::Array(a)) => {
+        (Value::Array { elements: e, .. }, SurrealValue::Array(a)) => {
             if e.len() != a.len() {
                 return CompareResult::Mismatch {
                     expected: format!("array of length {}", e.len()),
@@ -314,11 +312,11 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
         }
 
         // JSON/JSONB comparison - always stored as SurrealDB Object
-        (UniversalValue::Json(e), SurrealValue::Object(a)) => compare_json_to_surreal_object(e, a),
-        (UniversalValue::Jsonb(e), SurrealValue::Object(a)) => compare_json_to_surreal_object(e, a),
+        (Value::Json(e), SurrealValue::Object(a)) => compare_json_to_surreal_object(e, a),
+        (Value::Jsonb(e), SurrealValue::Object(a)) => compare_json_to_surreal_object(e, a),
 
         // Enum comparison (strict 1:1) - stored as string in SurrealDB
-        (UniversalValue::Enum { value: e, .. }, SurrealValue::Strand(a)) => {
+        (Value::Enum { value: e, .. }, SurrealValue::Strand(a)) => {
             if e == a.as_str() {
                 CompareResult::Match
             } else {
@@ -330,7 +328,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
         }
 
         // Set comparison (strict 1:1) - stored as array in SurrealDB
-        (UniversalValue::Set { elements: e, .. }, SurrealValue::Array(a)) => {
+        (Value::Set { elements: e, .. }, SurrealValue::Array(a)) => {
             if e.len() != a.len() {
                 return CompareResult::Mismatch {
                     expected: format!("set of {} elements", e.len()),
@@ -357,7 +355,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
         }
 
         // Geometry comparison - always stored as JSON object in SurrealDB
-        (UniversalValue::Geometry { data, .. }, SurrealValue::Object(a)) => {
+        (Value::Geometry { data, .. }, SurrealValue::Object(a)) => {
             let GeometryData(expected_json) = data;
             // Convert SurrealDB Object to JSON and compare
             let actual_json = surreal_object_to_json(a);
@@ -374,7 +372,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
         }
 
         // Duration comparison - compare as seconds
-        (UniversalValue::Duration(e), SurrealValue::Duration(a)) => {
+        (Value::Duration(e), SurrealValue::Duration(a)) => {
             // Convert both to std::time::Duration for comparison
             let expected_secs = e.as_secs();
             let expected_nanos = e.subsec_nanos();
@@ -503,7 +501,7 @@ mod tests {
     #[test]
     fn test_compare_null() {
         assert_eq!(
-            compare_values(&UniversalValue::Null, &SurrealValue::None),
+            compare_values(&Value::Null, &SurrealValue::None),
             CompareResult::Match
         );
     }
@@ -511,11 +509,11 @@ mod tests {
     #[test]
     fn test_compare_bool() {
         assert_eq!(
-            compare_values(&UniversalValue::Bool(true), &SurrealValue::Bool(true)),
+            compare_values(&Value::Bool(true), &SurrealValue::Bool(true)),
             CompareResult::Match
         );
         assert!(matches!(
-            compare_values(&UniversalValue::Bool(true), &SurrealValue::Bool(false)),
+            compare_values(&Value::Bool(true), &SurrealValue::Bool(false)),
             CompareResult::Mismatch { .. }
         ));
     }
@@ -523,10 +521,7 @@ mod tests {
     #[test]
     fn test_compare_int32() {
         assert_eq!(
-            compare_values(
-                &UniversalValue::Int32(42),
-                &SurrealValue::Number(Number::Int(42))
-            ),
+            compare_values(&Value::Int32(42), &SurrealValue::Number(Number::Int(42))),
             CompareResult::Match
         );
     }
@@ -535,7 +530,7 @@ mod tests {
     fn test_compare_int64() {
         assert_eq!(
             compare_values(
-                &UniversalValue::Int64(123456789),
+                &Value::Int64(123456789),
                 &SurrealValue::Number(Number::Int(123456789))
             ),
             CompareResult::Match
@@ -546,7 +541,7 @@ mod tests {
     fn test_compare_float() {
         assert_eq!(
             compare_values(
-                &UniversalValue::Float64(1.23456),
+                &Value::Float64(1.23456),
                 &SurrealValue::Number(Number::Float(1.23456))
             ),
             CompareResult::Match
@@ -557,14 +552,14 @@ mod tests {
     fn test_compare_string() {
         assert_eq!(
             compare_values(
-                &UniversalValue::Text("hello".to_string()),
+                &Value::Text("hello".to_string()),
                 &SurrealValue::Strand(Strand::from("hello"))
             ),
             CompareResult::Match
         );
         assert!(matches!(
             compare_values(
-                &UniversalValue::Text("hello".to_string()),
+                &Value::Text("hello".to_string()),
                 &SurrealValue::Strand(Strand::from("world"))
             ),
             CompareResult::Mismatch { .. }
@@ -576,7 +571,7 @@ mod tests {
         let u = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
         let surreal_uuid = surrealdb2::sql::Uuid::from(u);
         assert_eq!(
-            compare_values(&UniversalValue::Uuid(u), &SurrealValue::Uuid(surreal_uuid)),
+            compare_values(&Value::Uuid(u), &SurrealValue::Uuid(surreal_uuid)),
             CompareResult::Match
         );
     }
@@ -585,13 +580,9 @@ mod tests {
     fn test_compare_array() {
         use surrealdb2::sql::Array;
 
-        let expected = UniversalValue::Array {
-            elements: vec![
-                UniversalValue::Int32(1),
-                UniversalValue::Int32(2),
-                UniversalValue::Int32(3),
-            ],
-            element_type: Box::new(sync_core::UniversalType::Int32),
+        let expected = Value::Array {
+            elements: vec![Value::Int32(1), Value::Int32(2), Value::Int32(3)],
+            element_type: Box::new(sync_core::Type::Int32),
         };
         let actual = SurrealValue::Array(Array::from(vec![
             SurrealValue::Number(Number::Int(1)),
@@ -605,9 +596,9 @@ mod tests {
     fn test_compare_array_length_mismatch() {
         use surrealdb2::sql::Array;
 
-        let expected = UniversalValue::Array {
-            elements: vec![UniversalValue::Int32(1), UniversalValue::Int32(2)],
-            element_type: Box::new(sync_core::UniversalType::Int32),
+        let expected = Value::Array {
+            elements: vec![Value::Int32(1), Value::Int32(2)],
+            element_type: Box::new(sync_core::Type::Int32),
         };
         let actual = SurrealValue::Array(Array::from(vec![
             SurrealValue::Number(Number::Int(1)),
@@ -629,7 +620,7 @@ mod tests {
             "value": 42,
             "active": true
         });
-        let expected = UniversalValue::Json(Box::new(expected_json));
+        let expected = Value::Json(Box::new(expected_json));
 
         let mut actual_obj = Object::default();
         actual_obj.insert("name".to_string(), SurrealValue::Strand("test".into()));
@@ -648,7 +639,7 @@ mod tests {
             "name": "test",
             "value": 42
         });
-        let expected = UniversalValue::Json(Box::new(expected_json));
+        let expected = Value::Json(Box::new(expected_json));
 
         let mut actual_obj = Object::default();
         actual_obj.insert("name".to_string(), SurrealValue::Strand("different".into()));
@@ -671,7 +662,7 @@ mod tests {
                 "key": "value"
             }
         });
-        let expected = UniversalValue::Json(Box::new(expected_json));
+        let expected = Value::Json(Box::new(expected_json));
 
         let mut nested_obj = Object::default();
         nested_obj.insert("key".to_string(), SurrealValue::Strand("value".into()));
@@ -700,7 +691,7 @@ mod tests {
             "type": "Point",
             "coordinates": [-73.97, 40.77]
         });
-        let expected = UniversalValue::Geometry {
+        let expected = Value::Geometry {
             data: GeometryData(geojson),
             geometry_type: GeometryType::Point,
         };

--- a/crates/loadtest-verify-surreal2/src/verifier.rs
+++ b/crates/loadtest-verify-surreal2/src/verifier.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 use surrealdb2::engine::any::Any;
 use surrealdb2::sql::Value as SurrealValue;
 use surrealdb2::Surreal;
-use sync_core::{GeneratorTableDefinition, Schema, UniversalRow};
+use sync_core::{GeneratorTableDefinition, Row, Schema};
 use tracing::{debug, info, warn};
 
 /// Streaming verifier that generates expected data and compares with SurrealDB.
@@ -238,24 +238,22 @@ impl StreamingVerifier {
     /// Query a single row from SurrealDB by its ID.
     async fn query_row(
         &self,
-        expected_row: &UniversalRow,
+        expected_row: &Row,
         table_schema: &GeneratorTableDefinition,
     ) -> Result<Option<RecordResult>, VerifyError> {
         use surrealdb2::sql::{Id, Thing};
 
         // Construct proper Thing based on ID type to match how sync stores records
         let thing = match &expected_row.id {
-            sync_core::UniversalValue::Uuid(u) => Thing::from((
+            sync_core::Value::Uuid(u) => Thing::from((
                 self.table_name.as_str(),
                 Id::Uuid(surrealdb2::sql::Uuid::from(*u)),
             )),
-            sync_core::UniversalValue::Int64(i) => {
-                Thing::from((self.table_name.as_str(), Id::Number(*i)))
-            }
-            sync_core::UniversalValue::Int32(i) => {
+            sync_core::Value::Int64(i) => Thing::from((self.table_name.as_str(), Id::Number(*i))),
+            sync_core::Value::Int32(i) => {
                 Thing::from((self.table_name.as_str(), Id::Number(*i as i64)))
             }
-            sync_core::UniversalValue::Text(s) => {
+            sync_core::Value::Text(s) => {
                 Thing::from((self.table_name.as_str(), Id::String(s.clone())))
             }
             other => {
@@ -321,28 +319,25 @@ impl StreamingVerifier {
         &self,
         response: &mut surrealdb2::Response,
         field_name: &str,
-        data_type: &sync_core::UniversalType,
+        data_type: &sync_core::Type,
         record_id: &surrealdb2::sql::Thing,
     ) -> Result<Option<SurrealValue>, VerifyError> {
-        use sync_core::UniversalType;
+        use sync_core::Type;
 
         match data_type {
-            UniversalType::Bool => {
+            Type::Bool => {
                 let val: Option<bool> = response.take((0, field_name))?;
                 Ok(val.map(SurrealValue::Bool))
             }
-            UniversalType::Int8 { .. }
-            | UniversalType::Int16
-            | UniversalType::Int32
-            | UniversalType::Int64 => {
+            Type::Int8 { .. } | Type::Int16 | Type::Int32 | Type::Int64 => {
                 let val: Option<i64> = response.take((0, field_name))?;
                 Ok(val.map(|v| SurrealValue::Number(surrealdb2::sql::Number::Int(v))))
             }
-            UniversalType::Float32 | UniversalType::Float64 => {
+            Type::Float32 | Type::Float64 => {
                 let val: Option<f64> = response.take((0, field_name))?;
                 Ok(val.map(|v| SurrealValue::Number(surrealdb2::sql::Number::Float(v))))
             }
-            UniversalType::Decimal { .. } => {
+            Type::Decimal { .. } => {
                 // Decimal fields may be stored as Number::Decimal or Number::Float
                 // Try reading as rust_decimal::Decimal first (works for both V2 and V3 SDKs)
                 match response.take::<Option<Decimal>>((0, field_name)) {
@@ -369,14 +364,11 @@ impl StreamingVerifier {
                     }
                 }
             }
-            UniversalType::Char { .. }
-            | UniversalType::VarChar { .. }
-            | UniversalType::Text
-            | UniversalType::Enum { .. } => {
+            Type::Char { .. } | Type::VarChar { .. } | Type::Text | Type::Enum { .. } => {
                 let val: Option<String> = response.take((0, field_name))?;
                 Ok(val.map(|v| SurrealValue::Strand(surrealdb2::sql::Strand::from(v))))
             }
-            UniversalType::Uuid => {
+            Type::Uuid => {
                 // UUIDs can be stored as native UUID type or as string
                 // Try native UUID first, fall back to string
                 let result: Result<Option<uuid::Uuid>, _> = response.take((0, field_name));
@@ -395,39 +387,37 @@ impl StreamingVerifier {
                     }
                 }
             }
-            UniversalType::Ulid => {
+            Type::Ulid => {
                 // ULIDs are stored as strings in SurrealDB
                 let val: Option<String> = response.take((0, field_name))?;
                 Ok(val.map(|v| SurrealValue::Strand(surrealdb2::sql::Strand::from(v))))
             }
-            UniversalType::LocalDateTime
-            | UniversalType::LocalDateTimeNano
-            | UniversalType::ZonedDateTime => {
+            Type::LocalDateTime | Type::LocalDateTimeNano | Type::ZonedDateTime => {
                 let val: Option<chrono::DateTime<chrono::Utc>> = response.take((0, field_name))?;
                 Ok(val.map(|v| SurrealValue::Datetime(surrealdb2::sql::Datetime::from(v))))
             }
-            UniversalType::Date => {
+            Type::Date => {
                 let val: Option<String> = response.take((0, field_name))?;
                 Ok(val.map(|v| SurrealValue::Strand(surrealdb2::sql::Strand::from(v))))
             }
-            UniversalType::Time => {
+            Type::Time => {
                 let val: Option<String> = response.take((0, field_name))?;
                 Ok(val.map(|v| SurrealValue::Strand(surrealdb2::sql::Strand::from(v))))
             }
-            UniversalType::Blob | UniversalType::Bytes => {
+            Type::Blob | Type::Bytes => {
                 let val: Option<Vec<u8>> = response.take((0, field_name))?;
                 Ok(val.map(|v| SurrealValue::Bytes(surrealdb2::sql::Bytes::from(v))))
             }
-            UniversalType::Json | UniversalType::Jsonb => {
+            Type::Json | Type::Jsonb => {
                 // JSON values are stored as native Objects in SurrealDB
                 // Use serde_json::Value for dynamic JSON extraction
                 let val: Option<serde_json::Value> = response.take((0, field_name))?;
                 Ok(val.map(|v| json_value_to_surreal(&v)))
             }
-            UniversalType::Array { element_type } => {
+            Type::Array { element_type } => {
                 // Extract array based on element type
                 match element_type.as_ref() {
-                    UniversalType::Int32 | UniversalType::Int16 | UniversalType::Int64 => {
+                    Type::Int32 | Type::Int16 | Type::Int64 => {
                         let val: Option<Vec<i64>> = response.take((0, field_name))?;
                         Ok(val.map(|arr| {
                             let items: Vec<SurrealValue> = arr
@@ -437,9 +427,7 @@ impl StreamingVerifier {
                             SurrealValue::Array(surrealdb2::sql::Array::from(items))
                         }))
                     }
-                    UniversalType::Text
-                    | UniversalType::VarChar { .. }
-                    | UniversalType::Char { .. } => {
+                    Type::Text | Type::VarChar { .. } | Type::Char { .. } => {
                         let val: Option<Vec<String>> = response.take((0, field_name))?;
                         Ok(val.map(|arr| {
                             let items: Vec<SurrealValue> = arr
@@ -455,30 +443,30 @@ impl StreamingVerifier {
                     }
                 }
             }
-            UniversalType::Set { .. } => {
+            Type::Set { .. } => {
                 // Sets - for now just skip complex set handling
                 Ok(None)
             }
-            UniversalType::Geometry { .. } => {
+            Type::Geometry { .. } => {
                 // Geometry - skip for now
                 Ok(None)
             }
-            UniversalType::Duration => {
+            Type::Duration => {
                 // Duration - extract as SurrealDB duration
                 let val: Option<surrealdb2::sql::Duration> = response.take((0, field_name))?;
                 Ok(val.map(SurrealValue::Duration))
             }
-            UniversalType::Thing => {
+            Type::Thing => {
                 // Thing - extract as SurrealDB Thing
                 let val: Option<surrealdb2::sql::Thing> = response.take((0, field_name))?;
                 Ok(val.map(SurrealValue::Thing))
             }
-            UniversalType::Object => {
+            Type::Object => {
                 // Object - stored as native Object in SurrealDB
                 let val: Option<serde_json::Value> = response.take((0, field_name))?;
                 Ok(val.map(|v| json_value_to_surreal(&v)))
             }
-            UniversalType::TimeTz => {
+            Type::TimeTz => {
                 // TimeTz - stored as string in SurrealDB
                 let val: Option<String> = response.take((0, field_name))?;
                 Ok(val.map(|s| SurrealValue::Strand(surrealdb2::sql::Strand::from(s))))
@@ -489,7 +477,7 @@ impl StreamingVerifier {
     /// Compare an expected row with an actual SurrealDB record.
     fn compare_row(
         &self,
-        expected: &UniversalRow,
+        expected: &Row,
         actual: &RecordResult,
         table_schema: &GeneratorTableDefinition,
     ) -> Vec<FieldMismatch> {
@@ -554,13 +542,13 @@ impl StreamingVerifier {
     }
 }
 
-/// Format a UniversalValue ID for display.
-fn format_id(value: &sync_core::UniversalValue) -> String {
+/// Format a Value ID for display.
+fn format_id(value: &sync_core::Value) -> String {
     match value {
-        sync_core::UniversalValue::Uuid(u) => u.to_string(),
-        sync_core::UniversalValue::Int64(i) => i.to_string(),
-        sync_core::UniversalValue::Int32(i) => i.to_string(),
-        sync_core::UniversalValue::Text(s) => s.clone(),
+        sync_core::Value::Uuid(u) => u.to_string(),
+        sync_core::Value::Int64(i) => i.to_string(),
+        sync_core::Value::Int32(i) => i.to_string(),
+        sync_core::Value::Text(s) => s.clone(),
         _ => format!("{value:?}"),
     }
 }
@@ -641,12 +629,12 @@ tables:
     fn test_format_id() {
         let uuid = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
         assert_eq!(
-            format_id(&sync_core::UniversalValue::Uuid(uuid)),
+            format_id(&sync_core::Value::Uuid(uuid)),
             "550e8400-e29b-41d4-a716-446655440000"
         );
-        assert_eq!(format_id(&sync_core::UniversalValue::Int64(12345)), "12345");
+        assert_eq!(format_id(&sync_core::Value::Int64(12345)), "12345");
         assert_eq!(
-            format_id(&sync_core::UniversalValue::Text("test-id".to_string())),
+            format_id(&sync_core::Value::Text("test-id".to_string())),
             "test-id"
         );
     }

--- a/crates/loadtest-verify-surreal3/src/compare.rs
+++ b/crates/loadtest-verify-surreal3/src/compare.rs
@@ -1,7 +1,7 @@
 //! Field comparison logic for SurrealDB v3.
 
 use surrealdb3::types::Value as SurrealValue;
-use sync_core::{GeometryData, UniversalValue};
+use sync_core::{GeometryData, Value};
 
 /// Result of comparing two values.
 #[derive(Debug, Clone, PartialEq)]
@@ -35,14 +35,14 @@ fn number_as_float(n: &surrealdb3::types::Number) -> f64 {
 }
 
 /// Compare a generated value with a SurrealDB v3 value.
-pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> CompareResult {
+pub fn compare_values(expected: &Value, actual: &SurrealValue) -> CompareResult {
     match (expected, actual) {
         // Null comparison
-        (UniversalValue::Null, SurrealValue::None) => CompareResult::Match,
-        (UniversalValue::Null, SurrealValue::Null) => CompareResult::Match,
+        (Value::Null, SurrealValue::None) => CompareResult::Match,
+        (Value::Null, SurrealValue::Null) => CompareResult::Match,
 
         // Boolean comparison
-        (UniversalValue::Bool(e), SurrealValue::Bool(a)) => {
+        (Value::Bool(e), SurrealValue::Bool(a)) => {
             if e == a {
                 CompareResult::Match
             } else {
@@ -54,7 +54,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
         }
 
         // Integer comparisons
-        (UniversalValue::Int8 { value: e, .. }, SurrealValue::Number(n)) => {
+        (Value::Int8 { value: e, .. }, SurrealValue::Number(n)) => {
             let a = number_as_int(n);
             if *e as i64 == a {
                 CompareResult::Match
@@ -65,7 +65,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
                 }
             }
         }
-        (UniversalValue::Int16(e), SurrealValue::Number(n)) => {
+        (Value::Int16(e), SurrealValue::Number(n)) => {
             let a = number_as_int(n);
             if *e as i64 == a {
                 CompareResult::Match
@@ -76,7 +76,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
                 }
             }
         }
-        (UniversalValue::Int32(e), SurrealValue::Number(n)) => {
+        (Value::Int32(e), SurrealValue::Number(n)) => {
             let a = number_as_int(n);
             if *e as i64 == a {
                 CompareResult::Match
@@ -87,7 +87,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
                 }
             }
         }
-        (UniversalValue::Int64(e), SurrealValue::Number(n)) => {
+        (Value::Int64(e), SurrealValue::Number(n)) => {
             let a = number_as_int(n);
             if *e == a {
                 CompareResult::Match
@@ -100,7 +100,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
         }
 
         // Float comparison (with tolerance)
-        (UniversalValue::Float32(e), SurrealValue::Number(n)) => {
+        (Value::Float32(e), SurrealValue::Number(n)) => {
             let a = number_as_float(n);
             let tolerance = 1e-6_f64;
             if ((*e as f64) - a).abs() < tolerance {
@@ -112,7 +112,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
                 }
             }
         }
-        (UniversalValue::Float64(e), SurrealValue::Number(n)) => {
+        (Value::Float64(e), SurrealValue::Number(n)) => {
             let a = number_as_float(n);
             let tolerance = 1e-10;
             if (e - a).abs() < tolerance {
@@ -126,7 +126,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
         }
 
         // String comparison (v3 uses Value::String instead of Value::Strand)
-        (UniversalValue::Text(e), SurrealValue::String(a)) => {
+        (Value::Text(e), SurrealValue::String(a)) => {
             if e == a {
                 CompareResult::Match
             } else {
@@ -137,7 +137,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
             }
         }
         // Char comparison (strict 1:1)
-        (UniversalValue::Char { value: e, .. }, SurrealValue::String(a)) => {
+        (Value::Char { value: e, .. }, SurrealValue::String(a)) => {
             if e == a {
                 CompareResult::Match
             } else {
@@ -148,7 +148,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
             }
         }
         // VarChar comparison (strict 1:1)
-        (UniversalValue::VarChar { value: e, .. }, SurrealValue::String(a)) => {
+        (Value::VarChar { value: e, .. }, SurrealValue::String(a)) => {
             if e == a {
                 CompareResult::Match
             } else {
@@ -160,7 +160,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
         }
 
         // Bytes comparison (v3 uses as_ref() instead of as_slice())
-        (UniversalValue::Bytes(e), SurrealValue::Bytes(a)) => {
+        (Value::Bytes(e), SurrealValue::Bytes(a)) => {
             if e == a.as_ref() {
                 CompareResult::Match
             } else {
@@ -171,7 +171,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
             }
         }
         // Blob comparison (strict 1:1)
-        (UniversalValue::Blob(e), SurrealValue::Bytes(a)) => {
+        (Value::Blob(e), SurrealValue::Bytes(a)) => {
             if e == a.as_ref() {
                 CompareResult::Match
             } else {
@@ -183,7 +183,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
         }
 
         // UUID comparison
-        (UniversalValue::Uuid(e), SurrealValue::Uuid(a)) => {
+        (Value::Uuid(e), SurrealValue::Uuid(a)) => {
             // Convert SurrealDB UUID to standard uuid for comparison
             let expected_uuid = *e;
             let actual_uuid: uuid::Uuid = (*a).into();
@@ -197,7 +197,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
             }
         }
         // UUID stored as string
-        (UniversalValue::Uuid(e), SurrealValue::String(a)) => {
+        (Value::Uuid(e), SurrealValue::String(a)) => {
             let expected_uuid = e.to_string();
             if expected_uuid == *a {
                 CompareResult::Match
@@ -210,7 +210,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
         }
 
         // DateTime comparison
-        (UniversalValue::LocalDateTime(e), SurrealValue::Datetime(a)) => {
+        (Value::LocalDateTime(e), SurrealValue::Datetime(a)) => {
             // Compare timestamps (allowing for microsecond precision differences)
             let e_ts = e.timestamp_micros();
             let a_ts = a.timestamp_micros();
@@ -224,7 +224,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
             }
         }
         // Date comparison (strict 1:1) - stored as string in SurrealDB
-        (UniversalValue::Date(e), SurrealValue::String(a)) => {
+        (Value::Date(e), SurrealValue::String(a)) => {
             let expected = e.format("%Y-%m-%d").to_string();
             if expected == *a {
                 CompareResult::Match
@@ -236,7 +236,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
             }
         }
         // Time comparison (strict 1:1) - stored as string in SurrealDB
-        (UniversalValue::Time(e), SurrealValue::String(a)) => {
+        (Value::Time(e), SurrealValue::String(a)) => {
             let expected = e.format("%H:%M:%S").to_string();
             if expected == *a {
                 CompareResult::Match
@@ -248,7 +248,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
             }
         }
         // DateTimeNano comparison (strict 1:1)
-        (UniversalValue::LocalDateTimeNano(e), SurrealValue::Datetime(a)) => {
+        (Value::LocalDateTimeNano(e), SurrealValue::Datetime(a)) => {
             let e_ts = e.timestamp_micros();
             let a_ts = a.timestamp_micros();
             if e_ts == a_ts {
@@ -261,7 +261,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
             }
         }
         // TimestampTz comparison (strict 1:1)
-        (UniversalValue::ZonedDateTime(e), SurrealValue::Datetime(a)) => {
+        (Value::ZonedDateTime(e), SurrealValue::Datetime(a)) => {
             let e_ts = e.timestamp_micros();
             let a_ts = a.timestamp_micros();
             if e_ts == a_ts {
@@ -275,7 +275,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
         }
 
         // Decimal comparison
-        (UniversalValue::Decimal { value: e, .. }, SurrealValue::Number(n)) => {
+        (Value::Decimal { value: e, .. }, SurrealValue::Number(n)) => {
             // Parse expected decimal string and compare as float with tolerance
             let expected_f64: f64 = match e.parse() {
                 Ok(v) => v,
@@ -301,15 +301,13 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
         // Decimal stored as string is NOT valid - must be stored as Number (Decimal or Float)
         // TODO: could consider adding a verifier option to allow this, so that some sources without the schema files
         // that store decimals as strings can be verified using this verifier.
-        (UniversalValue::Decimal { value: e, .. }, SurrealValue::String(a)) => {
-            CompareResult::Mismatch {
-                expected: format!("{e} (as Decimal or Float, not String)"),
-                actual: format!("\"{a}\" (String)"),
-            }
-        }
+        (Value::Decimal { value: e, .. }, SurrealValue::String(a)) => CompareResult::Mismatch {
+            expected: format!("{e} (as Decimal or Float, not String)"),
+            actual: format!("\"{a}\" (String)"),
+        },
 
         // Array comparison
-        (UniversalValue::Array { elements: e, .. }, SurrealValue::Array(a)) => {
+        (Value::Array { elements: e, .. }, SurrealValue::Array(a)) => {
             if e.len() != a.len() {
                 return CompareResult::Mismatch {
                     expected: format!("array of length {}", e.len()),
@@ -334,11 +332,11 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
         }
 
         // JSON/JSONB comparison - always stored as SurrealDB Object
-        (UniversalValue::Json(e), SurrealValue::Object(a)) => compare_json_to_surreal_object(e, a),
-        (UniversalValue::Jsonb(e), SurrealValue::Object(a)) => compare_json_to_surreal_object(e, a),
+        (Value::Json(e), SurrealValue::Object(a)) => compare_json_to_surreal_object(e, a),
+        (Value::Jsonb(e), SurrealValue::Object(a)) => compare_json_to_surreal_object(e, a),
 
         // Enum comparison (strict 1:1) - stored as string in SurrealDB
-        (UniversalValue::Enum { value: e, .. }, SurrealValue::String(a)) => {
+        (Value::Enum { value: e, .. }, SurrealValue::String(a)) => {
             if e == a {
                 CompareResult::Match
             } else {
@@ -350,7 +348,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
         }
 
         // Set comparison (strict 1:1) - stored as array in SurrealDB
-        (UniversalValue::Set { elements: e, .. }, SurrealValue::Array(a)) => {
+        (Value::Set { elements: e, .. }, SurrealValue::Array(a)) => {
             if e.len() != a.len() {
                 return CompareResult::Mismatch {
                     expected: format!("set of {} elements", e.len()),
@@ -377,7 +375,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
         }
 
         // Geometry comparison - always stored as JSON object in SurrealDB
-        (UniversalValue::Geometry { data, .. }, SurrealValue::Object(a)) => {
+        (Value::Geometry { data, .. }, SurrealValue::Object(a)) => {
             let GeometryData(expected_json) = data;
             // Convert SurrealDB Object to JSON and compare
             let actual_json = surreal_object_to_json(a);
@@ -394,7 +392,7 @@ pub fn compare_values(expected: &UniversalValue, actual: &SurrealValue) -> Compa
         }
 
         // Duration comparison - compare as seconds
-        (UniversalValue::Duration(e), SurrealValue::Duration(a)) => {
+        (Value::Duration(e), SurrealValue::Duration(a)) => {
             // Convert both to std::time::Duration for comparison
             let expected_secs = e.as_secs();
             let expected_nanos = e.subsec_nanos();
@@ -523,7 +521,7 @@ mod tests {
     #[test]
     fn test_compare_null() {
         assert_eq!(
-            compare_values(&UniversalValue::Null, &SurrealValue::None),
+            compare_values(&Value::Null, &SurrealValue::None),
             CompareResult::Match
         );
     }
@@ -531,11 +529,11 @@ mod tests {
     #[test]
     fn test_compare_bool() {
         assert_eq!(
-            compare_values(&UniversalValue::Bool(true), &SurrealValue::Bool(true)),
+            compare_values(&Value::Bool(true), &SurrealValue::Bool(true)),
             CompareResult::Match
         );
         assert!(matches!(
-            compare_values(&UniversalValue::Bool(true), &SurrealValue::Bool(false)),
+            compare_values(&Value::Bool(true), &SurrealValue::Bool(false)),
             CompareResult::Mismatch { .. }
         ));
     }
@@ -543,10 +541,7 @@ mod tests {
     #[test]
     fn test_compare_int32() {
         assert_eq!(
-            compare_values(
-                &UniversalValue::Int32(42),
-                &SurrealValue::Number(Number::Int(42))
-            ),
+            compare_values(&Value::Int32(42), &SurrealValue::Number(Number::Int(42))),
             CompareResult::Match
         );
     }
@@ -555,7 +550,7 @@ mod tests {
     fn test_compare_int64() {
         assert_eq!(
             compare_values(
-                &UniversalValue::Int64(123456789),
+                &Value::Int64(123456789),
                 &SurrealValue::Number(Number::Int(123456789))
             ),
             CompareResult::Match
@@ -566,7 +561,7 @@ mod tests {
     fn test_compare_float() {
         assert_eq!(
             compare_values(
-                &UniversalValue::Float64(1.23456),
+                &Value::Float64(1.23456),
                 &SurrealValue::Number(Number::Float(1.23456))
             ),
             CompareResult::Match
@@ -578,14 +573,14 @@ mod tests {
         // V3 uses Value::String instead of Value::Strand
         assert_eq!(
             compare_values(
-                &UniversalValue::Text("hello".to_string()),
+                &Value::Text("hello".to_string()),
                 &SurrealValue::String("hello".to_string())
             ),
             CompareResult::Match
         );
         assert!(matches!(
             compare_values(
-                &UniversalValue::Text("hello".to_string()),
+                &Value::Text("hello".to_string()),
                 &SurrealValue::String("world".to_string())
             ),
             CompareResult::Mismatch { .. }
@@ -597,7 +592,7 @@ mod tests {
         let u = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
         let surreal_uuid = surrealdb3::types::Uuid::from(u);
         assert_eq!(
-            compare_values(&UniversalValue::Uuid(u), &SurrealValue::Uuid(surreal_uuid)),
+            compare_values(&Value::Uuid(u), &SurrealValue::Uuid(surreal_uuid)),
             CompareResult::Match
         );
     }
@@ -606,13 +601,9 @@ mod tests {
     fn test_compare_array() {
         use surrealdb3::types::Array;
 
-        let expected = UniversalValue::Array {
-            elements: vec![
-                UniversalValue::Int32(1),
-                UniversalValue::Int32(2),
-                UniversalValue::Int32(3),
-            ],
-            element_type: Box::new(sync_core::UniversalType::Int32),
+        let expected = Value::Array {
+            elements: vec![Value::Int32(1), Value::Int32(2), Value::Int32(3)],
+            element_type: Box::new(sync_core::Type::Int32),
         };
         let actual = SurrealValue::Array(Array::from(vec![
             SurrealValue::Number(Number::Int(1)),
@@ -626,9 +617,9 @@ mod tests {
     fn test_compare_array_length_mismatch() {
         use surrealdb3::types::Array;
 
-        let expected = UniversalValue::Array {
-            elements: vec![UniversalValue::Int32(1), UniversalValue::Int32(2)],
-            element_type: Box::new(sync_core::UniversalType::Int32),
+        let expected = Value::Array {
+            elements: vec![Value::Int32(1), Value::Int32(2)],
+            element_type: Box::new(sync_core::Type::Int32),
         };
         let actual = SurrealValue::Array(Array::from(vec![
             SurrealValue::Number(Number::Int(1)),
@@ -650,7 +641,7 @@ mod tests {
             "value": 42,
             "active": true
         });
-        let expected = UniversalValue::Json(Box::new(expected_json));
+        let expected = Value::Json(Box::new(expected_json));
 
         let mut actual_obj = Object::default();
         actual_obj.insert("name".to_string(), SurrealValue::String("test".to_string()));
@@ -669,7 +660,7 @@ mod tests {
             "name": "test",
             "value": 42
         });
-        let expected = UniversalValue::Json(Box::new(expected_json));
+        let expected = Value::Json(Box::new(expected_json));
 
         let mut actual_obj = Object::default();
         actual_obj.insert(
@@ -695,7 +686,7 @@ mod tests {
                 "key": "value"
             }
         });
-        let expected = UniversalValue::Json(Box::new(expected_json));
+        let expected = Value::Json(Box::new(expected_json));
 
         let mut nested_obj = Object::default();
         nested_obj.insert("key".to_string(), SurrealValue::String("value".to_string()));
@@ -724,7 +715,7 @@ mod tests {
             "type": "Point",
             "coordinates": [-73.97, 40.77]
         });
-        let expected = UniversalValue::Geometry {
+        let expected = Value::Geometry {
             data: GeometryData(geojson),
             geometry_type: GeometryType::Point,
         };

--- a/crates/loadtest-verify-surreal3/src/verifier.rs
+++ b/crates/loadtest-verify-surreal3/src/verifier.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 use surrealdb3::engine::any::Any;
 use surrealdb3::types::Value as SurrealValue;
 use surrealdb3::Surreal;
-use sync_core::{GeneratorTableDefinition, Schema, UniversalRow};
+use sync_core::{GeneratorTableDefinition, Row, Schema};
 use tracing::{debug, info, warn};
 
 /// Streaming verifier that generates expected data and compares with SurrealDB v3.
@@ -238,24 +238,24 @@ impl StreamingVerifier3 {
     /// Query a single row from SurrealDB by its ID.
     async fn query_row(
         &self,
-        expected_row: &UniversalRow,
+        expected_row: &Row,
         table_schema: &GeneratorTableDefinition,
     ) -> Result<Option<RecordResult>, VerifyError> {
         use surrealdb3::types::{RecordId, RecordIdKey};
 
         // Construct proper RecordId based on ID type to match how sync stores records
         let record_id = match &expected_row.id {
-            sync_core::UniversalValue::Uuid(u) => RecordId::new(
+            sync_core::Value::Uuid(u) => RecordId::new(
                 self.table_name.as_str(),
                 RecordIdKey::Uuid(surrealdb3::types::Uuid::from(*u)),
             ),
-            sync_core::UniversalValue::Int64(i) => {
+            sync_core::Value::Int64(i) => {
                 RecordId::new(self.table_name.as_str(), RecordIdKey::Number(*i))
             }
-            sync_core::UniversalValue::Int32(i) => {
+            sync_core::Value::Int32(i) => {
                 RecordId::new(self.table_name.as_str(), RecordIdKey::Number(*i as i64))
             }
-            sync_core::UniversalValue::Text(s) => {
+            sync_core::Value::Text(s) => {
                 RecordId::new(self.table_name.as_str(), RecordIdKey::String(s.clone()))
             }
             other => {
@@ -327,29 +327,26 @@ impl StreamingVerifier3 {
         &self,
         response: &mut surrealdb3::IndexedResults,
         field_name: &str,
-        data_type: &sync_core::UniversalType,
+        data_type: &sync_core::Type,
         record_id: &surrealdb3::types::RecordId,
     ) -> Result<Option<SurrealValue>, VerifyError> {
         use surrealdb3::types::Number;
-        use sync_core::UniversalType;
+        use sync_core::Type;
 
         match data_type {
-            UniversalType::Bool => {
+            Type::Bool => {
                 let val: Option<bool> = response.take((0, field_name))?;
                 Ok(val.map(SurrealValue::Bool))
             }
-            UniversalType::Int8 { .. }
-            | UniversalType::Int16
-            | UniversalType::Int32
-            | UniversalType::Int64 => {
+            Type::Int8 { .. } | Type::Int16 | Type::Int32 | Type::Int64 => {
                 let val: Option<i64> = response.take((0, field_name))?;
                 Ok(val.map(|v| SurrealValue::Number(Number::Int(v))))
             }
-            UniversalType::Float32 | UniversalType::Float64 => {
+            Type::Float32 | Type::Float64 => {
                 let val: Option<f64> = response.take((0, field_name))?;
                 Ok(val.map(|v| SurrealValue::Number(Number::Float(v))))
             }
-            UniversalType::Decimal { .. } => {
+            Type::Decimal { .. } => {
                 match response.take::<Option<Decimal>>((0, field_name)) {
                     Ok(Some(d)) => Ok(Some(SurrealValue::Number(Number::Decimal(d)))),
                     Ok(None) => Ok(None),
@@ -388,14 +385,11 @@ impl StreamingVerifier3 {
                     }
                 }
             }
-            UniversalType::Char { .. }
-            | UniversalType::VarChar { .. }
-            | UniversalType::Text
-            | UniversalType::Enum { .. } => {
+            Type::Char { .. } | Type::VarChar { .. } | Type::Text | Type::Enum { .. } => {
                 let val: Option<String> = response.take((0, field_name))?;
                 Ok(val.map(SurrealValue::String))
             }
-            UniversalType::Uuid => {
+            Type::Uuid => {
                 let result: Result<Option<uuid::Uuid>, _> = response.take((0, field_name));
                 match result {
                     Ok(Some(v)) => Ok(Some(SurrealValue::Uuid(surrealdb3::types::Uuid::from(v)))),
@@ -427,39 +421,37 @@ impl StreamingVerifier3 {
                     }
                 }
             }
-            UniversalType::Ulid => {
+            Type::Ulid => {
                 // ULIDs are stored as strings in SurrealDB
                 let val: Option<String> = response.take((0, field_name))?;
                 Ok(val.map(SurrealValue::String))
             }
-            UniversalType::LocalDateTime
-            | UniversalType::LocalDateTimeNano
-            | UniversalType::ZonedDateTime => {
+            Type::LocalDateTime | Type::LocalDateTimeNano | Type::ZonedDateTime => {
                 let val: Option<chrono::DateTime<chrono::Utc>> = response.take((0, field_name))?;
                 Ok(val.map(|v| SurrealValue::Datetime(surrealdb3::types::Datetime::from(v))))
             }
-            UniversalType::Date => {
+            Type::Date => {
                 let val: Option<String> = response.take((0, field_name))?;
                 Ok(val.map(SurrealValue::String))
             }
-            UniversalType::Time => {
+            Type::Time => {
                 let val: Option<String> = response.take((0, field_name))?;
                 Ok(val.map(SurrealValue::String))
             }
-            UniversalType::Blob | UniversalType::Bytes => {
+            Type::Blob | Type::Bytes => {
                 let val: Option<Vec<u8>> = response.take((0, field_name))?;
                 Ok(val.map(|v| SurrealValue::Bytes(surrealdb3::types::Bytes::from(v))))
             }
-            UniversalType::Json | UniversalType::Jsonb => {
+            Type::Json | Type::Jsonb => {
                 // JSON values are stored as native Objects in SurrealDB
                 // Use serde_json::Value for dynamic JSON extraction
                 let val: Option<serde_json::Value> = response.take((0, field_name))?;
                 Ok(val.map(|v| json_value_to_surreal(&v)))
             }
-            UniversalType::Array { element_type } => {
+            Type::Array { element_type } => {
                 // Extract array based on element type
                 match element_type.as_ref() {
-                    UniversalType::Int32 | UniversalType::Int16 | UniversalType::Int64 => {
+                    Type::Int32 | Type::Int16 | Type::Int64 => {
                         let val: Option<Vec<i64>> = response.take((0, field_name))?;
                         Ok(val.map(|arr| {
                             let items: Vec<SurrealValue> = arr
@@ -469,9 +461,7 @@ impl StreamingVerifier3 {
                             SurrealValue::Array(surrealdb3::types::Array::from(items))
                         }))
                     }
-                    UniversalType::Text
-                    | UniversalType::VarChar { .. }
-                    | UniversalType::Char { .. } => {
+                    Type::Text | Type::VarChar { .. } | Type::Char { .. } => {
                         let val: Option<Vec<String>> = response.take((0, field_name))?;
                         Ok(val.map(|arr| {
                             let items: Vec<SurrealValue> =
@@ -485,30 +475,30 @@ impl StreamingVerifier3 {
                     }
                 }
             }
-            UniversalType::Set { .. } => {
+            Type::Set { .. } => {
                 // Sets - for now just skip complex set handling
                 Ok(None)
             }
-            UniversalType::Geometry { .. } => {
+            Type::Geometry { .. } => {
                 // Geometry - skip for now
                 Ok(None)
             }
-            UniversalType::Duration => {
+            Type::Duration => {
                 // Duration - extract as SurrealDB duration
                 let val: Option<surrealdb3::types::Duration> = response.take((0, field_name))?;
                 Ok(val.map(SurrealValue::Duration))
             }
-            UniversalType::Thing => {
+            Type::Thing => {
                 // Thing - extract as SurrealDB RecordId
                 let val: Option<surrealdb3::types::RecordId> = response.take((0, field_name))?;
                 Ok(val.map(SurrealValue::RecordId))
             }
-            UniversalType::Object => {
+            Type::Object => {
                 // Object - stored as native Object in SurrealDB
                 let val: Option<serde_json::Value> = response.take((0, field_name))?;
                 Ok(val.map(|v| json_value_to_surreal(&v)))
             }
-            UniversalType::TimeTz => {
+            Type::TimeTz => {
                 // TimeTz - stored as string in SurrealDB
                 let val: Option<String> = response.take((0, field_name))?;
                 Ok(val.map(SurrealValue::String))
@@ -519,7 +509,7 @@ impl StreamingVerifier3 {
     /// Compare an expected row with an actual SurrealDB record.
     fn compare_row(
         &self,
-        expected: &UniversalRow,
+        expected: &Row,
         actual: &RecordResult,
         table_schema: &GeneratorTableDefinition,
     ) -> Vec<FieldMismatch> {
@@ -584,13 +574,13 @@ impl StreamingVerifier3 {
     }
 }
 
-/// Format a UniversalValue ID for display.
-fn format_id(value: &sync_core::UniversalValue) -> String {
+/// Format a Value ID for display.
+fn format_id(value: &sync_core::Value) -> String {
     match value {
-        sync_core::UniversalValue::Uuid(u) => u.to_string(),
-        sync_core::UniversalValue::Int64(i) => i.to_string(),
-        sync_core::UniversalValue::Int32(i) => i.to_string(),
-        sync_core::UniversalValue::Text(s) => s.clone(),
+        sync_core::Value::Uuid(u) => u.to_string(),
+        sync_core::Value::Int64(i) => i.to_string(),
+        sync_core::Value::Int32(i) => i.to_string(),
+        sync_core::Value::Text(s) => s.clone(),
         _ => format!("{value:?}"),
     }
 }
@@ -671,12 +661,12 @@ tables:
     fn test_format_id() {
         let uuid = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
         assert_eq!(
-            format_id(&sync_core::UniversalValue::Uuid(uuid)),
+            format_id(&sync_core::Value::Uuid(uuid)),
             "550e8400-e29b-41d4-a716-446655440000"
         );
-        assert_eq!(format_id(&sync_core::UniversalValue::Int64(12345)), "12345");
+        assert_eq!(format_id(&sync_core::Value::Int64(12345)), "12345");
         assert_eq!(
-            format_id(&sync_core::UniversalValue::Text("test-id".to_string())),
+            format_id(&sync_core::Value::Text("test-id".to_string())),
             "test-id"
         );
     }

--- a/crates/mongodb-changestream-source/src/full_sync.rs
+++ b/crates/mongodb-changestream-source/src/full_sync.rs
@@ -8,7 +8,7 @@ use mongodb_types::BsonValueWithSchema;
 use std::collections::HashMap;
 use std::time::Duration;
 use surreal_sink::SurrealSink;
-use sync_core::{DatabaseSchema, UniversalRow, UniversalType, UniversalValue};
+use sync_core::{DatabaseSchema, Row, Type, Value};
 use sync_transform::{ApplyOpts, Pipeline};
 
 /// Source database connection options (MongoDB-specific, library type without clap)
@@ -239,7 +239,7 @@ pub async fn run_full_sync_with_transforms<S: SurrealSink, CS: CheckpointStore>(
 
         #[async_trait]
         impl RowChunkSource for MongoCursorChunks<'_> {
-            async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<UniversalRow>>> {
+            async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<Row>>> {
                 if self.exhausted {
                     return Ok(None);
                 }
@@ -338,18 +338,16 @@ pub async fn run_full_sync_with_transforms<S: SurrealSink, CS: CheckpointStore>(
     Ok(())
 }
 
-/// Convert BSON values directly to UniversalValue (without schema)
-pub fn convert_bson_to_universal_value(
-    bson_value: mongodb::bson::Bson,
-) -> anyhow::Result<UniversalValue> {
+/// Convert BSON values directly to Value (without schema)
+pub fn convert_bson_to_universal_value(bson_value: mongodb::bson::Bson) -> anyhow::Result<Value> {
     convert_bson_to_universal_value_with_schema(bson_value, None)
 }
 
-/// Convert BSON values to UniversalValue with optional schema type hint
+/// Convert BSON values to Value with optional schema type hint
 pub fn convert_bson_to_universal_value_with_schema(
     bson_value: mongodb::bson::Bson,
-    field_type: Option<&UniversalType>,
-) -> anyhow::Result<UniversalValue> {
+    field_type: Option<&Type>,
+) -> anyhow::Result<Value> {
     use mongodb::bson::Bson;
 
     // If we have schema information, use the schema-aware converter from mongodb-types
@@ -360,13 +358,13 @@ pub fn convert_bson_to_universal_value_with_schema(
 
     // Fall back to schema-less conversion
     match bson_value {
-        Bson::Double(f) => Ok(UniversalValue::Float64(f)),
+        Bson::Double(f) => Ok(Value::Float64(f)),
         Bson::String(s) => {
             // Auto-detect ISO 8601 duration strings (PTxxxS format) and convert to Duration
             if let Some(duration) = try_parse_iso8601_duration(&s) {
-                Ok(UniversalValue::Duration(duration))
+                Ok(Value::Duration(duration))
             } else {
-                Ok(UniversalValue::Text(s))
+                Ok(Value::Text(s))
             }
         }
         Bson::Array(arr) => {
@@ -376,9 +374,9 @@ pub fn convert_bson_to_universal_value_with_schema(
                 vs.push(v);
             }
             // Use Json as element type since BSON arrays can contain mixed types
-            Ok(UniversalValue::Array {
+            Ok(Value::Array {
                 elements: vs,
-                element_type: Box::new(UniversalType::Json),
+                element_type: Box::new(Type::Json),
             })
         }
         Bson::Document(doc) => {
@@ -400,9 +398,9 @@ pub fn convert_bson_to_universal_value_with_schema(
                     }
                     _ => ref_id.to_string(),
                 };
-                Ok(UniversalValue::Thing {
+                Ok(Value::Thing {
                     table: ref_collection.clone(),
-                    id: Box::new(UniversalValue::Text(id_string)),
+                    id: Box::new(Value::Text(id_string)),
                 })
             } else {
                 // Regular document - convert recursively
@@ -411,37 +409,37 @@ pub fn convert_bson_to_universal_value_with_schema(
                     let v = convert_bson_to_universal_value(val)?;
                     obj.insert(key, v);
                 }
-                Ok(UniversalValue::Object(obj))
+                Ok(Value::Object(obj))
             }
         }
-        Bson::Boolean(b) => Ok(UniversalValue::Bool(b)),
-        Bson::Null => Ok(UniversalValue::Null),
+        Bson::Boolean(b) => Ok(Value::Bool(b)),
+        Bson::Null => Ok(Value::Null),
         Bson::RegularExpression(regex) => {
             // We assume SurrealDB's regex always use Rust's regex crate under the hood,
             // so we can say (?OPTIONS)PATTERN in SurrealDB whereas it is /PATTERN/OPTIONS in MongoDB.
             // Note that the regex crate does not support the /PATTERN/OPTIONS style.
             // See https://docs.rs/regex/latest/regex/#grouping-and-flags
-            Ok(UniversalValue::Text(format!(
+            Ok(Value::Text(format!(
                 "(?{}){}",
                 regex.options, regex.pattern
             )))
         }
-        Bson::JavaScriptCode(code) => Ok(UniversalValue::Text(code)),
+        Bson::JavaScriptCode(code) => Ok(Value::Text(code)),
         Bson::JavaScriptCodeWithScope(code_with_scope) => {
             let mut scope_obj = HashMap::new();
             for (key, val) in code_with_scope.scope {
                 let v = convert_bson_to_universal_value(val)?;
                 scope_obj.insert(key, v);
             }
-            let scope = UniversalValue::Object(scope_obj);
-            let code = UniversalValue::Text(code_with_scope.code);
+            let scope = Value::Object(scope_obj);
+            let code = Value::Text(code_with_scope.code);
             let mut result_obj = HashMap::new();
             result_obj.insert("$code".to_string(), code);
             result_obj.insert("$scope".to_string(), scope);
-            Ok(UniversalValue::Object(result_obj))
+            Ok(Value::Object(result_obj))
         }
-        Bson::Int32(i) => Ok(UniversalValue::Int64(i as i64)),
-        Bson::Int64(i) => Ok(UniversalValue::Int64(i)),
+        Bson::Int32(i) => Ok(Value::Int64(i as i64)),
+        Bson::Int64(i) => Ok(Value::Int64(i)),
         Bson::Timestamp(ts) => {
             // MongoDB Timestamp.time is seconds since Unix epoch
             let seconds = ts.time as i64;
@@ -449,64 +447,64 @@ pub fn convert_bson_to_universal_value_with_schema(
             let assumed_ns = ts.increment;
             if let Some(datetime) = chrono::DateTime::from_timestamp(seconds, assumed_ns) {
                 // MongoDB timestamps are in UTC, so use ZonedDateTime
-                Ok(UniversalValue::ZonedDateTime(datetime))
+                Ok(Value::ZonedDateTime(datetime))
             } else {
                 Err(anyhow::anyhow!(
                     "Failed to convert MongoDB timestamp to datetime"
                 ))
             }
         }
-        Bson::Binary(binary) => Ok(UniversalValue::Bytes(binary.bytes)),
-        Bson::ObjectId(oid) => Ok(UniversalValue::Text(oid.to_string())),
-        Bson::DateTime(dt) => Ok(UniversalValue::ZonedDateTime(dt.to_chrono())),
-        Bson::Symbol(s) => Ok(UniversalValue::Text(s)),
+        Bson::Binary(binary) => Ok(Value::Bytes(binary.bytes)),
+        Bson::ObjectId(oid) => Ok(Value::Text(oid.to_string())),
+        Bson::DateTime(dt) => Ok(Value::ZonedDateTime(dt.to_chrono())),
+        Bson::Symbol(s) => Ok(Value::Text(s)),
         Bson::Decimal128(d) => {
             let decimal_str = d.to_string();
             // Try to parse as float64
             match decimal_str.parse::<f64>() {
-                Ok(f) => Ok(UniversalValue::Float64(f)),
+                Ok(f) => Ok(Value::Float64(f)),
                 Err(e) => {
                     tracing::warn!("Failed to parse BSON Decimal128 '{}': {:?}", decimal_str, e);
                     Err(anyhow::anyhow!("Failed to parse BSON Decimal128"))
                 }
             }
         }
-        Bson::Undefined => Ok(UniversalValue::Null), // Map undefined to null
+        Bson::Undefined => Ok(Value::Null), // Map undefined to null
         Bson::MaxKey => {
             let mut mk = HashMap::new();
-            mk.insert("$maxKey".to_string(), UniversalValue::Int64(1));
-            Ok(UniversalValue::Object(mk))
+            mk.insert("$maxKey".to_string(), Value::Int64(1));
+            Ok(Value::Object(mk))
         }
         Bson::MinKey => {
             let mut mk = HashMap::new();
-            mk.insert("$minKey".to_string(), UniversalValue::Int64(1));
-            Ok(UniversalValue::Object(mk))
+            mk.insert("$minKey".to_string(), Value::Int64(1));
+            Ok(Value::Object(mk))
         }
         Bson::DbPointer(_db_pointer) => {
             // DBPointer is deprecated and fields are private
             // Store as a special string to preserve the information
-            Ok(UniversalValue::Text("$dbPointer".to_string()))
+            Ok(Value::Text("$dbPointer".to_string()))
         }
     }
 }
 
-/// Converts a BSON document containing _id to a UniversalRow with optional schema
+/// Converts a BSON document containing _id to a Row with optional schema
 pub fn convert_bson_document_to_record_with_schema(
     doc: mongodb::bson::Document,
     collection_name: &str,
     row_index: u64,
     schema: Option<&DatabaseSchema>,
-) -> anyhow::Result<UniversalRow> {
+) -> anyhow::Result<Row> {
     // Get table schema for field type lookup
     let table_def = schema.and_then(|s| s.get_table(collection_name));
 
-    // Extract MongoDB _id and convert to UniversalValue
+    // Extract MongoDB _id and convert to Value
     let id_value = if let Some(id_bson) = doc.get("_id") {
         match id_bson {
-            mongodb::bson::Bson::ObjectId(oid) => UniversalValue::Text(oid.to_string()),
-            mongodb::bson::Bson::String(s) => UniversalValue::Text(s.clone()),
-            mongodb::bson::Bson::Int32(i) => UniversalValue::Int64(*i as i64),
-            mongodb::bson::Bson::Int64(i) => UniversalValue::Int64(*i),
+            mongodb::bson::Bson::ObjectId(oid) => Value::Text(oid.to_string()),
+            mongodb::bson::Bson::String(s) => Value::Text(s.clone()),
+            mongodb::bson::Bson::Int32(i) => Value::Int64(*i as i64),
+            mongodb::bson::Bson::Int64(i) => Value::Int64(*i),
             _ => anyhow::bail!("Unsupported _id type in MongoDB document: {id_bson:?}"),
         }
     } else {
@@ -524,7 +522,7 @@ pub fn convert_bson_document_to_record_with_schema(
         }
     }
 
-    Ok(UniversalRow::new(
+    Ok(Row::new(
         collection_name.to_string(),
         row_index,
         id_value,

--- a/crates/mongodb-changestream-source/src/incremental_sync.rs
+++ b/crates/mongodb-changestream-source/src/incremental_sync.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use surreal_sink::SurrealSink;
-use sync_core::{UniversalChange, UniversalChangeOp, UniversalValue};
+use sync_core::{Change, ChangeOp, Value};
 use sync_transform::{
     ApplyOpts, CheckpointPolicy, Pipeline, PositionedEvent, SourceDriver, SourceRuntimeOpts,
     StopReason,
@@ -57,14 +57,14 @@ impl ReplicationTailOptions {
 #[async_trait]
 pub trait ChangeStream: Send + Sync {
     /// Get the next change event from the stream
-    async fn next(&mut self) -> Option<Result<UniversalChange>>;
+    async fn next(&mut self) -> Option<Result<Change>>;
 
     /// Get the current checkpoint of the stream
     fn checkpoint(&self) -> Option<MongoDBCheckpoint>;
 }
 
-/// Convert a BSON document directly to a UniversalValue map
-fn bson_doc_to_universal_values(doc: Document) -> Result<HashMap<String, UniversalValue>> {
+/// Convert a BSON document directly to a Value map
+fn bson_doc_to_universal_values(doc: Document) -> Result<HashMap<String, Value>> {
     let mut map = HashMap::new();
 
     for (key, value) in doc {
@@ -189,8 +189,7 @@ impl MongodbIncrementalSource {
     async fn start_change_stream(
         &self,
         checkpoint: Option<MongoDBCheckpoint>,
-    ) -> Result<std::pin::Pin<Box<dyn futures::Stream<Item = Result<UniversalChange>> + Send>>>
-    {
+    ) -> Result<std::pin::Pin<Box<dyn futures::Stream<Item = Result<Change>> + Send>>> {
         let database = self.client.database(&self.database);
 
         // Build change stream options
@@ -245,19 +244,18 @@ impl MongodbIncrementalSource {
             .buffer_unordered(1);
 
         // Box the stream with Send bound
-        let boxed_stream: std::pin::Pin<
-            Box<dyn futures::Stream<Item = Result<UniversalChange>> + Send>,
-        > = Box::pin(stream);
+        let boxed_stream: std::pin::Pin<Box<dyn futures::Stream<Item = Result<Change>> + Send>> =
+            Box::pin(stream);
 
         Ok(boxed_stream)
     }
 
-    /// Convert MongoDB change event to our UniversalChange
+    /// Convert MongoDB change event to our Change
     async fn convert_change_event(
         event: ChangeStreamEvent<Document>,
         _database_name: &str,
         seen_token: Arc<Mutex<Vec<u8>>>,
-    ) -> Result<UniversalChange> {
+    ) -> Result<Change> {
         // Track the fetch-time resume token separately from the sink-safe bookmark.
         if let Ok(token_bytes) = bson::to_vec(&event.id) {
             *seen_token.lock().await = token_bytes;
@@ -265,10 +263,10 @@ impl MongodbIncrementalSource {
 
         // Determine operation type
         let operation = match event.operation_type {
-            mongodb::change_stream::event::OperationType::Insert => UniversalChangeOp::Create,
-            mongodb::change_stream::event::OperationType::Update => UniversalChangeOp::Update,
-            mongodb::change_stream::event::OperationType::Replace => UniversalChangeOp::Update,
-            mongodb::change_stream::event::OperationType::Delete => UniversalChangeOp::Delete,
+            mongodb::change_stream::event::OperationType::Insert => ChangeOp::Create,
+            mongodb::change_stream::event::OperationType::Update => ChangeOp::Update,
+            mongodb::change_stream::event::OperationType::Replace => ChangeOp::Update,
+            mongodb::change_stream::event::OperationType::Delete => ChangeOp::Delete,
             op => {
                 // Skip other operation types (like invalidate, drop, etc.)
                 return Err(anyhow!("Unsupported operation type: {op:?}"));
@@ -281,15 +279,15 @@ impl MongodbIncrementalSource {
             .and_then(|ns| ns.coll)
             .unwrap_or_else(|| "unknown".to_string());
 
-        // Get document ID as UniversalValue
+        // Get document ID as Value
         let id_value = if let Some(id) = event.document_key {
-            // Convert BSON document key to UniversalValue
+            // Convert BSON document key to Value
             if let Ok(oid) = id.get_object_id("_id") {
-                UniversalValue::Text(oid.to_hex())
+                Value::Text(oid.to_hex())
             } else if let Ok(s) = id.get_str("_id") {
-                UniversalValue::Text(s.to_string())
+                Value::Text(s.to_string())
             } else if let Ok(i) = id.get_i64("_id") {
-                UniversalValue::Int64(i)
+                Value::Int64(i)
             } else {
                 return Err(anyhow!(
                     "Unsupported _id type in document key: {:?}",
@@ -301,20 +299,20 @@ impl MongodbIncrementalSource {
         };
 
         let data = match operation {
-            UniversalChangeOp::Delete => None,
+            ChangeOp::Delete => None,
             _ => {
                 let d = event.full_document.unwrap();
                 Some(bson_doc_to_universal_values(d)?)
             }
         };
 
-        Ok(UniversalChange::new(operation, collection, id_value, data))
+        Ok(Change::new(operation, collection, id_value, data))
     }
 }
 
 // Type alias for complex MongoDB change stream type
 type MongoStreamType =
-    Arc<Mutex<std::pin::Pin<Box<dyn futures::Stream<Item = Result<UniversalChange>> + Send>>>>;
+    Arc<Mutex<std::pin::Pin<Box<dyn futures::Stream<Item = Result<Change>> + Send>>>>;
 
 /// A change stream wrapper for MongoDB incremental sync.
 ///
@@ -330,7 +328,7 @@ pub struct MongoChangeStream {
 
 impl MongoChangeStream {
     pub fn new(
-        stream: std::pin::Pin<Box<dyn futures::Stream<Item = Result<UniversalChange>> + Send>>,
+        stream: std::pin::Pin<Box<dyn futures::Stream<Item = Result<Change>> + Send>>,
         _initial_resume_token: Vec<u8>,
     ) -> Self {
         Self {
@@ -341,7 +339,7 @@ impl MongoChangeStream {
 
 #[async_trait]
 impl ChangeStream for MongoChangeStream {
-    async fn next(&mut self) -> Option<Result<UniversalChange>> {
+    async fn next(&mut self) -> Option<Result<Change>> {
         let mut stream = self.stream.lock().await;
         stream.next().await
     }

--- a/crates/mongodb-types/src/forward.rs
+++ b/crates/mongodb-types/src/forward.rs
@@ -4,7 +4,7 @@
 
 use bson::{Bson, DateTime as BsonDateTime};
 use sync_core::values::GeometryData;
-use sync_core::{GeometryType, TypedValue, UniversalType, UniversalValue};
+use sync_core::{GeometryType, Type, TypedValue, Value};
 
 /// Wrapper for BSON values that can be inserted into MongoDB.
 #[derive(Debug, Clone)]
@@ -26,22 +26,20 @@ impl From<TypedValue> for BsonValue {
     fn from(tv: TypedValue) -> Self {
         match (&tv.sync_type, &tv.value) {
             // Special case: JSON/JSONB can be stored as Text and needs parsing
-            (UniversalType::Json, UniversalValue::Text(s)) => {
+            (Type::Json, Value::Text(s)) => {
                 // Try to parse as JSON, otherwise store as string
                 match serde_json::from_str::<serde_json::Value>(s) {
                     Ok(v) => BsonValue(serde_json_to_bson(&v)),
                     Err(_) => BsonValue(Bson::String(s.clone())),
                 }
             }
-            (UniversalType::Jsonb, UniversalValue::Text(s)) => {
-                match serde_json::from_str::<serde_json::Value>(s) {
-                    Ok(v) => BsonValue(serde_json_to_bson(&v)),
-                    Err(_) => BsonValue(Bson::String(s.clone())),
-                }
-            }
+            (Type::Jsonb, Value::Text(s)) => match serde_json::from_str::<serde_json::Value>(s) {
+                Ok(v) => BsonValue(serde_json_to_bson(&v)),
+                Err(_) => BsonValue(Bson::String(s.clone())),
+            },
 
             // Special case: Arrays with element_type need typed conversion
-            (UniversalType::Array { element_type }, UniversalValue::Array { elements, .. }) => {
+            (Type::Array { element_type }, Value::Array { elements, .. }) => {
                 let bson_arr: Vec<Bson> = elements
                     .iter()
                     .map(|v| {
@@ -55,92 +53,88 @@ impl From<TypedValue> for BsonValue {
                 BsonValue(Bson::Array(bson_arr))
             }
 
-            // All other cases delegate to From<UniversalValue>
+            // All other cases delegate to From<Value>
             _ => BsonValue::from(tv.value),
         }
     }
 }
 
-impl From<UniversalValue> for BsonValue {
-    fn from(value: UniversalValue) -> Self {
+impl From<Value> for BsonValue {
+    fn from(value: Value) -> Self {
         match value {
             // Null
-            UniversalValue::Null => BsonValue(Bson::Null),
+            Value::Null => BsonValue(Bson::Null),
 
             // Boolean
-            UniversalValue::Bool(b) => BsonValue(Bson::Boolean(b)),
+            Value::Bool(b) => BsonValue(Bson::Boolean(b)),
 
             // Integer types - MongoDB uses i32 and i64
-            UniversalValue::Int8 { value, .. } => BsonValue(Bson::Int32(value as i32)),
-            UniversalValue::Int16(i) => BsonValue(Bson::Int32(i as i32)),
-            UniversalValue::Int32(i) => BsonValue(Bson::Int32(i)),
-            UniversalValue::Int64(i) => BsonValue(Bson::Int64(i)),
+            Value::Int8 { value, .. } => BsonValue(Bson::Int32(value as i32)),
+            Value::Int16(i) => BsonValue(Bson::Int32(i as i32)),
+            Value::Int32(i) => BsonValue(Bson::Int32(i)),
+            Value::Int64(i) => BsonValue(Bson::Int64(i)),
 
             // Floating point
-            UniversalValue::Float32(f) => BsonValue(Bson::Double(f as f64)),
-            UniversalValue::Float64(f) => BsonValue(Bson::Double(f)),
+            Value::Float32(f) => BsonValue(Bson::Double(f as f64)),
+            Value::Float64(f) => BsonValue(Bson::Double(f)),
 
             // Decimal - MongoDB has Decimal128, but we'll use string for precision
-            UniversalValue::Decimal { value, .. } => BsonValue(Bson::String(value)),
+            Value::Decimal { value, .. } => BsonValue(Bson::String(value)),
 
             // String types
-            UniversalValue::Char { value, .. } => BsonValue(Bson::String(value)),
-            UniversalValue::VarChar { value, .. } => BsonValue(Bson::String(value)),
-            UniversalValue::Text(s) => BsonValue(Bson::String(s)),
+            Value::Char { value, .. } => BsonValue(Bson::String(value)),
+            Value::VarChar { value, .. } => BsonValue(Bson::String(value)),
+            Value::Text(s) => BsonValue(Bson::String(s)),
 
             // Binary types
-            UniversalValue::Blob(b) => BsonValue(Bson::Binary(bson::Binary {
+            Value::Blob(b) => BsonValue(Bson::Binary(bson::Binary {
                 subtype: bson::spec::BinarySubtype::Generic,
                 bytes: b,
             })),
-            UniversalValue::Bytes(b) => BsonValue(Bson::Binary(bson::Binary {
+            Value::Bytes(b) => BsonValue(Bson::Binary(bson::Binary {
                 subtype: bson::spec::BinarySubtype::Generic,
                 bytes: b,
             })),
 
             // Date/time types
-            UniversalValue::Date(dt) => {
+            Value::Date(dt) => {
                 // Store date as string in YYYY-MM-DD format
                 BsonValue(Bson::String(dt.format("%Y-%m-%d").to_string()))
             }
-            UniversalValue::Time(dt) => {
+            Value::Time(dt) => {
                 // Store time as string with fractional seconds preserved
                 BsonValue(Bson::String(dt.format("%H:%M:%S%.f").to_string()))
             }
-            UniversalValue::LocalDateTime(dt) => {
-                BsonValue(Bson::DateTime(BsonDateTime::from_chrono(dt)))
-            }
-            UniversalValue::LocalDateTimeNano(dt) => {
+            Value::LocalDateTime(dt) => BsonValue(Bson::DateTime(BsonDateTime::from_chrono(dt))),
+            Value::LocalDateTimeNano(dt) => {
                 // MongoDB DateTime has millisecond precision, so we lose nanoseconds
                 BsonValue(Bson::DateTime(BsonDateTime::from_chrono(dt)))
             }
-            UniversalValue::ZonedDateTime(dt) => {
-                BsonValue(Bson::DateTime(BsonDateTime::from_chrono(dt)))
-            }
+            Value::ZonedDateTime(dt) => BsonValue(Bson::DateTime(BsonDateTime::from_chrono(dt))),
             // TimeTz - store as string to preserve timezone format
-            UniversalValue::TimeTz(s) => BsonValue(Bson::String(s)),
+            Value::TimeTz(s) => BsonValue(Bson::String(s)),
 
             // UUID - MongoDB has native UUID binary subtype
-            UniversalValue::Uuid(u) => BsonValue(Bson::Binary(bson::Binary {
+            Value::Uuid(u) => BsonValue(Bson::Binary(bson::Binary {
                 subtype: bson::spec::BinarySubtype::Uuid,
                 bytes: u.as_bytes().to_vec(),
             })),
 
             // ULID - store as string in MongoDB
-            UniversalValue::Ulid(u) => BsonValue(Bson::String(u.to_string())),
+            Value::Ulid(u) => BsonValue(Bson::String(u.to_string())),
 
             // JSON types - convert to BSON document
-            UniversalValue::Json(json_val) => {
+            Value::Json(json_val) => {
                 let bson_val = json_value_to_bson(&json_val);
                 BsonValue(bson_val)
             }
-            UniversalValue::Jsonb(json_val) => {
+            Value::Jsonb(json_val) => {
                 let bson_val = json_value_to_bson(&json_val);
                 BsonValue(bson_val)
             }
 
             // Array types - recursively convert elements
-            UniversalValue::Array { elements, .. } => {
+            Value::Array { elements, .. } => {
                 let bson_arr: Vec<Bson> = elements
                     .into_iter()
                     .map(|v| BsonValue::from(v).into_inner())
@@ -149,16 +143,16 @@ impl From<UniversalValue> for BsonValue {
             }
 
             // Set - stored as array
-            UniversalValue::Set { elements, .. } => {
+            Value::Set { elements, .. } => {
                 let bson_arr: Vec<Bson> = elements.into_iter().map(Bson::String).collect();
                 BsonValue(Bson::Array(bson_arr))
             }
 
             // Enum - stored as string
-            UniversalValue::Enum { value, .. } => BsonValue(Bson::String(value)),
+            Value::Enum { value, .. } => BsonValue(Bson::String(value)),
 
             // Geometry types - store as GeoJSON with type field
-            UniversalValue::Geometry {
+            Value::Geometry {
                 data,
                 geometry_type,
             } => {
@@ -180,7 +174,7 @@ impl From<UniversalValue> for BsonValue {
             }
 
             // Duration - store as ISO 8601 duration string
-            UniversalValue::Duration(d) => {
+            Value::Duration(d) => {
                 let secs = d.as_secs();
                 let nanos = d.subsec_nanos();
                 if nanos == 0 {
@@ -191,12 +185,12 @@ impl From<UniversalValue> for BsonValue {
             }
 
             // Thing - record reference as "table:id" format
-            UniversalValue::Thing { table, id } => {
+            Value::Thing { table, id } => {
                 let id_str = match id.as_ref() {
-                    UniversalValue::Text(s) => s.clone(),
-                    UniversalValue::Int32(i) => i.to_string(),
-                    UniversalValue::Int64(i) => i.to_string(),
-                    UniversalValue::Uuid(u) => u.to_string(),
+                    Value::Text(s) => s.clone(),
+                    Value::Int32(i) => i.to_string(),
+                    Value::Int64(i) => i.to_string(),
+                    Value::Uuid(u) => u.to_string(),
                     other => panic!(
                         "Unsupported Thing ID type: {other:?}. \
                          Supported types: Text, Int32, Int64, Uuid"
@@ -206,7 +200,7 @@ impl From<UniversalValue> for BsonValue {
             }
 
             // Object - convert to BSON document
-            UniversalValue::Object(map) => {
+            Value::Object(map) => {
                 let mut doc = bson::Document::new();
                 for (k, v) in map {
                     doc.insert(k, BsonValue::from(v).into_inner());
@@ -214,13 +208,12 @@ impl From<UniversalValue> for BsonValue {
                 BsonValue(Bson::Document(doc))
             }
 
-            UniversalValue::ZeroTemporal {
+            Value::ZeroTemporal {
                 intended_type,
                 source,
             } => {
-                let s = source.unwrap_or_else(|| {
-                    UniversalValue::canonical_zero_literal(&intended_type).to_string()
-                });
+                let s = source
+                    .unwrap_or_else(|| Value::canonical_zero_literal(&intended_type).to_string());
                 BsonValue(Bson::String(s))
             }
         }
@@ -260,53 +253,51 @@ fn json_object_to_bson_doc(map: &serde_json::Map<String, serde_json::Value>) -> 
     doc
 }
 
-/// Convert a UniversalValue to a BSON value (without type context).
+/// Convert a Value to a BSON value (without type context).
 #[allow(dead_code)]
-fn generated_value_to_bson(value: &UniversalValue) -> Bson {
+fn generated_value_to_bson(value: &Value) -> Bson {
     match value {
-        UniversalValue::Null => Bson::Null,
-        UniversalValue::Bool(b) => Bson::Boolean(*b),
-        UniversalValue::Int8 { value, .. } => Bson::Int32(*value as i32),
-        UniversalValue::Int16(i) => Bson::Int32(*i as i32),
-        UniversalValue::Int32(i) => Bson::Int32(*i),
-        UniversalValue::Int64(i) => Bson::Int64(*i),
-        UniversalValue::Float32(f) => Bson::Double(*f as f64),
-        UniversalValue::Float64(f) => Bson::Double(*f),
-        UniversalValue::Char { value, .. } => Bson::String(value.clone()),
-        UniversalValue::VarChar { value, .. } => Bson::String(value.clone()),
-        UniversalValue::Text(s) => Bson::String(s.clone()),
-        UniversalValue::Blob(b) | UniversalValue::Bytes(b) => Bson::Binary(bson::Binary {
+        Value::Null => Bson::Null,
+        Value::Bool(b) => Bson::Boolean(*b),
+        Value::Int8 { value, .. } => Bson::Int32(*value as i32),
+        Value::Int16(i) => Bson::Int32(*i as i32),
+        Value::Int32(i) => Bson::Int32(*i),
+        Value::Int64(i) => Bson::Int64(*i),
+        Value::Float32(f) => Bson::Double(*f as f64),
+        Value::Float64(f) => Bson::Double(*f),
+        Value::Char { value, .. } => Bson::String(value.clone()),
+        Value::VarChar { value, .. } => Bson::String(value.clone()),
+        Value::Text(s) => Bson::String(s.clone()),
+        Value::Blob(b) | Value::Bytes(b) => Bson::Binary(bson::Binary {
             subtype: bson::spec::BinarySubtype::Generic,
             bytes: b.clone(),
         }),
-        UniversalValue::Uuid(u) => Bson::Binary(bson::Binary {
+        Value::Uuid(u) => Bson::Binary(bson::Binary {
             subtype: bson::spec::BinarySubtype::Uuid,
             bytes: u.as_bytes().to_vec(),
         }),
-        UniversalValue::Ulid(u) => Bson::String(u.to_string()),
-        UniversalValue::Date(dt) => Bson::String(dt.format("%Y-%m-%d").to_string()),
-        UniversalValue::Time(dt) => Bson::String(dt.format("%H:%M:%S%.f").to_string()),
-        UniversalValue::LocalDateTime(dt)
-        | UniversalValue::LocalDateTimeNano(dt)
-        | UniversalValue::ZonedDateTime(dt) => Bson::DateTime(BsonDateTime::from_chrono(*dt)),
-        UniversalValue::TimeTz(s) => Bson::String(s.clone()),
-        UniversalValue::Decimal { value, .. } => Bson::String(value.clone()),
-        UniversalValue::Array { elements, .. } => {
+        Value::Ulid(u) => Bson::String(u.to_string()),
+        Value::Date(dt) => Bson::String(dt.format("%Y-%m-%d").to_string()),
+        Value::Time(dt) => Bson::String(dt.format("%H:%M:%S%.f").to_string()),
+        Value::LocalDateTime(dt) | Value::LocalDateTimeNano(dt) | Value::ZonedDateTime(dt) => {
+            Bson::DateTime(BsonDateTime::from_chrono(*dt))
+        }
+        Value::TimeTz(s) => Bson::String(s.clone()),
+        Value::Decimal { value, .. } => Bson::String(value.clone()),
+        Value::Array { elements, .. } => {
             Bson::Array(elements.iter().map(generated_value_to_bson).collect())
         }
-        UniversalValue::Json(json_val) | UniversalValue::Jsonb(json_val) => {
-            json_value_to_bson(json_val)
-        }
-        UniversalValue::Set { elements, .. } => {
+        Value::Json(json_val) | Value::Jsonb(json_val) => json_value_to_bson(json_val),
+        Value::Set { elements, .. } => {
             Bson::Array(elements.iter().map(|s| Bson::String(s.clone())).collect())
         }
-        UniversalValue::Enum { value, .. } => Bson::String(value.clone()),
-        UniversalValue::Geometry { data, .. } => {
+        Value::Enum { value, .. } => Bson::String(value.clone()),
+        Value::Geometry { data, .. } => {
             use sync_core::values::GeometryData;
             let GeometryData(json_val) = data;
             serde_json_to_bson(json_val)
         }
-        UniversalValue::Duration(d) => {
+        Value::Duration(d) => {
             let secs = d.as_secs();
             let nanos = d.subsec_nanos();
             if nanos == 0 {
@@ -315,12 +306,12 @@ fn generated_value_to_bson(value: &UniversalValue) -> Bson {
                 Bson::String(format!("PT{secs}.{nanos:09}S"))
             }
         }
-        UniversalValue::Thing { table, id } => {
+        Value::Thing { table, id } => {
             let id_str = match id.as_ref() {
-                UniversalValue::Text(s) => s.clone(),
-                UniversalValue::Int32(i) => i.to_string(),
-                UniversalValue::Int64(i) => i.to_string(),
-                UniversalValue::Uuid(u) => u.to_string(),
+                Value::Text(s) => s.clone(),
+                Value::Int32(i) => i.to_string(),
+                Value::Int64(i) => i.to_string(),
+                Value::Uuid(u) => u.to_string(),
                 other => panic!(
                     "Unsupported Thing ID type for MongoDB: {other:?}. \
                      Supported types: Text, Int32, Int64, Uuid"
@@ -328,20 +319,20 @@ fn generated_value_to_bson(value: &UniversalValue) -> Bson {
             };
             Bson::String(format!("{table}:{id_str}"))
         }
-        UniversalValue::Object(map) => {
+        Value::Object(map) => {
             let mut doc = bson::Document::new();
             for (k, v) in map {
                 doc.insert(k.clone(), generated_value_to_bson(v));
             }
             Bson::Document(doc)
         }
-        UniversalValue::ZeroTemporal {
+        Value::ZeroTemporal {
             intended_type,
             source,
         } => {
             let s = source
                 .as_deref()
-                .unwrap_or_else(|| UniversalValue::canonical_zero_literal(intended_type));
+                .unwrap_or_else(|| Value::canonical_zero_literal(intended_type));
             Bson::String(s.to_string())
         }
     }
@@ -401,7 +392,7 @@ mod tests {
 
     #[test]
     fn test_null_conversion() {
-        let tv = TypedValue::null(UniversalType::Text);
+        let tv = TypedValue::null(Type::Text);
         let bson_val: BsonValue = tv.into();
         assert!(matches!(bson_val.0, Bson::Null));
     }
@@ -587,8 +578,8 @@ mod tests {
     #[test]
     fn test_json_string_conversion() {
         let tv = TypedValue {
-            sync_type: UniversalType::Json,
-            value: UniversalValue::Text(r#"{"key": "value"}"#.to_string()),
+            sync_type: Type::Json,
+            value: Value::Text(r#"{"key": "value"}"#.to_string()),
         };
         let bson_val: BsonValue = tv.into();
         if let Bson::Document(doc) = bson_val.0 {
@@ -601,12 +592,8 @@ mod tests {
     #[test]
     fn test_array_int_conversion() {
         let tv = TypedValue::array(
-            vec![
-                UniversalValue::Int32(1),
-                UniversalValue::Int32(2),
-                UniversalValue::Int32(3),
-            ],
-            UniversalType::Int32,
+            vec![Value::Int32(1), Value::Int32(2), Value::Int32(3)],
+            Type::Int32,
         );
         let bson_val: BsonValue = tv.into();
         if let Bson::Array(arr) = bson_val.0 {
@@ -622,11 +609,8 @@ mod tests {
     #[test]
     fn test_array_text_conversion() {
         let tv = TypedValue::array(
-            vec![
-                UniversalValue::Text("a".to_string()),
-                UniversalValue::Text("b".to_string()),
-            ],
-            UniversalType::Text,
+            vec![Value::Text("a".to_string()), Value::Text("b".to_string())],
+            Type::Text,
         );
         let bson_val: BsonValue = tv.into();
         if let Bson::Array(arr) = bson_val.0 {

--- a/crates/mongodb-types/src/reverse.rs
+++ b/crates/mongodb-types/src/reverse.rs
@@ -5,7 +5,7 @@
 use bson::Bson;
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
-use sync_core::{TypedValue, UniversalType, UniversalValue};
+use sync_core::{Type, TypedValue, Value};
 
 /// Parse an ISO 8601 duration string (PTxS or PTx.xxxxxxxxxS format).
 ///
@@ -37,12 +37,12 @@ pub struct BsonValueWithSchema {
     /// The BSON value from MongoDB.
     pub value: Bson,
     /// The expected sync type for conversion.
-    pub sync_type: UniversalType,
+    pub sync_type: Type,
 }
 
 impl BsonValueWithSchema {
     /// Create a new BsonValueWithSchema.
-    pub fn new(value: Bson, sync_type: UniversalType) -> Self {
+    pub fn new(value: Bson, sync_type: Type) -> Self {
         Self { value, sync_type }
     }
 
@@ -58,141 +58,139 @@ impl From<BsonValueWithSchema> for TypedValue {
             // Null
             (sync_type, Bson::Null) => TypedValue {
                 sync_type: sync_type.clone(),
-                value: UniversalValue::Null,
+                value: Value::Null,
             },
 
             // Boolean
-            (UniversalType::Bool, Bson::Boolean(b)) => TypedValue::bool(*b),
+            (Type::Bool, Bson::Boolean(b)) => TypedValue::bool(*b),
 
             // Integer types
-            (UniversalType::Int8 { width }, Bson::Int32(i)) => TypedValue {
-                sync_type: UniversalType::Int8 { width: *width },
-                value: UniversalValue::Int32(*i),
+            (Type::Int8 { width }, Bson::Int32(i)) => TypedValue {
+                sync_type: Type::Int8 { width: *width },
+                value: Value::Int32(*i),
             },
-            (UniversalType::Int16, Bson::Int32(i)) => TypedValue::int16(*i as i16),
-            (UniversalType::Int32, Bson::Int32(i)) => TypedValue::int32(*i),
-            (UniversalType::Int64, Bson::Int64(i)) => TypedValue::int64(*i),
+            (Type::Int16, Bson::Int32(i)) => TypedValue::int16(*i as i16),
+            (Type::Int32, Bson::Int32(i)) => TypedValue::int32(*i),
+            (Type::Int64, Bson::Int64(i)) => TypedValue::int64(*i),
             // Handle Int64 for Int (MongoDB might return Int64)
-            (UniversalType::Int32, Bson::Int64(i)) => TypedValue::int32(*i as i32),
+            (Type::Int32, Bson::Int64(i)) => TypedValue::int32(*i as i32),
             // Handle Int32 for BigInt
-            (UniversalType::Int64, Bson::Int32(i)) => TypedValue::int64(*i as i64),
+            (Type::Int64, Bson::Int32(i)) => TypedValue::int64(*i as i64),
 
             // Floating point
-            (UniversalType::Float32, Bson::Double(f)) => TypedValue::float32(*f as f32),
-            (UniversalType::Float64, Bson::Double(f)) => TypedValue::float64(*f),
+            (Type::Float32, Bson::Double(f)) => TypedValue::float32(*f as f32),
+            (Type::Float64, Bson::Double(f)) => TypedValue::float64(*f),
 
             // Decimal - stored as string in MongoDB for precision
-            (UniversalType::Decimal { precision, scale }, Bson::String(s)) => {
+            (Type::Decimal { precision, scale }, Bson::String(s)) => {
                 TypedValue::decimal(s, *precision, *scale)
             }
             // Also handle Decimal128 if present
-            (UniversalType::Decimal { precision, scale }, Bson::Decimal128(d)) => {
+            (Type::Decimal { precision, scale }, Bson::Decimal128(d)) => {
                 TypedValue::decimal(d.to_string(), *precision, *scale)
             }
 
             // String types
-            (UniversalType::Char { length }, Bson::String(s)) => TypedValue {
-                sync_type: UniversalType::Char { length: *length },
-                value: UniversalValue::Text(s.clone()),
+            (Type::Char { length }, Bson::String(s)) => TypedValue {
+                sync_type: Type::Char { length: *length },
+                value: Value::Text(s.clone()),
             },
-            (UniversalType::VarChar { length }, Bson::String(s)) => TypedValue {
-                sync_type: UniversalType::VarChar { length: *length },
-                value: UniversalValue::Text(s.clone()),
+            (Type::VarChar { length }, Bson::String(s)) => TypedValue {
+                sync_type: Type::VarChar { length: *length },
+                value: Value::Text(s.clone()),
             },
-            (UniversalType::Text, Bson::String(s)) => TypedValue::text(s),
+            (Type::Text, Bson::String(s)) => TypedValue::text(s),
 
             // Binary types
-            (UniversalType::Blob, Bson::Binary(bin)) => TypedValue {
-                sync_type: UniversalType::Blob,
-                value: UniversalValue::Bytes(bin.bytes.clone()),
+            (Type::Blob, Bson::Binary(bin)) => TypedValue {
+                sync_type: Type::Blob,
+                value: Value::Bytes(bin.bytes.clone()),
             },
-            (UniversalType::Bytes, Bson::Binary(bin)) => TypedValue::bytes(bin.bytes.clone()),
+            (Type::Bytes, Bson::Binary(bin)) => TypedValue::bytes(bin.bytes.clone()),
 
             // UUID
-            (UniversalType::Uuid, Bson::Binary(bin)) => {
+            (Type::Uuid, Bson::Binary(bin)) => {
                 if bin.subtype == bson::spec::BinarySubtype::Uuid
                     || bin.subtype == bson::spec::BinarySubtype::UuidOld
                 {
                     if let Ok(uuid) = uuid::Uuid::from_slice(&bin.bytes) {
                         TypedValue::uuid(uuid)
                     } else {
-                        TypedValue::null(UniversalType::Uuid)
+                        TypedValue::null(Type::Uuid)
                     }
                 } else {
-                    TypedValue::null(UniversalType::Uuid)
+                    TypedValue::null(Type::Uuid)
                 }
             }
             // UUID might also be stored as string
-            (UniversalType::Uuid, Bson::String(s)) => {
+            (Type::Uuid, Bson::String(s)) => {
                 if let Ok(uuid) = uuid::Uuid::parse_str(s) {
                     TypedValue::uuid(uuid)
                 } else {
-                    TypedValue::null(UniversalType::Uuid)
+                    TypedValue::null(Type::Uuid)
                 }
             }
 
             // Date/time types
-            (UniversalType::LocalDateTime, Bson::DateTime(dt)) => {
-                TypedValue::datetime(dt.to_chrono())
-            }
-            (UniversalType::LocalDateTimeNano, Bson::DateTime(dt)) => TypedValue {
-                sync_type: UniversalType::LocalDateTimeNano,
-                value: UniversalValue::LocalDateTime(dt.to_chrono()),
+            (Type::LocalDateTime, Bson::DateTime(dt)) => TypedValue::datetime(dt.to_chrono()),
+            (Type::LocalDateTimeNano, Bson::DateTime(dt)) => TypedValue {
+                sync_type: Type::LocalDateTimeNano,
+                value: Value::LocalDateTime(dt.to_chrono()),
             },
-            (UniversalType::ZonedDateTime, Bson::DateTime(dt)) => TypedValue {
-                sync_type: UniversalType::ZonedDateTime,
-                value: UniversalValue::LocalDateTime(dt.to_chrono()),
+            (Type::ZonedDateTime, Bson::DateTime(dt)) => TypedValue {
+                sync_type: Type::ZonedDateTime,
+                value: Value::LocalDateTime(dt.to_chrono()),
             },
 
             // Date stored as string
-            (UniversalType::Date, Bson::String(s)) => {
+            (Type::Date, Bson::String(s)) => {
                 if let Ok(dt) = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
                     let datetime = dt.and_hms_opt(0, 0, 0).unwrap();
                     let utc_dt = DateTime::<Utc>::from_naive_utc_and_offset(datetime, Utc);
                     TypedValue {
-                        sync_type: UniversalType::Date,
-                        value: UniversalValue::LocalDateTime(utc_dt),
+                        sync_type: Type::Date,
+                        value: Value::LocalDateTime(utc_dt),
                     }
                 } else {
-                    TypedValue::null(UniversalType::Date)
+                    TypedValue::null(Type::Date)
                 }
             }
 
             // Time stored as string
-            (UniversalType::Time, Bson::String(s)) => {
+            (Type::Time, Bson::String(s)) => {
                 if let Ok(time) = chrono::NaiveTime::parse_from_str(s, "%H:%M:%S") {
                     let datetime = chrono::NaiveDate::from_ymd_opt(1970, 1, 1)
                         .unwrap()
                         .and_time(time);
                     let utc_dt = DateTime::<Utc>::from_naive_utc_and_offset(datetime, Utc);
                     TypedValue {
-                        sync_type: UniversalType::Time,
-                        value: UniversalValue::LocalDateTime(utc_dt),
+                        sync_type: Type::Time,
+                        value: Value::LocalDateTime(utc_dt),
                     }
                 } else {
-                    TypedValue::null(UniversalType::Time)
+                    TypedValue::null(Type::Time)
                 }
             }
 
             // JSON types
-            (UniversalType::Json, Bson::Document(doc)) => {
+            (Type::Json, Bson::Document(doc)) => {
                 let json = bson_doc_to_json(doc);
                 TypedValue {
-                    sync_type: UniversalType::Json,
-                    value: UniversalValue::Json(Box::new(json)),
+                    sync_type: Type::Json,
+                    value: Value::Json(Box::new(json)),
                 }
             }
-            (UniversalType::Jsonb, Bson::Document(doc)) => {
+            (Type::Jsonb, Bson::Document(doc)) => {
                 let json = bson_doc_to_json(doc);
                 TypedValue {
-                    sync_type: UniversalType::Jsonb,
-                    value: UniversalValue::Json(Box::new(json)),
+                    sync_type: Type::Jsonb,
+                    value: Value::Json(Box::new(json)),
                 }
             }
 
             // Array types
-            (UniversalType::Array { element_type }, Bson::Array(arr)) => {
-                let values: Vec<UniversalValue> = arr
+            (Type::Array { element_type }, Bson::Array(arr)) => {
+                let values: Vec<Value> = arr
                     .iter()
                     .map(|v| {
                         let bv = BsonValueWithSchema::new(v.clone(), (**element_type).clone());
@@ -203,58 +201,58 @@ impl From<BsonValueWithSchema> for TypedValue {
             }
 
             // Set - stored as array in MongoDB
-            (UniversalType::Set { values: set_values }, Bson::Array(arr)) => {
-                let values: Vec<UniversalValue> = arr
+            (Type::Set { values: set_values }, Bson::Array(arr)) => {
+                let values: Vec<Value> = arr
                     .iter()
                     .filter_map(|v| {
                         if let Bson::String(s) = v {
-                            Some(UniversalValue::Text(s.clone()))
+                            Some(Value::Text(s.clone()))
                         } else {
                             None
                         }
                     })
                     .collect();
                 TypedValue {
-                    sync_type: UniversalType::Set {
+                    sync_type: Type::Set {
                         values: set_values.clone(),
                     },
-                    value: UniversalValue::Array {
+                    value: Value::Array {
                         elements: values,
-                        element_type: Box::new(UniversalType::Text),
+                        element_type: Box::new(Type::Text),
                     },
                 }
             }
 
             // Enum - stored as string
             (
-                UniversalType::Enum {
+                Type::Enum {
                     values: enum_values,
                 },
                 Bson::String(s),
             ) => TypedValue {
-                sync_type: UniversalType::Enum {
+                sync_type: Type::Enum {
                     values: enum_values.clone(),
                 },
-                value: UniversalValue::Text(s.clone()),
+                value: Value::Text(s.clone()),
             },
 
             // Geometry types - stored as GeoJSON document
-            (UniversalType::Geometry { geometry_type }, Bson::Document(doc)) => {
+            (Type::Geometry { geometry_type }, Bson::Document(doc)) => {
                 let json = bson_doc_to_json(doc);
                 TypedValue {
-                    sync_type: UniversalType::Geometry {
+                    sync_type: Type::Geometry {
                         geometry_type: geometry_type.clone(),
                     },
-                    value: UniversalValue::Json(Box::new(json)),
+                    value: Value::Json(Box::new(json)),
                 }
             }
 
             // Duration - parse ISO 8601 duration string (PTxS or PTx.xxxxxxxxxS format)
-            (UniversalType::Duration, Bson::String(s)) => {
+            (Type::Duration, Bson::String(s)) => {
                 if let Some(duration) = parse_iso8601_duration(s) {
                     TypedValue::duration(duration)
                 } else {
-                    TypedValue::null(UniversalType::Duration)
+                    TypedValue::null(Type::Duration)
                 }
             }
 
@@ -264,9 +262,9 @@ impl From<BsonValueWithSchema> for TypedValue {
     }
 }
 
-/// Convert a BSON document to a HashMap of UniversalValue.
+/// Convert a BSON document to a HashMap of Value.
 #[allow(dead_code)]
-fn bson_doc_to_hashmap(doc: &bson::Document) -> HashMap<String, UniversalValue> {
+fn bson_doc_to_hashmap(doc: &bson::Document) -> HashMap<String, Value> {
     let mut map = HashMap::new();
     for (key, value) in doc {
         map.insert(key.clone(), bson_to_generated_value(value));
@@ -298,72 +296,72 @@ fn bson_to_json(value: &Bson) -> serde_json::Value {
     }
 }
 
-/// Convert a BSON value to UniversalValue (without type context).
+/// Convert a BSON value to Value (without type context).
 #[allow(dead_code)]
-fn bson_to_generated_value(value: &Bson) -> UniversalValue {
+fn bson_to_generated_value(value: &Bson) -> Value {
     match value {
-        Bson::Null => UniversalValue::Null,
-        Bson::Boolean(b) => UniversalValue::Bool(*b),
-        Bson::Int32(i) => UniversalValue::Int32(*i),
-        Bson::Int64(i) => UniversalValue::Int64(*i),
-        Bson::Double(f) => UniversalValue::Float64(*f),
-        Bson::String(s) => UniversalValue::Text(s.clone()),
+        Bson::Null => Value::Null,
+        Bson::Boolean(b) => Value::Bool(*b),
+        Bson::Int32(i) => Value::Int32(*i),
+        Bson::Int64(i) => Value::Int64(*i),
+        Bson::Double(f) => Value::Float64(*f),
+        Bson::String(s) => Value::Text(s.clone()),
         Bson::Binary(bin) => {
             if bin.subtype == bson::spec::BinarySubtype::Uuid
                 || bin.subtype == bson::spec::BinarySubtype::UuidOld
             {
                 if let Ok(uuid) = uuid::Uuid::from_slice(&bin.bytes) {
-                    UniversalValue::Uuid(uuid)
+                    Value::Uuid(uuid)
                 } else {
-                    UniversalValue::Bytes(bin.bytes.clone())
+                    Value::Bytes(bin.bytes.clone())
                 }
             } else {
-                UniversalValue::Bytes(bin.bytes.clone())
+                Value::Bytes(bin.bytes.clone())
             }
         }
-        Bson::DateTime(dt) => UniversalValue::LocalDateTime(dt.to_chrono()),
-        Bson::Decimal128(d) => UniversalValue::Decimal {
+        Bson::DateTime(dt) => Value::LocalDateTime(dt.to_chrono()),
+        Bson::Decimal128(d) => Value::Decimal {
             value: d.to_string(),
             precision: 38,
             scale: 10,
         },
-        Bson::Array(arr) => UniversalValue::Array {
+        Bson::Array(arr) => Value::Array {
             elements: arr.iter().map(bson_to_generated_value).collect(),
-            element_type: Box::new(UniversalType::Text),
+            element_type: Box::new(Type::Text),
         },
-        Bson::Document(doc) => UniversalValue::Json(Box::new(bson_doc_to_json(doc))),
+        Bson::Document(doc) => Value::Json(Box::new(bson_doc_to_json(doc))),
         // ObjectId - convert to string
-        Bson::ObjectId(oid) => UniversalValue::Text(oid.to_hex()),
+        Bson::ObjectId(oid) => Value::Text(oid.to_hex()),
         // Timestamp - convert to DateTime
         Bson::Timestamp(ts) => {
             let secs = ts.time as i64;
             if let Some(dt) = DateTime::from_timestamp(secs, 0) {
-                UniversalValue::LocalDateTime(dt)
+                Value::LocalDateTime(dt)
             } else {
-                UniversalValue::Null
+                Value::Null
             }
         }
         // Regex - convert to string pattern
         Bson::RegularExpression(regex) => {
-            UniversalValue::Text(format!("/{}/{}", regex.pattern, regex.options))
+            Value::Text(format!("/{}/{}", regex.pattern, regex.options))
         }
         // JavaScript - convert to string
-        Bson::JavaScriptCode(code) => UniversalValue::Text(code.clone()),
-        Bson::JavaScriptCodeWithScope(code_scope) => UniversalValue::Text(code_scope.code.clone()),
+        Bson::JavaScriptCode(code) => Value::Text(code.clone()),
+        Bson::JavaScriptCodeWithScope(code_scope) => Value::Text(code_scope.code.clone()),
         // Symbol - convert to string
-        Bson::Symbol(s) => UniversalValue::Text(s.clone()),
+        Bson::Symbol(s) => Value::Text(s.clone()),
         // Undefined - treat as null
-        Bson::Undefined => UniversalValue::Null,
+        Bson::Undefined => Value::Null,
         // MinKey/MaxKey - convert to string
-        Bson::MinKey => UniversalValue::Text("$minKey".to_string()),
-        Bson::MaxKey => UniversalValue::Text("$maxKey".to_string()),
+        Bson::MinKey => Value::Text("$minKey".to_string()),
+        Bson::MaxKey => Value::Text("$maxKey".to_string()),
         // DbPointer is deprecated
-        Bson::DbPointer(_) => UniversalValue::Null,
+        Bson::DbPointer(_) => Value::Null,
     }
 }
 
 /// Extract a typed value from a BSON document field.
-pub fn extract_field(doc: &bson::Document, field: &str, sync_type: &UniversalType) -> TypedValue {
+pub fn extract_field(doc: &bson::Document, field: &str, sync_type: &Type) -> TypedValue {
     match doc.get(field) {
         Some(value) => BsonValueWithSchema::new(value.clone(), sync_type.clone()).to_typed_value(),
         None => TypedValue::null(sync_type.clone()),
@@ -373,7 +371,7 @@ pub fn extract_field(doc: &bson::Document, field: &str, sync_type: &UniversalTyp
 /// Convert a complete BSON document to a map of TypedValues using schema.
 pub fn document_to_typed_values(
     doc: &bson::Document,
-    schema: &[(String, UniversalType)],
+    schema: &[(String, Type)],
 ) -> HashMap<String, TypedValue> {
     let mut result = HashMap::new();
     for (field_name, sync_type) in schema {
@@ -392,37 +390,37 @@ mod tests {
 
     #[test]
     fn test_null_conversion() {
-        let bv = BsonValueWithSchema::new(Bson::Null, UniversalType::Text);
+        let bv = BsonValueWithSchema::new(Bson::Null, Type::Text);
         let tv = TypedValue::from(bv);
-        assert!(matches!(tv.value, UniversalValue::Null));
+        assert!(matches!(tv.value, Value::Null));
     }
 
     #[test]
     fn test_bool_conversion() {
-        let bv = BsonValueWithSchema::new(Bson::Boolean(true), UniversalType::Bool);
+        let bv = BsonValueWithSchema::new(Bson::Boolean(true), Type::Bool);
         let tv = TypedValue::from(bv);
-        assert!(matches!(tv.value, UniversalValue::Bool(true)));
+        assert!(matches!(tv.value, Value::Bool(true)));
     }
 
     #[test]
     fn test_int32_conversion() {
-        let bv = BsonValueWithSchema::new(Bson::Int32(42), UniversalType::Int32);
+        let bv = BsonValueWithSchema::new(Bson::Int32(42), Type::Int32);
         let tv = TypedValue::from(bv);
-        assert!(matches!(tv.value, UniversalValue::Int32(42)));
+        assert!(matches!(tv.value, Value::Int32(42)));
     }
 
     #[test]
     fn test_int64_conversion() {
-        let bv = BsonValueWithSchema::new(Bson::Int64(9876543210), UniversalType::Int64);
+        let bv = BsonValueWithSchema::new(Bson::Int64(9876543210), Type::Int64);
         let tv = TypedValue::from(bv);
-        assert!(matches!(tv.value, UniversalValue::Int64(9876543210)));
+        assert!(matches!(tv.value, Value::Int64(9876543210)));
     }
 
     #[test]
     fn test_double_conversion() {
-        let bv = BsonValueWithSchema::new(Bson::Double(1.23456), UniversalType::Float64);
+        let bv = BsonValueWithSchema::new(Bson::Double(1.23456), Type::Float64);
         let tv = TypedValue::from(bv);
-        if let UniversalValue::Float64(f) = tv.value {
+        if let Value::Float64(f) = tv.value {
             assert!((f - 1.23456).abs() < 0.00001);
         } else {
             panic!("Expected Float64");
@@ -433,13 +431,13 @@ mod tests {
     fn test_decimal_from_string() {
         let bv = BsonValueWithSchema::new(
             Bson::String("123.456".to_string()),
-            UniversalType::Decimal {
+            Type::Decimal {
                 precision: 10,
                 scale: 3,
             },
         );
         let tv = TypedValue::from(bv);
-        if let UniversalValue::Decimal {
+        if let Value::Decimal {
             value,
             precision,
             scale,
@@ -455,24 +453,20 @@ mod tests {
 
     #[test]
     fn test_string_conversion() {
-        let bv =
-            BsonValueWithSchema::new(Bson::String("hello world".to_string()), UniversalType::Text);
+        let bv = BsonValueWithSchema::new(Bson::String("hello world".to_string()), Type::Text);
         let tv = TypedValue::from(bv);
-        assert!(matches!(tv.value, UniversalValue::Text(ref s) if s == "hello world"));
+        assert!(matches!(tv.value, Value::Text(ref s) if s == "hello world"));
     }
 
     #[test]
     fn test_varchar_conversion() {
         let bv = BsonValueWithSchema::new(
             Bson::String("test".to_string()),
-            UniversalType::VarChar { length: 100 },
+            Type::VarChar { length: 100 },
         );
         let tv = TypedValue::from(bv);
-        assert!(matches!(
-            tv.sync_type,
-            UniversalType::VarChar { length: 100 }
-        ));
-        assert!(matches!(tv.value, UniversalValue::Text(ref s) if s == "test"));
+        assert!(matches!(tv.sync_type, Type::VarChar { length: 100 }));
+        assert!(matches!(tv.value, Value::Text(ref s) if s == "test"));
     }
 
     #[test]
@@ -481,9 +475,9 @@ mod tests {
             subtype: bson::spec::BinarySubtype::Generic,
             bytes: vec![0x01, 0x02, 0x03],
         };
-        let bv = BsonValueWithSchema::new(Bson::Binary(bin), UniversalType::Bytes);
+        let bv = BsonValueWithSchema::new(Bson::Binary(bin), Type::Bytes);
         let tv = TypedValue::from(bv);
-        assert!(matches!(tv.value, UniversalValue::Bytes(ref b) if *b == vec![0x01, 0x02, 0x03]));
+        assert!(matches!(tv.value, Value::Bytes(ref b) if *b == vec![0x01, 0x02, 0x03]));
     }
 
     #[test]
@@ -493,9 +487,9 @@ mod tests {
             subtype: bson::spec::BinarySubtype::Uuid,
             bytes: uuid.as_bytes().to_vec(),
         };
-        let bv = BsonValueWithSchema::new(Bson::Binary(bin), UniversalType::Uuid);
+        let bv = BsonValueWithSchema::new(Bson::Binary(bin), Type::Uuid);
         let tv = TypedValue::from(bv);
-        if let UniversalValue::Uuid(u) = tv.value {
+        if let Value::Uuid(u) = tv.value {
             assert_eq!(u, uuid);
         } else {
             panic!("Expected Uuid");
@@ -506,10 +500,10 @@ mod tests {
     fn test_uuid_from_string() {
         let bv = BsonValueWithSchema::new(
             Bson::String("550e8400-e29b-41d4-a716-446655440000".to_string()),
-            UniversalType::Uuid,
+            Type::Uuid,
         );
         let tv = TypedValue::from(bv);
-        if let UniversalValue::Uuid(u) = tv.value {
+        if let Value::Uuid(u) = tv.value {
             assert_eq!(u.to_string(), "550e8400-e29b-41d4-a716-446655440000");
         } else {
             panic!("Expected Uuid");
@@ -520,9 +514,9 @@ mod tests {
     fn test_datetime_conversion() {
         let dt = Utc.with_ymd_and_hms(2024, 6, 15, 10, 30, 0).unwrap();
         let bson_dt = BsonDateTime::from_chrono(dt);
-        let bv = BsonValueWithSchema::new(Bson::DateTime(bson_dt), UniversalType::LocalDateTime);
+        let bv = BsonValueWithSchema::new(Bson::DateTime(bson_dt), Type::LocalDateTime);
         let tv = TypedValue::from(bv);
-        if let UniversalValue::LocalDateTime(result_dt) = tv.value {
+        if let Value::LocalDateTime(result_dt) = tv.value {
             assert_eq!(result_dt.year(), 2024);
             assert_eq!(result_dt.month(), 6);
             assert_eq!(result_dt.day(), 15);
@@ -533,10 +527,9 @@ mod tests {
 
     #[test]
     fn test_date_from_string() {
-        let bv =
-            BsonValueWithSchema::new(Bson::String("2024-06-15".to_string()), UniversalType::Date);
+        let bv = BsonValueWithSchema::new(Bson::String("2024-06-15".to_string()), Type::Date);
         let tv = TypedValue::from(bv);
-        if let UniversalValue::LocalDateTime(dt) = tv.value {
+        if let Value::LocalDateTime(dt) = tv.value {
             assert_eq!(dt.format("%Y-%m-%d").to_string(), "2024-06-15");
         } else {
             panic!("Expected DateTime");
@@ -545,10 +538,9 @@ mod tests {
 
     #[test]
     fn test_time_from_string() {
-        let bv =
-            BsonValueWithSchema::new(Bson::String("14:30:45".to_string()), UniversalType::Time);
+        let bv = BsonValueWithSchema::new(Bson::String("14:30:45".to_string()), Type::Time);
         let tv = TypedValue::from(bv);
-        if let UniversalValue::LocalDateTime(dt) = tv.value {
+        if let Value::LocalDateTime(dt) = tv.value {
             assert_eq!(dt.format("%H:%M:%S").to_string(), "14:30:45");
         } else {
             panic!("Expected DateTime");
@@ -561,9 +553,9 @@ mod tests {
             "name": "test",
             "count": 42
         };
-        let bv = BsonValueWithSchema::new(Bson::Document(doc), UniversalType::Json);
+        let bv = BsonValueWithSchema::new(Bson::Document(doc), Type::Json);
         let tv = TypedValue::from(bv);
-        if let UniversalValue::Json(json_val) = tv.value {
+        if let Value::Json(json_val) = tv.value {
             if let serde_json::Value::Object(map) = json_val.as_ref() {
                 assert!(
                     matches!(map.get("name"), Some(serde_json::Value::String(s)) if s == "test")
@@ -584,16 +576,16 @@ mod tests {
         let arr = vec![Bson::Int32(1), Bson::Int32(2), Bson::Int32(3)];
         let bv = BsonValueWithSchema::new(
             Bson::Array(arr),
-            UniversalType::Array {
-                element_type: Box::new(UniversalType::Int32),
+            Type::Array {
+                element_type: Box::new(Type::Int32),
             },
         );
         let tv = TypedValue::from(bv);
-        if let UniversalValue::Array { elements, .. } = tv.value {
+        if let Value::Array { elements, .. } = tv.value {
             assert_eq!(elements.len(), 3);
-            assert!(matches!(elements[0], UniversalValue::Int32(1)));
-            assert!(matches!(elements[1], UniversalValue::Int32(2)));
-            assert!(matches!(elements[2], UniversalValue::Int32(3)));
+            assert!(matches!(elements[0], Value::Int32(1)));
+            assert!(matches!(elements[1], Value::Int32(2)));
+            assert!(matches!(elements[2], Value::Int32(3)));
         } else {
             panic!("Expected Array");
         }
@@ -604,12 +596,12 @@ mod tests {
         let arr = vec![Bson::String("a".to_string()), Bson::String("b".to_string())];
         let bv = BsonValueWithSchema::new(
             Bson::Array(arr),
-            UniversalType::Set {
+            Type::Set {
                 values: vec!["a".to_string(), "b".to_string(), "c".to_string()],
             },
         );
         let tv = TypedValue::from(bv);
-        if let UniversalValue::Array { elements, .. } = tv.value {
+        if let Value::Array { elements, .. } = tv.value {
             assert_eq!(elements.len(), 2);
         } else {
             panic!("Expected Array");
@@ -620,12 +612,12 @@ mod tests {
     fn test_enum_conversion() {
         let bv = BsonValueWithSchema::new(
             Bson::String("active".to_string()),
-            UniversalType::Enum {
+            Type::Enum {
                 values: vec!["active".to_string(), "inactive".to_string()],
             },
         );
         let tv = TypedValue::from(bv);
-        assert!(matches!(tv.value, UniversalValue::Text(ref s) if s == "active"));
+        assert!(matches!(tv.value, Value::Text(ref s) if s == "active"));
     }
 
     #[test]
@@ -636,12 +628,12 @@ mod tests {
         };
         let bv = BsonValueWithSchema::new(
             Bson::Document(doc),
-            UniversalType::Geometry {
+            Type::Geometry {
                 geometry_type: GeometryType::Point,
             },
         );
         let tv = TypedValue::from(bv);
-        if let UniversalValue::Json(json_val) = tv.value {
+        if let Value::Json(json_val) = tv.value {
             if let serde_json::Value::Object(map) = json_val.as_ref() {
                 assert!(
                     matches!(map.get("type"), Some(serde_json::Value::String(s)) if s == "Point")
@@ -660,14 +652,14 @@ mod tests {
             "name": "Alice",
             "age": 30
         };
-        let name = extract_field(&doc, "name", &UniversalType::Text);
-        assert!(matches!(name.value, UniversalValue::Text(ref s) if s == "Alice"));
+        let name = extract_field(&doc, "name", &Type::Text);
+        assert!(matches!(name.value, Value::Text(ref s) if s == "Alice"));
 
-        let age = extract_field(&doc, "age", &UniversalType::Int32);
-        assert!(matches!(age.value, UniversalValue::Int32(30)));
+        let age = extract_field(&doc, "age", &Type::Int32);
+        assert!(matches!(age.value, Value::Int32(30)));
 
-        let missing = extract_field(&doc, "missing", &UniversalType::Text);
-        assert!(matches!(missing.value, UniversalValue::Null));
+        let missing = extract_field(&doc, "missing", &Type::Text);
+        assert!(matches!(missing.value, Value::Null));
     }
 
     #[test]
@@ -678,21 +670,21 @@ mod tests {
             "score": 95.5
         };
         let schema = vec![
-            ("name".to_string(), UniversalType::Text),
-            ("active".to_string(), UniversalType::Bool),
-            ("score".to_string(), UniversalType::Float64),
+            ("name".to_string(), Type::Text),
+            ("active".to_string(), Type::Bool),
+            ("score".to_string(), Type::Float64),
         ];
 
         let values = document_to_typed_values(&doc, &schema);
         assert!(matches!(
             values.get("name").unwrap().value,
-            UniversalValue::Text(ref s) if s == "Bob"
+            Value::Text(ref s) if s == "Bob"
         ));
         assert!(matches!(
             values.get("active").unwrap().value,
-            UniversalValue::Bool(true)
+            Value::Bool(true)
         ));
-        if let UniversalValue::Float64(f) = values.get("score").unwrap().value {
+        if let Value::Float64(f) = values.get("score").unwrap().value {
             assert!((f - 95.5).abs() < 0.001);
         } else {
             panic!("Expected Float64");
@@ -702,17 +694,17 @@ mod tests {
     #[test]
     fn test_int64_to_int_conversion() {
         // MongoDB might return Int64 when we expect Int32
-        let bv = BsonValueWithSchema::new(Bson::Int64(100), UniversalType::Int32);
+        let bv = BsonValueWithSchema::new(Bson::Int64(100), Type::Int32);
         let tv = TypedValue::from(bv);
-        assert!(matches!(tv.value, UniversalValue::Int32(100)));
+        assert!(matches!(tv.value, Value::Int32(100)));
     }
 
     #[test]
     fn test_int32_to_bigint_conversion() {
         // MongoDB might return Int32 when we expect Int64
-        let bv = BsonValueWithSchema::new(Bson::Int32(100), UniversalType::Int64);
+        let bv = BsonValueWithSchema::new(Bson::Int32(100), Type::Int64);
         let tv = TypedValue::from(bv);
-        assert!(matches!(tv.value, UniversalValue::Int64(100)));
+        assert!(matches!(tv.value, Value::Int64(100)));
     }
 
     #[test]
@@ -722,7 +714,7 @@ mod tests {
             "_id": oid
         };
         let map = bson_doc_to_hashmap(&doc);
-        if let Some(UniversalValue::Text(s)) = map.get("_id") {
+        if let Some(Value::Text(s)) = map.get("_id") {
             assert_eq!(s, &oid.to_hex());
         } else {
             panic!("Expected String for ObjectId");

--- a/crates/mysql-binlog-source/src/change.rs
+++ b/crates/mysql-binlog-source/src/change.rs
@@ -8,17 +8,15 @@ use mysql_types::{
     apply_mysql_json_diffs_to_cell, binlog_cell_to_universal_value, BinlogColumnMeta,
     RowConversionConfig,
 };
-use sync_core::{
-    DatabaseSchema, UniversalChange, UniversalChangeOp, UniversalType, UniversalValue,
-};
+use sync_core::{Change, ChangeOp, DatabaseSchema, Type, Value};
 
-pub fn cdc_change_to_universal(
+pub fn cdc_to_change(
     change: &CdcChange,
     table_map: &TableMapEvent,
     column_names: &[String],
     schema: &DatabaseSchema,
     json_columns: &HashMap<String, Vec<String>>,
-) -> Result<UniversalChange> {
+) -> Result<Change> {
     let table_def = schema
         .get_table(&change.table)
         .ok_or_else(|| anyhow!("unknown table '{}' in schema", change.table))?;
@@ -27,15 +25,15 @@ pub fn cdc_change_to_universal(
     let config = row_conversion_config(schema, &change.table, json_columns);
 
     let update_merged;
-    let (op, cells): (UniversalChangeOp, &[CellValue]) = match &change.operation {
-        RowChange::Insert(values) => (UniversalChangeOp::Create, values.as_slice()),
+    let (op, cells): (ChangeOp, &[CellValue]) = match &change.operation {
+        RowChange::Insert(values) => (ChangeOp::Create, values.as_slice()),
         RowChange::Update { before, after } => {
             let pk_indices = pk_column_indices(column_names, &pk_columns);
             update_merged = merge_update_cells(before, after, &pk_indices)
                 .map_err(|e| anyhow!("apply partial JSON update: {e}"))?;
-            (UniversalChangeOp::Update, update_merged.as_slice())
+            (ChangeOp::Update, update_merged.as_slice())
         }
-        RowChange::Delete(values) => (UniversalChangeOp::Delete, values.as_slice()),
+        RowChange::Delete(values) => (ChangeOp::Delete, values.as_slice()),
     };
 
     if cells.len() != table_map.columns.len() {
@@ -70,17 +68,17 @@ pub fn cdc_change_to_universal(
     }
 
     let id = extract_primary_key(&values, &pk_columns)?;
-    let data = if op == UniversalChangeOp::Delete {
+    let data = if op == ChangeOp::Delete {
         None
     } else {
-        let fields: HashMap<String, UniversalValue> = values
+        let fields: HashMap<String, Value> = values
             .into_iter()
             .filter(|(name, _)| !pk_columns.contains(name))
             .collect();
         Some(fields)
     };
 
-    Ok(UniversalChange::new(op, change.table.clone(), id, data))
+    Ok(Change::new(op, change.table.clone(), id, data))
 }
 
 fn table_pk_columns(table_def: &sync_core::TableDefinition) -> Vec<String> {
@@ -101,8 +99,8 @@ fn row_conversion_config(
     if let Some(table_def) = schema.get_table(table) {
         for name in table_def.column_names() {
             match table_def.get_column_type(name) {
-                Some(UniversalType::Bool) => boolean_columns.push(name.to_string()),
-                Some(UniversalType::Set { .. }) => set_columns.push(name.to_string()),
+                Some(Type::Bool) => boolean_columns.push(name.to_string()),
+                Some(Type::Set { .. }) => set_columns.push(name.to_string()),
                 _ => {}
             }
         }
@@ -123,7 +121,7 @@ fn binlog_column_meta(
 ) -> BinlogColumnMeta {
     let is_binary = matches!(
         table_def.get_column_type(column_name),
-        Some(UniversalType::Blob | UniversalType::Bytes)
+        Some(Type::Blob | Type::Bytes)
     );
     BinlogColumnMeta::new(column_name, col_def.column_type, col_def.metadata.clone())
         .with_unsigned(col_def.unsigned)
@@ -134,10 +132,9 @@ fn binlog_column_meta(
 fn fix_set_value_from_bitmask(
     column_name: &str,
     table_def: &sync_core::TableDefinition,
-    value: UniversalValue,
-) -> UniversalValue {
-    let Some(UniversalType::Set { values: allowed }) = table_def.get_column_type(column_name)
-    else {
+    value: Value,
+) -> Value {
+    let Some(Type::Set { values: allowed }) = table_def.get_column_type(column_name) else {
         return value;
     };
     if allowed.is_empty() {
@@ -145,11 +142,9 @@ fn fix_set_value_from_bitmask(
     }
 
     let mask = match &value {
-        UniversalValue::Set { elements, .. } if elements.len() == 1 => {
-            elements[0].parse::<u64>().ok()
-        }
-        UniversalValue::Text(s) => s.parse::<u64>().ok(),
-        UniversalValue::VarChar { value: s, .. } => s.parse::<u64>().ok(),
+        Value::Set { elements, .. } if elements.len() == 1 => elements[0].parse::<u64>().ok(),
+        Value::Text(s) => s.parse::<u64>().ok(),
+        Value::VarChar { value: s, .. } => s.parse::<u64>().ok(),
         _ => None,
     };
     let Some(mask) = mask else {
@@ -162,7 +157,7 @@ fn fix_set_value_from_bitmask(
             selected.push(label.clone());
         }
     }
-    UniversalValue::Set {
+    Value::Set {
         elements: selected,
         allowed_values: allowed.clone(),
     }
@@ -177,10 +172,9 @@ fn fix_set_value_from_bitmask(
 fn fix_enum_value_from_index(
     column_name: &str,
     table_def: &sync_core::TableDefinition,
-    value: UniversalValue,
-) -> UniversalValue {
-    let Some(UniversalType::Enum { values: allowed }) = table_def.get_column_type(column_name)
-    else {
+    value: Value,
+) -> Value {
+    let Some(Type::Enum { values: allowed }) = table_def.get_column_type(column_name) else {
         return value;
     };
     if allowed.is_empty() {
@@ -188,14 +182,14 @@ fn fix_enum_value_from_index(
     }
 
     let index = match &value {
-        UniversalValue::Enum { value: s, .. } => s.parse::<i64>().ok(),
-        UniversalValue::Text(s) => s.parse::<i64>().ok(),
-        UniversalValue::VarChar { value: s, .. } => s.parse::<i64>().ok(),
-        UniversalValue::Char { value: s, .. } => s.parse::<i64>().ok(),
-        UniversalValue::Int8 { value, .. } => Some(i64::from(*value)),
-        UniversalValue::Int16(v) => Some(i64::from(*v)),
-        UniversalValue::Int32(v) => Some(i64::from(*v)),
-        UniversalValue::Int64(v) => Some(*v),
+        Value::Enum { value: s, .. } => s.parse::<i64>().ok(),
+        Value::Text(s) => s.parse::<i64>().ok(),
+        Value::VarChar { value: s, .. } => s.parse::<i64>().ok(),
+        Value::Char { value: s, .. } => s.parse::<i64>().ok(),
+        Value::Int8 { value, .. } => Some(i64::from(*value)),
+        Value::Int16(v) => Some(i64::from(*v)),
+        Value::Int32(v) => Some(i64::from(*v)),
+        Value::Int64(v) => Some(*v),
         _ => return value,
     };
     let Some(index) = index else {
@@ -223,7 +217,7 @@ fn fix_enum_value_from_index(
         return value;
     };
 
-    UniversalValue::Enum {
+    Value::Enum {
         value: label,
         allowed_values: allowed.clone(),
     }
@@ -264,10 +258,7 @@ fn merge_update_cells(
         .collect()
 }
 
-fn extract_primary_key(
-    values: &HashMap<String, UniversalValue>,
-    pk_columns: &[String],
-) -> Result<UniversalValue> {
+fn extract_primary_key(values: &HashMap<String, Value>, pk_columns: &[String]) -> Result<Value> {
     if pk_columns.is_empty() {
         return Err(anyhow!("table has no primary key"));
     }
@@ -286,9 +277,9 @@ fn extract_primary_key(
                 .ok_or_else(|| anyhow!("primary key column '{col}' missing"))?,
         );
     }
-    Ok(UniversalValue::Array {
+    Ok(Value::Array {
         elements: parts,
-        element_type: Box::new(UniversalType::Text),
+        element_type: Box::new(Type::Text),
     })
 }
 
@@ -297,10 +288,10 @@ mod tests {
     use super::*;
     use sync_core::{ColumnDefinition, TableDefinition};
 
-    fn table_with_column(name: &str, ty: UniversalType) -> TableDefinition {
+    fn table_with_column(name: &str, ty: Type) -> TableDefinition {
         TableDefinition::new(
             "t",
-            ColumnDefinition::new("id", UniversalType::Int32),
+            ColumnDefinition::new("id", Type::Int32),
             vec![ColumnDefinition::new(name, ty)],
         )
     }
@@ -309,15 +300,15 @@ mod tests {
     fn enum_index_maps_to_label() {
         let table = table_with_column(
             "status",
-            UniversalType::Enum {
+            Type::Enum {
                 values: vec!["active".into(), "inactive".into(), "pending".into()],
             },
         );
         // Binlog decodes ENUM as a 1-based index; the source layer sees it as Char.
-        let value = UniversalValue::char("2", 8);
+        let value = Value::char("2", 8);
         let fixed = fix_enum_value_from_index("status", &table, value);
         match fixed {
-            UniversalValue::Enum {
+            Value::Enum {
                 value,
                 allowed_values,
             } => {
@@ -332,13 +323,13 @@ mod tests {
     fn enum_index_zero_is_empty_value() {
         let table = table_with_column(
             "status",
-            UniversalType::Enum {
+            Type::Enum {
                 values: vec!["active".into(), "inactive".into()],
             },
         );
-        let fixed = fix_enum_value_from_index("status", &table, UniversalValue::Text("0".into()));
+        let fixed = fix_enum_value_from_index("status", &table, Value::Text("0".into()));
         match fixed {
-            UniversalValue::Enum { value, .. } => assert_eq!(value, ""),
+            Value::Enum { value, .. } => assert_eq!(value, ""),
             other => panic!("expected Enum, got {other:?}"),
         }
     }
@@ -347,26 +338,26 @@ mod tests {
     fn enum_index_out_of_range_keeps_raw_value() {
         let table = table_with_column(
             "status",
-            UniversalType::Enum {
+            Type::Enum {
                 values: vec!["active".into(), "inactive".into()],
             },
         );
-        let fixed = fix_enum_value_from_index("status", &table, UniversalValue::Text("9".into()));
-        assert_eq!(fixed, UniversalValue::Text("9".into()));
+        let fixed = fix_enum_value_from_index("status", &table, Value::Text("9".into()));
+        assert_eq!(fixed, Value::Text("9".into()));
     }
 
     #[test]
     fn enum_from_enum_variant_index() {
         let table = table_with_column(
             "status",
-            UniversalType::Enum {
+            Type::Enum {
                 values: vec!["red".into(), "green".into(), "blue".into()],
             },
         );
-        let value = UniversalValue::enum_value("3", vec![]);
+        let value = Value::enum_value("3", vec![]);
         let fixed = fix_enum_value_from_index("status", &table, value);
         match fixed {
-            UniversalValue::Enum { value, .. } => assert_eq!(value, "blue"),
+            Value::Enum { value, .. } => assert_eq!(value, "blue"),
             other => panic!("expected Enum, got {other:?}"),
         }
     }
@@ -375,15 +366,15 @@ mod tests {
     fn set_bitmask_maps_to_labels() {
         let table = table_with_column(
             "tags",
-            UniversalType::Set {
+            Type::Set {
                 values: vec!["read".into(), "write".into(), "execute".into()],
             },
         );
         // Binlog decodes SET as a numeric bitmask string; read|execute = bits 0 and 2 = 5.
-        let value = UniversalValue::set(vec!["5".into()], vec![]);
+        let value = Value::set(vec!["5".into()], vec![]);
         let fixed = fix_set_value_from_bitmask("tags", &table, value);
         match fixed {
-            UniversalValue::Set {
+            Value::Set {
                 elements,
                 allowed_values,
             } => {

--- a/crates/mysql-binlog-source/src/full_sync.rs
+++ b/crates/mysql-binlog-source/src/full_sync.rs
@@ -7,10 +7,10 @@ use anyhow::Result;
 use async_trait::async_trait;
 use checkpoint::Checkpoint;
 use checkpoint::{CheckpointStore, SyncManager, SyncPhase};
-use mysql_async::{prelude::*, Pool, Row};
+use mysql_async::{prelude::*, Pool, Row as MysqlRow};
 use mysql_types::{row_to_typed_values_with_config, RowConversionConfig};
 use surreal_sink::SurrealSink;
-use sync_core::{UniversalRow, UniversalValue};
+use sync_core::{Row, Value};
 use sync_transform::{
     run_source_runtime_with, ApplyOpts, Pipeline, RowChunkDriver, RowChunkSource, SourceRuntimeOpts,
 };
@@ -197,7 +197,7 @@ async fn collect_schema_info(
 ) -> Result<HashMap<String, TableSchemaInfo>> {
     let mut schema_info: HashMap<String, TableSchemaInfo> = HashMap::new();
 
-    let boolean_rows: Vec<Row> = conn
+    let boolean_rows: Vec<MysqlRow> = conn
         .query(
             r#"
             SELECT TABLE_NAME, COLUMN_NAME
@@ -218,7 +218,7 @@ async fn collect_schema_info(
             .push(column_name);
     }
 
-    let set_rows: Vec<Row> = conn
+    let set_rows: Vec<MysqlRow> = conn
         .query(
             r#"
             SELECT TABLE_NAME, COLUMN_NAME
@@ -256,7 +256,7 @@ async fn get_user_tables(
     if !from_opts.tables.is_empty() {
         return Ok(from_opts.tables.clone());
     }
-    let rows: Vec<Row> = conn
+    let rows: Vec<MysqlRow> = conn
         .query(format!(
             "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES \
              WHERE TABLE_SCHEMA = '{database}' \
@@ -275,7 +275,7 @@ pub async fn get_primary_key_columns(
     database: &str,
     table: &str,
 ) -> Result<Vec<String>> {
-    let rows: Vec<Row> = conn
+    let rows: Vec<MysqlRow> = conn
         .query(format!(
             "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE \
              WHERE TABLE_SCHEMA = '{database}' AND TABLE_NAME = '{table}' \
@@ -330,7 +330,7 @@ async fn migrate_table<S: SurrealSink>(
     if !pk_columns.is_empty() {
         if sync_opts.dry_run {
             let mut total_processed = 0usize;
-            let mut after: Option<Vec<UniversalValue>> = None;
+            let mut after: Option<Vec<Value>> = None;
             loop {
                 if cancel.is_cancelled() {
                     return Ok(total_processed);
@@ -362,7 +362,7 @@ async fn migrate_table<S: SurrealSink>(
             conn: &'a mut mysql_async::Conn,
             table_name: &'a str,
             pk_columns: &'a [String],
-            after: Option<Vec<UniversalValue>>,
+            after: Option<Vec<Value>>,
             batch_size: usize,
             config: &'a RowConversionConfig,
             cancel: &'a tokio_util::sync::CancellationToken,
@@ -371,7 +371,7 @@ async fn migrate_table<S: SurrealSink>(
 
         #[async_trait]
         impl RowChunkSource for MysqlKeysetChunks<'_> {
-            async fn next_chunk(&mut self) -> Result<Option<Vec<UniversalRow>>> {
+            async fn next_chunk(&mut self) -> Result<Option<Vec<Row>>> {
                 if self.exhausted || self.cancel.is_cancelled() {
                     self.exhausted = true;
                     return Ok(None);
@@ -427,7 +427,7 @@ async fn migrate_table<S: SurrealSink>(
             if cancel.is_cancelled() {
                 return Ok(total_processed);
             }
-            let rows: Vec<Row> = conn
+            let rows: Vec<MysqlRow> = conn
                 .query(format!(
                     "SELECT * FROM `{table_name}` LIMIT {batch_size} OFFSET {offset}"
                 ))
@@ -458,12 +458,12 @@ async fn migrate_table<S: SurrealSink>(
 
     #[async_trait]
     impl RowChunkSource for MysqlOffsetChunks<'_> {
-        async fn next_chunk(&mut self) -> Result<Option<Vec<UniversalRow>>> {
+        async fn next_chunk(&mut self) -> Result<Option<Vec<Row>>> {
             if self.exhausted || self.cancel.is_cancelled() {
                 self.exhausted = true;
                 return Ok(None);
             }
-            let rows: Vec<Row> = self
+            let rows: Vec<MysqlRow> = self
                 .conn
                 .query(format!(
                     "SELECT * FROM `{}` LIMIT {} OFFSET {}",
@@ -479,18 +479,13 @@ async fn migrate_table<S: SurrealSink>(
             for (i, row) in rows.iter().enumerate() {
                 let row_index = (self.offset + i) as u64;
                 let typed_values = row_to_typed_values_with_config(row, self.config)?;
-                let values: HashMap<String, UniversalValue> = typed_values
+                let values: HashMap<String, Value> = typed_values
                     .into_iter()
                     .map(|(k, tv)| (k, tv.value))
                     .collect();
-                let id = UniversalValue::Int64(row_index as i64);
+                let id = Value::Int64(row_index as i64);
                 let fields = values;
-                batch.push(UniversalRow::new(
-                    self.table_name.to_string(),
-                    row_index,
-                    id,
-                    fields,
-                ));
+                batch.push(Row::new(self.table_name.to_string(), row_index, id, fields));
             }
             let n = batch.len();
             self.offset += n;
@@ -523,10 +518,10 @@ pub async fn read_table_chunk(
     conn: &mut mysql_async::Conn,
     table_name: &str,
     pk_columns: &[String],
-    after: Option<&[UniversalValue]>,
+    after: Option<&[Value]>,
     limit: usize,
     config: &RowConversionConfig,
-) -> Result<Vec<UniversalRow>> {
+) -> Result<Vec<Row>> {
     surreal_sync_mysql_trigger_source::read_table_chunk(
         conn, table_name, pk_columns, after, limit, config,
     )

--- a/crates/mysql-binlog-source/src/incremental_sync.rs
+++ b/crates/mysql-binlog-source/src/incremental_sync.rs
@@ -22,7 +22,7 @@ use crate::catch_up::{
     effective_sync_tables, emit_catch_up_progress, read_catch_up_progress, CatchUpProgress,
     CoverageKind,
 };
-use crate::change::cdc_change_to_universal;
+use crate::change::cdc_to_change;
 use crate::checkpoint::BinlogCheckpoint;
 use crate::client::{
     connect_binlog_client_with_poll, get_pool_conn, new_mysql_pool_with_ssl, resolve_database,
@@ -429,7 +429,7 @@ where
                                 names
                             };
 
-                        let universal = cdc_change_to_universal(
+                        let universal = cdc_to_change(
                             &change,
                             &table_map,
                             &column_names,

--- a/crates/mysql-binlog-source/src/lib.rs
+++ b/crates/mysql-binlog-source/src/lib.rs
@@ -22,7 +22,7 @@ pub use catch_up::{
     effective_sync_tables, emit_catch_up_progress, max_binlog_checkpoint, read_catch_up_progress,
     tables_pending_snapshot, CatchUpProgress, CoverageKind, TableCoverageEntry,
 };
-pub use change::cdc_change_to_universal;
+pub use change::cdc_to_change;
 pub use checkpoint::{get_current_checkpoint, BinlogCheckpoint, BinlogReconciliationPos};
 pub use client::{connect_binlog_client, new_mysql_pool_with_ssl, parse_mysql_uri};
 pub use flavor::Flavor;

--- a/crates/mysql-binlog-source/src/schema.rs
+++ b/crates/mysql-binlog-source/src/schema.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use anyhow::Result;
 use mysql_async::prelude::*;
 use mysql_types::mysql_column_to_universal_type;
-use sync_core::{ColumnDefinition, DatabaseSchema, TableDefinition, UniversalType};
+use sync_core::{ColumnDefinition, DatabaseSchema, TableDefinition, Type};
 
 /// Collect schema information for all tables in the current database.
 pub async fn collect_mysql_database_schema(conn: &mut mysql_async::Conn) -> Result<DatabaseSchema> {
@@ -45,7 +45,7 @@ pub async fn collect_mysql_database_schema(conn: &mut mysql_async::Conn) -> Resu
         pk_columns.entry(table_name).or_default().push(column_name);
     }
 
-    let mut table_columns: HashMap<String, Vec<(String, UniversalType)>> = HashMap::new();
+    let mut table_columns: HashMap<String, Vec<(String, Type)>> = HashMap::new();
     for row in column_rows {
         let table_name: String = row.get(0).ok_or_else(|| anyhow::anyhow!("missing table"))?;
         let column_name: String = row
@@ -64,7 +64,7 @@ pub async fn collect_mysql_database_schema(conn: &mut mysql_async::Conn) -> Resu
             .get(&table_name)
             .is_some_and(|cols| cols.contains(&column_name));
         let universal_type = if is_json {
-            UniversalType::Json
+            Type::Json
         } else {
             mysql_column_to_universal_type(&data_type, &column_type, precision, scale)
         };
@@ -93,8 +93,7 @@ pub async fn collect_mysql_database_schema(conn: &mut mysql_async::Conn) -> Resu
             }
         }
 
-        let pk =
-            primary_key.unwrap_or_else(|| ColumnDefinition::new(pk_col_name, UniversalType::Int64));
+        let pk = primary_key.unwrap_or_else(|| ColumnDefinition::new(pk_col_name, Type::Int64));
         let mut table_def = TableDefinition::new(table_name, pk, other_columns);
         if pk_list.len() > 1 {
             table_def.composite_primary_key = Some(pk_list);

--- a/crates/mysql-binlog-source/src/watermark_source.rs
+++ b/crates/mysql-binlog-source/src/watermark_source.rs
@@ -13,9 +13,7 @@ use surreal_sync_interleaved_snapshot::{
     SnapshotCheckpointer, SnapshotSignal, SnapshotTransforms, TableSpec, WatermarkKind,
     WatermarkSource,
 };
-use sync_core::{
-    DatabaseSchema, UniversalChange, UniversalChangeOp, UniversalRow, UniversalType, UniversalValue,
-};
+use sync_core::{Change, ChangeOp, DatabaseSchema, Row, Type, Value};
 use tracing::info;
 use uuid::Uuid;
 
@@ -23,7 +21,7 @@ use crate::catch_up::{
     effective_sync_tables, emit_catch_up_progress, read_catch_up_progress, CatchUpProgress,
     CoverageKind,
 };
-use crate::change::cdc_change_to_universal;
+use crate::change::cdc_to_change;
 use crate::checkpoint::{get_current_checkpoint, BinlogCheckpoint, BinlogReconciliationPos};
 use crate::client::{
     connect_binlog_client, get_pool_conn, new_mysql_pool_with_ssl, resolve_database,
@@ -311,7 +309,7 @@ impl BinlogWatermarkSource {
             .column_names_by_table
             .get(&change.table)
             .ok_or_else(|| anyhow!("missing column names for table '{}'", change.table))?;
-        let universal = cdc_change_to_universal(
+        let universal = cdc_to_change(
             change,
             table_map,
             column_names,
@@ -388,7 +386,7 @@ impl WatermarkSource for BinlogWatermarkSource {
         table: &TableSpec,
         after: Option<&PkTuple>,
         limit: usize,
-    ) -> Result<Vec<UniversalRow>> {
+    ) -> Result<Vec<Row>> {
         let mut conn = self.pool.get_conn().await?;
         use_database(&mut conn, &self.database).await?;
         let config = self.conversion_config(&table.table);
@@ -599,13 +597,8 @@ fn signal_insert_to_event(
     Ok(Some(ReconciliationEvent {
         position: BinlogReconciliationPos::new(change.position.clone()),
         table: SIGNAL_TABLE.to_string(),
-        pk: PkTuple::new(vec![UniversalValue::Uuid(id)]),
-        change: UniversalChange::new(
-            UniversalChangeOp::Create,
-            SIGNAL_TABLE,
-            UniversalValue::Uuid(id),
-            None,
-        ),
+        pk: PkTuple::new(vec![Value::Uuid(id)]),
+        change: Change::new(ChangeOp::Create, SIGNAL_TABLE, Value::Uuid(id), None),
     }))
 }
 
@@ -622,44 +615,44 @@ fn signal_uuid_from_row(values: &[binlog_protocol::CellValue]) -> Result<Uuid> {
     Uuid::parse_str(&id_str).map_err(|e| anyhow!("invalid signal UUID '{id_str}': {e}"))
 }
 
-fn pk_tuple_from_primary_key(pk: &UniversalValue) -> PkTuple {
+fn pk_tuple_from_primary_key(pk: &Value) -> PkTuple {
     match pk {
-        UniversalValue::Array { elements, .. } => {
+        Value::Array { elements, .. } => {
             PkTuple::new(elements.iter().map(normalize_pk_value).collect())
         }
         single => PkTuple::new(vec![normalize_pk_value(single)]),
     }
 }
 
-fn normalize_pk_value(value: &UniversalValue) -> UniversalValue {
+fn normalize_pk_value(value: &Value) -> Value {
     match value {
-        UniversalValue::Int8 { value, .. } => UniversalValue::Int64(*value as i64),
-        UniversalValue::Int16(v) => UniversalValue::Int64(*v as i64),
-        UniversalValue::Int32(v) => UniversalValue::Int64(*v as i64),
-        UniversalValue::Int64(v) => UniversalValue::Int64(*v),
-        UniversalValue::Uuid(u) => UniversalValue::Uuid(*u),
-        UniversalValue::Char { value, .. } => UniversalValue::Text(value.clone()),
-        UniversalValue::VarChar { value, .. } => UniversalValue::Text(value.clone()),
-        UniversalValue::Text(s) => UniversalValue::Text(s.clone()),
+        Value::Int8 { value, .. } => Value::Int64(*value as i64),
+        Value::Int16(v) => Value::Int64(*v as i64),
+        Value::Int32(v) => Value::Int64(*v as i64),
+        Value::Int64(v) => Value::Int64(*v),
+        Value::Uuid(u) => Value::Uuid(*u),
+        Value::Char { value, .. } => Value::Text(value.clone()),
+        Value::VarChar { value, .. } => Value::Text(value.clone()),
+        Value::Text(s) => Value::Text(s.clone()),
         other => other.clone(),
     }
 }
 
 /// Re-insert composite primary key columns into row fields so the interleaved
 /// snapshot loop can recover keys via `PkTuple::from_row`.
-fn normalize_row_pk(row: &mut UniversalRow, pk_columns: &[String]) {
+fn normalize_row_pk(row: &mut Row, pk_columns: &[String]) {
     if pk_columns.len() == 1 {
         row.id = normalize_pk_value(&row.id);
         return;
     }
-    if let UniversalValue::Array { elements, .. } = &row.id {
-        let canonical: Vec<UniversalValue> = elements.iter().map(normalize_pk_value).collect();
+    if let Value::Array { elements, .. } = &row.id {
+        let canonical: Vec<Value> = elements.iter().map(normalize_pk_value).collect();
         for (col, value) in pk_columns.iter().zip(canonical.iter()) {
             row.fields.insert(col.clone(), value.clone());
         }
-        row.id = UniversalValue::Array {
+        row.id = Value::Array {
             elements: canonical,
-            element_type: Box::new(UniversalType::Text),
+            element_type: Box::new(Type::Text),
         };
     }
 }
@@ -744,9 +737,9 @@ fn conversions_from_schema(
         };
         for column in table.column_names() {
             match table.get_column_type(column) {
-                Some(UniversalType::Bool) => conv.boolean_columns.push(column.to_string()),
-                Some(UniversalType::Set { .. }) => conv.set_columns.push(column.to_string()),
-                Some(UniversalType::Json) if !conv.json_columns.iter().any(|c| c == column) => {
+                Some(Type::Bool) => conv.boolean_columns.push(column.to_string()),
+                Some(Type::Set { .. }) => conv.set_columns.push(column.to_string()),
+                Some(Type::Json) if !conv.json_columns.iter().any(|c| c == column) => {
                     conv.json_columns.push(column.to_string());
                 }
                 _ => {}

--- a/crates/mysql-binlog-source/tests/suite/common/mod.rs
+++ b/crates/mysql-binlog-source/tests/suite/common/mod.rs
@@ -15,9 +15,7 @@ use surreal_sync_mysql_binlog_source::{
     request_snapshot, BinlogWatermarkSource, SourceOpts, SIGNAL_TABLE,
 };
 use surreal_sync_mysql_trigger_source::read_table_chunk;
-use sync_core::{
-    UniversalChange, UniversalRelation, UniversalRelationChange, UniversalRow, UniversalValue,
-};
+use sync_core::{Change, Relation, RelationChange, Row, Value};
 use tokio::sync::Mutex;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -47,7 +45,7 @@ pub fn init_logging() {
         .try_init();
 }
 
-type SinkState = BTreeMap<String, BTreeMap<String, HashMap<String, UniversalValue>>>;
+type SinkState = BTreeMap<String, BTreeMap<String, HashMap<String, Value>>>;
 
 #[derive(Default)]
 pub struct MemSink {
@@ -71,17 +69,17 @@ impl MemSink {
     }
 }
 
-pub fn id_key(id: &UniversalValue) -> String {
+pub fn id_key(id: &Value) -> String {
     serde_json::to_string(&canon_scalar(id)).expect("serialize id")
 }
 
 #[async_trait::async_trait]
 impl SurrealSink for MemSink {
-    async fn write_universal_rows(&self, rows: &[UniversalRow]) -> Result<()> {
+    async fn write_rows(&self, rows: &[Row]) -> Result<()> {
         let mut state = self.state.lock().await;
         for row in rows {
             let pk_len = match &row.id {
-                UniversalValue::Array { elements, .. } => elements.len(),
+                Value::Array { elements, .. } => elements.len(),
                 _ => 1,
             };
             state
@@ -92,21 +90,21 @@ impl SurrealSink for MemSink {
         Ok(())
     }
 
-    async fn write_universal_relations(&self, _relations: &[UniversalRelation]) -> Result<()> {
+    async fn write_relations(&self, _relations: &[Relation]) -> Result<()> {
         Ok(())
     }
 
-    async fn apply_universal_change(&self, change: &UniversalChange) -> Result<()> {
+    async fn apply_change(&self, change: &Change) -> Result<()> {
         let mut state = self.state.lock().await;
         let key = canon_change_id_key(&change.id);
         match change.operation {
-            sync_core::UniversalChangeOp::Create | sync_core::UniversalChangeOp::Update => {
+            sync_core::ChangeOp::Create | sync_core::ChangeOp::Update => {
                 state
                     .entry(change.table.clone())
                     .or_default()
-                    .insert(key, change.data.clone().unwrap_or_default());
+                    .insert(key, change.fields.clone().unwrap_or_default());
             }
-            sync_core::UniversalChangeOp::Delete => {
+            sync_core::ChangeOp::Delete => {
                 if let Some(rows) = state.get_mut(&change.table) {
                     rows.remove(&key);
                 }
@@ -115,34 +113,31 @@ impl SurrealSink for MemSink {
         Ok(())
     }
 
-    async fn apply_universal_relation_change(
-        &self,
-        _change: &UniversalRelationChange,
-    ) -> Result<()> {
+    async fn apply_relation_change(&self, _change: &RelationChange) -> Result<()> {
         Ok(())
     }
 }
 
-fn canon_scalar(value: &UniversalValue) -> UniversalValue {
+fn canon_scalar(value: &Value) -> Value {
     match value {
-        UniversalValue::Int8 { value, .. } => UniversalValue::Int64(*value as i64),
-        UniversalValue::Int16(v) => UniversalValue::Int64(*v as i64),
-        UniversalValue::Int32(v) => UniversalValue::Int64(*v as i64),
-        UniversalValue::Int64(v) => UniversalValue::Int64(*v),
-        UniversalValue::Uuid(u) => UniversalValue::Uuid(*u),
-        UniversalValue::Char { value, .. } => UniversalValue::Text(value.clone()),
-        UniversalValue::VarChar { value, .. } => UniversalValue::Text(value.clone()),
-        UniversalValue::Text(s) => UniversalValue::Text(s.clone()),
+        Value::Int8 { value, .. } => Value::Int64(*value as i64),
+        Value::Int16(v) => Value::Int64(*v as i64),
+        Value::Int32(v) => Value::Int64(*v as i64),
+        Value::Int64(v) => Value::Int64(*v),
+        Value::Uuid(u) => Value::Uuid(*u),
+        Value::Char { value, .. } => Value::Text(value.clone()),
+        Value::VarChar { value, .. } => Value::Text(value.clone()),
+        Value::Text(s) => Value::Text(s.clone()),
         other => other.clone(),
     }
 }
 
-fn canon_change_id_key(id: &UniversalValue) -> String {
+fn canon_change_id_key(id: &Value) -> String {
     match id {
-        UniversalValue::Array { elements, .. } => {
-            let canon = UniversalValue::Array {
+        Value::Array { elements, .. } => {
+            let canon = Value::Array {
                 elements: elements.iter().map(canon_scalar).collect(),
-                element_type: Box::new(sync_core::UniversalType::Text),
+                element_type: Box::new(sync_core::Type::Text),
             };
             id_key(&canon)
         }
@@ -150,15 +145,15 @@ fn canon_change_id_key(id: &UniversalValue) -> String {
     }
 }
 
-fn canon_id_key(row: &UniversalRow, pk_len: usize) -> String {
+fn canon_id_key(row: &Row, pk_len: usize) -> String {
     if pk_len == 1 {
         return id_key(&canon_scalar(&row.id));
     }
     match &row.id {
-        UniversalValue::Array { elements, .. } => {
-            let canon = UniversalValue::Array {
+        Value::Array { elements, .. } => {
+            let canon = Value::Array {
                 elements: elements.iter().map(canon_scalar).collect(),
-                element_type: Box::new(sync_core::UniversalType::Text),
+                element_type: Box::new(sync_core::Type::Text),
             };
             id_key(&canon)
         }
@@ -175,7 +170,7 @@ async fn source_value_map(
     let mut conn = pool.get_conn().await?;
     let config = RowConversionConfig::default();
     let mut out = BTreeMap::new();
-    let mut after: Option<Vec<UniversalValue>> = None;
+    let mut after: Option<Vec<Value>> = None;
     loop {
         let chunk =
             read_table_chunk(&mut conn, table, pk_columns, after.as_deref(), 64, &config).await?;
@@ -215,7 +210,7 @@ async fn drain_stream(source: &mut BinlogWatermarkSource, sink: &MemSink) -> Res
             if event.table == SIGNAL_TABLE {
                 continue;
             }
-            sink.apply_universal_change(&event.change).await?;
+            sink.apply_change(&event.change).await?;
         }
     }
     Ok(())

--- a/crates/mysql-binlog-source/tests/suite/conversion.rs
+++ b/crates/mysql-binlog-source/tests/suite/conversion.rs
@@ -1,4 +1,4 @@
-//! INSERT -> binlog -> `cdc_change_to_universal` over unified-dataset-style columns.
+//! INSERT -> binlog -> `cdc_to_change` over unified-dataset-style columns.
 
 use std::collections::HashMap;
 use std::time::Duration;
@@ -6,12 +6,9 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use binlog_protocol::{BinlogClient, CdcChange, EventBody, ReplicaOptions, SslMode};
 use mysql_async::prelude::*;
-use surreal_sync_mysql_binlog_source::cdc_change_to_universal;
+use surreal_sync_mysql_binlog_source::cdc_to_change;
 use surreal_sync_mysql_trigger_source::json_columns::get_json_columns;
-use sync_core::{
-    ColumnDefinition, DatabaseSchema, TableDefinition, UniversalChangeOp, UniversalType,
-    UniversalValue,
-};
+use sync_core::{ChangeOp, ColumnDefinition, DatabaseSchema, TableDefinition, Type, Value};
 
 async fn connect_client(
     conn_str: &str,
@@ -129,17 +126,17 @@ async fn wait_for_change(
 fn enum_set_schema() -> DatabaseSchema {
     DatabaseSchema::new(vec![TableDefinition::new(
         "enum_set_tbl",
-        ColumnDefinition::new("id", UniversalType::Int32),
+        ColumnDefinition::new("id", Type::Int32),
         vec![
             ColumnDefinition::new(
                 "status",
-                UniversalType::Enum {
+                Type::Enum {
                     values: vec!["active".into(), "inactive".into(), "pending".into()],
                 },
             ),
             ColumnDefinition::new(
                 "tags",
-                UniversalType::Set {
+                Type::Set {
                     values: vec!["read".into(), "write".into(), "execute".into()],
                 },
             ),
@@ -148,7 +145,7 @@ fn enum_set_schema() -> DatabaseSchema {
 }
 
 /// End-to-end check that ENUM labels (not the raw 1-based index) and SET labels
-/// (not the raw bitmask) survive the binlog -> `cdc_change_to_universal` path,
+/// (not the raw bitmask) survive the binlog -> `cdc_to_change` path,
 /// across both INSERT and UPDATE.
 #[tokio::test]
 async fn binlog_enum_and_set_convert_to_labels() -> Result<()> {
@@ -189,13 +186,12 @@ async fn binlog_enum_and_set_convert_to_labels() -> Result<()> {
     .await?;
 
     let (change, table_map) = wait_for_change(&mut client, "enum_set_tbl").await?;
-    let universal =
-        cdc_change_to_universal(&change, &table_map, &column_names, &schema, &json_columns)?;
-    assert_eq!(universal.operation, UniversalChangeOp::Create);
-    let data = universal.data.context("expected INSERT row data")?;
+    let universal = cdc_to_change(&change, &table_map, &column_names, &schema, &json_columns)?;
+    assert_eq!(universal.operation, ChangeOp::Create);
+    let data = universal.fields.context("expected INSERT row data")?;
 
     match data.get("status").context("missing status")? {
-        UniversalValue::Enum {
+        Value::Enum {
             value,
             allowed_values,
         } => {
@@ -205,7 +201,7 @@ async fn binlog_enum_and_set_convert_to_labels() -> Result<()> {
         other => panic!("expected Enum for status, got {other:?}"),
     }
     match data.get("tags").context("missing tags")? {
-        UniversalValue::Set {
+        Value::Set {
             elements,
             allowed_values,
         } => {
@@ -227,16 +223,15 @@ async fn binlog_enum_and_set_convert_to_labels() -> Result<()> {
     .await?;
 
     let (change, table_map) = wait_for_change(&mut client, "enum_set_tbl").await?;
-    let universal =
-        cdc_change_to_universal(&change, &table_map, &column_names, &schema, &json_columns)?;
-    assert_eq!(universal.operation, UniversalChangeOp::Update);
-    let data = universal.data.context("expected UPDATE row data")?;
+    let universal = cdc_to_change(&change, &table_map, &column_names, &schema, &json_columns)?;
+    assert_eq!(universal.operation, ChangeOp::Update);
+    let data = universal.fields.context("expected UPDATE row data")?;
     match data.get("status").context("missing status")? {
-        UniversalValue::Enum { value, .. } => assert_eq!(value, "pending"),
+        Value::Enum { value, .. } => assert_eq!(value, "pending"),
         other => panic!("expected Enum for status, got {other:?}"),
     }
     match data.get("tags").context("missing tags")? {
-        UniversalValue::Set { elements, .. } => {
+        Value::Set { elements, .. } => {
             assert_eq!(elements, &vec!["write".to_string()]);
         }
         other => panic!("expected Set for tags, got {other:?}"),
@@ -249,25 +244,25 @@ async fn binlog_enum_and_set_convert_to_labels() -> Result<()> {
 
 fn users_schema() -> DatabaseSchema {
     let columns = vec![
-        ColumnDefinition::new("name", UniversalType::VarChar { length: 255 }),
-        ColumnDefinition::nullable("email", UniversalType::VarChar { length: 255 }),
-        ColumnDefinition::nullable("age", UniversalType::Int32),
-        ColumnDefinition::new("active", UniversalType::Bool),
+        ColumnDefinition::new("name", Type::VarChar { length: 255 }),
+        ColumnDefinition::nullable("email", Type::VarChar { length: 255 }),
+        ColumnDefinition::nullable("age", Type::Int32),
+        ColumnDefinition::new("active", Type::Bool),
         ColumnDefinition::new(
             "account_balance",
-            UniversalType::Decimal {
+            Type::Decimal {
                 precision: 19,
                 scale: 5,
             },
         ),
-        ColumnDefinition::nullable("score", UniversalType::Float64),
-        ColumnDefinition::nullable("metadata", UniversalType::Json),
-        ColumnDefinition::nullable("created_at", UniversalType::LocalDateTime),
-        ColumnDefinition::nullable("reference_id", UniversalType::VarChar { length: 255 }),
+        ColumnDefinition::nullable("score", Type::Float64),
+        ColumnDefinition::nullable("metadata", Type::Json),
+        ColumnDefinition::nullable("created_at", Type::LocalDateTime),
+        ColumnDefinition::nullable("reference_id", Type::VarChar { length: 255 }),
     ];
     DatabaseSchema::new(vec![TableDefinition::new(
         "all_types_users",
-        ColumnDefinition::new("id", UniversalType::VarChar { length: 255 }),
+        ColumnDefinition::new("id", Type::VarChar { length: 255 }),
         columns,
     )])
 }
@@ -332,12 +327,11 @@ async fn binlog_insert_converts_unified_users_columns() -> Result<()> {
 
     let (change, table_map) = wait_for_users_insert(&mut client).await?;
 
-    let universal =
-        cdc_change_to_universal(&change, &table_map, &column_names, &schema, &json_columns)?;
+    let universal = cdc_to_change(&change, &table_map, &column_names, &schema, &json_columns)?;
 
     assert_eq!(universal.table, "all_types_users");
-    assert_eq!(universal.operation, UniversalChangeOp::Create);
-    let data = universal.data.context("expected row data")?;
+    assert_eq!(universal.operation, ChangeOp::Create);
+    let data = universal.fields.context("expected row data")?;
     assert_eq!(
         data.get("name").and_then(|v| v.as_str()),
         Some("Alice Example")
@@ -410,10 +404,9 @@ async fn mariadb_binlog_insert_converts_unified_users_columns() -> Result<()> {
 
     let (change, table_map) = wait_for_users_insert(&mut client).await?;
 
-    let universal =
-        cdc_change_to_universal(&change, &table_map, &column_names, &schema, &json_columns)?;
-    assert_eq!(universal.operation, UniversalChangeOp::Create);
-    assert!(universal.data.is_some());
+    let universal = cdc_to_change(&change, &table_map, &column_names, &schema, &json_columns)?;
+    assert_eq!(universal.operation, ChangeOp::Create);
+    assert!(universal.fields.is_some());
 
     drop(conn);
     pool.disconnect().await?;

--- a/crates/mysql-binlog-source/tests/suite/integration.rs
+++ b/crates/mysql-binlog-source/tests/suite/integration.rs
@@ -11,7 +11,7 @@ use surreal_sync_mysql_binlog_source::{
     run_replication_tail_with_checkpoints, BinlogCheckpoint, CatchUpProgress,
     ReplicationTailOptions, SourceOpts,
 };
-use sync_core::{UniversalChange, UniversalValue};
+use sync_core::{Change, Value};
 
 struct MemSink {
     changes: std::sync::Mutex<Vec<String>>,
@@ -19,30 +19,20 @@ struct MemSink {
 
 #[async_trait::async_trait]
 impl surreal_sink::SurrealSink for MemSink {
-    async fn write_universal_rows(&self, rows: &[sync_core::UniversalRow]) -> anyhow::Result<()> {
+    async fn write_rows(&self, rows: &[sync_core::Row]) -> anyhow::Result<()> {
         // Homogeneous Update upserts coalesce here; mirror observations.
         let mut changes = self.changes.lock().expect("lock");
         for row in rows {
-            changes.push(format!(
-                "{:?}:{}",
-                sync_core::UniversalChangeOp::Update,
-                row.table
-            ));
+            changes.push(format!("{:?}:{}", sync_core::ChangeOp::Update, row.table));
         }
         Ok(())
     }
 
-    async fn write_universal_relations(
-        &self,
-        _relations: &[sync_core::UniversalRelation],
-    ) -> anyhow::Result<()> {
+    async fn write_relations(&self, _relations: &[sync_core::Relation]) -> anyhow::Result<()> {
         Ok(())
     }
 
-    async fn apply_universal_change(
-        &self,
-        change: &sync_core::UniversalChange,
-    ) -> anyhow::Result<()> {
+    async fn apply_change(&self, change: &sync_core::Change) -> anyhow::Result<()> {
         self.changes
             .lock()
             .expect("lock")
@@ -50,25 +40,25 @@ impl surreal_sink::SurrealSink for MemSink {
         Ok(())
     }
 
-    async fn apply_universal_relation_change(
+    async fn apply_relation_change(
         &self,
-        _change: &sync_core::UniversalRelationChange,
+        _change: &sync_core::RelationChange,
     ) -> anyhow::Result<()> {
         Ok(())
     }
 }
 
 struct CaptureSink {
-    changes: std::sync::Mutex<Vec<UniversalChange>>,
+    changes: std::sync::Mutex<Vec<Change>>,
 }
 
 #[async_trait::async_trait]
 impl surreal_sink::SurrealSink for CaptureSink {
-    async fn write_universal_rows(&self, rows: &[sync_core::UniversalRow]) -> anyhow::Result<()> {
+    async fn write_rows(&self, rows: &[sync_core::Row]) -> anyhow::Result<()> {
         // Homogeneous Update upserts coalesce here; mirror into `changes`.
         let mut changes = self.changes.lock().expect("lock");
         for row in rows {
-            changes.push(UniversalChange::update(
+            changes.push(Change::update(
                 row.table.clone(),
                 row.id.clone(),
                 row.fields.clone(),
@@ -77,21 +67,18 @@ impl surreal_sink::SurrealSink for CaptureSink {
         Ok(())
     }
 
-    async fn write_universal_relations(
-        &self,
-        _relations: &[sync_core::UniversalRelation],
-    ) -> anyhow::Result<()> {
+    async fn write_relations(&self, _relations: &[sync_core::Relation]) -> anyhow::Result<()> {
         Ok(())
     }
 
-    async fn apply_universal_change(&self, change: &UniversalChange) -> anyhow::Result<()> {
+    async fn apply_change(&self, change: &Change) -> anyhow::Result<()> {
         self.changes.lock().expect("lock").push(change.clone());
         Ok(())
     }
 
-    async fn apply_universal_relation_change(
+    async fn apply_relation_change(
         &self,
-        _change: &sync_core::UniversalRelationChange,
+        _change: &sync_core::RelationChange,
     ) -> anyhow::Result<()> {
         Ok(())
     }
@@ -253,8 +240,8 @@ async fn mysql_partial_json_update_is_applied_as_full_json_change() -> Result<()
         .iter()
         .find(|change| change.table == "docs")
         .expect("expected docs update");
-    let data = update.data.as_ref().expect("update data");
-    let Some(UniversalValue::Json(json)) = data.get("doc") else {
+    let data = update.fields.as_ref().expect("update data");
+    let Some(Value::Json(json)) = data.get("doc") else {
         panic!("expected JSON doc value, got {:?}", data.get("doc"));
     };
     assert_eq!(json["nested"]["count"], serde_json::json!(42));
@@ -492,10 +479,10 @@ async fn ddl_refreshes_schema_before_subsequent_rows() -> Result<()> {
     let changes = sink.changes.lock().expect("lock").clone();
     let status = changes
         .iter()
-        .find_map(|change| change.data.as_ref()?.get("status"))
+        .find_map(|change| change.fields.as_ref()?.get("status"))
         .expect("status field should be present after DDL refresh");
     match status {
-        UniversalValue::Enum { value, .. } => assert_eq!(value, "done"),
+        Value::Enum { value, .. } => assert_eq!(value, "done"),
         other => panic!("expected refreshed ENUM label, got {other:?}"),
     }
 
@@ -1155,9 +1142,9 @@ async fn start_at_head_checkpoint_resumes_from_current_position() -> Result<()> 
         .iter()
         .filter(|c| c.table == "widgets")
         .filter_map(|c| match &c.id {
-            UniversalValue::Int64(v) => Some(*v),
-            UniversalValue::Int32(v) => Some(*v as i64),
-            UniversalValue::Int8 { value, .. } => Some(*value as i64),
+            Value::Int64(v) => Some(*v),
+            Value::Int32(v) => Some(*v as i64),
+            Value::Int8 { value, .. } => Some(*value as i64),
             _ => None,
         })
         .collect();

--- a/crates/mysql-binlog-source/tests/suite/transforms.rs
+++ b/crates/mysql-binlog-source/tests/suite/transforms.rs
@@ -11,12 +11,12 @@ use surreal_sync_mysql_binlog_source::{
     run_full_sync_cancellable_with_transforms, run_replication_tail_with_transforms,
     BinlogCheckpoint, ReplicationTailOptions, SourceOpts, SyncOpts,
 };
-use sync_core::{UniversalChange, UniversalRow, UniversalValue};
+use sync_core::{Change, Row, Value};
 use sync_transform::{ApplyOpts, ChildStdioMode, ExternalTransform, FramerKind, Pipeline};
 
 struct CaptureSink {
-    changes: Mutex<Vec<UniversalChange>>,
-    rows: Mutex<Vec<UniversalRow>>,
+    changes: Mutex<Vec<Change>>,
+    rows: Mutex<Vec<Row>>,
 }
 
 impl CaptureSink {
@@ -30,13 +30,13 @@ impl CaptureSink {
 
 #[async_trait::async_trait]
 impl SurrealSink for CaptureSink {
-    async fn write_universal_rows(&self, rows: &[UniversalRow]) -> anyhow::Result<()> {
+    async fn write_rows(&self, rows: &[Row]) -> anyhow::Result<()> {
         // Homogeneous Update upserts coalesce here; mirror into `changes` for
         // incremental assertions (full sync still reads `rows`).
         self.rows.lock().expect("lock").extend(rows.iter().cloned());
         let mut changes = self.changes.lock().expect("lock");
         for row in rows {
-            changes.push(UniversalChange::update(
+            changes.push(Change::update(
                 row.table.clone(),
                 row.id.clone(),
                 row.fields.clone(),
@@ -45,21 +45,18 @@ impl SurrealSink for CaptureSink {
         Ok(())
     }
 
-    async fn write_universal_relations(
-        &self,
-        _relations: &[sync_core::UniversalRelation],
-    ) -> anyhow::Result<()> {
+    async fn write_relations(&self, _relations: &[sync_core::Relation]) -> anyhow::Result<()> {
         Ok(())
     }
 
-    async fn apply_universal_change(&self, change: &UniversalChange) -> anyhow::Result<()> {
+    async fn apply_change(&self, change: &Change) -> anyhow::Result<()> {
         self.changes.lock().expect("lock").push(change.clone());
         Ok(())
     }
 
-    async fn apply_universal_relation_change(
+    async fn apply_relation_change(
         &self,
-        _change: &sync_core::UniversalRelationChange,
+        _change: &sync_core::RelationChange,
     ) -> anyhow::Result<()> {
         Ok(())
     }
@@ -107,17 +104,17 @@ fn ensure_fixture_worker() -> PathBuf {
     path
 }
 
-fn name_field(change: &UniversalChange) -> Option<String> {
-    let data = change.data.as_ref()?;
+fn name_field(change: &Change) -> Option<String> {
+    let data = change.fields.as_ref()?;
     match data.get("name")? {
-        UniversalValue::VarChar { value, .. } | UniversalValue::Text(value) => Some(value.clone()),
+        Value::VarChar { value, .. } | Value::Text(value) => Some(value.clone()),
         other => panic!("unexpected name value: {other:?}"),
     }
 }
 
-fn row_name_field(row: &UniversalRow) -> Option<String> {
+fn row_name_field(row: &Row) -> Option<String> {
     match row.fields.get("name")? {
-        UniversalValue::VarChar { value, .. } | UniversalValue::Text(value) => Some(value.clone()),
+        Value::VarChar { value, .. } | Value::Text(value) => Some(value.clone()),
         other => panic!("unexpected name value: {other:?}"),
     }
 }

--- a/crates/mysql-trigger-source/src/full_sync.rs
+++ b/crates/mysql-trigger-source/src/full_sync.rs
@@ -1,18 +1,18 @@
 //! MySQL full sync implementation using TypedValue conversion path.
 //!
 //! This module uses the unified type conversion flow:
-//! MySQL Row → TypedValue (mysql-types) → UniversalRow (sync-core) → SurrealDB (surreal sink)
+//! MySQL MysqlRow → TypedValue (mysql-types) → Row (sync-core) → SurrealDB (surreal sink)
 
 use crate::{SourceOpts, SyncOpts};
 use anyhow::Result;
 use async_trait::async_trait;
 use checkpoint::{Checkpoint, CheckpointStore, SyncManager, SyncPhase};
-use mysql_async::{prelude::*, Params, Row, Value};
+use mysql_async::{prelude::*, Params, Row as MysqlRow, Value as MysqlValue};
 use mysql_types::{row_to_typed_values_with_config, RowConversionConfig};
 use std::collections::HashMap;
 use std::sync::Arc;
 use surreal_sink::SurrealSink;
-use sync_core::{UniversalRow, UniversalType, UniversalValue};
+use sync_core::{Row, Type, Value};
 use sync_transform::{
     run_source_runtime_with, ApplyOpts, Pipeline, RowChunkDriver, RowChunkSource, SourceRuntimeOpts,
 };
@@ -202,7 +202,7 @@ async fn collect_schema_info(
     let mut schema_info: HashMap<String, TableSchemaInfo> = HashMap::new();
 
     // Query to find TINYINT(1) columns which are typically boolean
-    let boolean_rows: Vec<Row> = conn
+    let boolean_rows: Vec<MysqlRow> = conn
         .query(
             r#"
             SELECT TABLE_NAME, COLUMN_NAME
@@ -226,7 +226,7 @@ async fn collect_schema_info(
     }
 
     // Query to find SET columns
-    let set_rows: Vec<Row> = conn
+    let set_rows: Vec<MysqlRow> = conn
         .query(
             r#"
             SELECT TABLE_NAME, COLUMN_NAME
@@ -261,7 +261,7 @@ async fn collect_schema_info(
 
 /// Get list of user tables (excluding system tables and our audit table)
 async fn get_user_tables(conn: &mut mysql_async::Conn, database: &str) -> Result<Vec<String>> {
-    let rows: Vec<Row> = conn
+    let rows: Vec<MysqlRow> = conn
         .query(format!(
             "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES \
              WHERE TABLE_SCHEMA = '{database}' \
@@ -285,7 +285,7 @@ pub async fn get_primary_key_columns(
     database: &str,
     table: &str,
 ) -> Result<Vec<String>> {
-    let rows: Vec<Row> = conn
+    let rows: Vec<MysqlRow> = conn
         .query(format!(
             "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE \
              WHERE TABLE_SCHEMA = '{database}' AND TABLE_NAME = '{table}' \
@@ -359,7 +359,7 @@ async fn migrate_table<S: SurrealSink>(
     if !pk_columns.is_empty() {
         if opts.sync_opts.dry_run {
             let mut total_processed = 0usize;
-            let mut after: Option<Vec<UniversalValue>> = None;
+            let mut after: Option<Vec<Value>> = None;
             loop {
                 let chunk = read_table_chunk(
                     conn,
@@ -388,7 +388,7 @@ async fn migrate_table<S: SurrealSink>(
             conn: &'a mut mysql_async::Conn,
             table_name: &'a str,
             pk_columns: &'a [String],
-            after: Option<Vec<UniversalValue>>,
+            after: Option<Vec<Value>>,
             batch_size: usize,
             config: &'a RowConversionConfig,
             exhausted: bool,
@@ -396,7 +396,7 @@ async fn migrate_table<S: SurrealSink>(
 
         #[async_trait]
         impl RowChunkSource for MysqlKeysetChunks<'_> {
-            async fn next_chunk(&mut self) -> Result<Option<Vec<UniversalRow>>> {
+            async fn next_chunk(&mut self) -> Result<Option<Vec<Row>>> {
                 if self.exhausted {
                     return Ok(None);
                 }
@@ -451,7 +451,7 @@ async fn migrate_table<S: SurrealSink>(
         let mut total_processed = 0usize;
         let mut offset = 0usize;
         loop {
-            let rows: Vec<Row> = conn
+            let rows: Vec<MysqlRow> = conn
                 .query(format!(
                     "SELECT * FROM `{table_name}` LIMIT {batch_size} OFFSET {offset}"
                 ))
@@ -482,11 +482,11 @@ async fn migrate_table<S: SurrealSink>(
 
     #[async_trait]
     impl RowChunkSource for MysqlOffsetChunks<'_> {
-        async fn next_chunk(&mut self) -> Result<Option<Vec<UniversalRow>>> {
+        async fn next_chunk(&mut self) -> Result<Option<Vec<Row>>> {
             if self.exhausted {
                 return Ok(None);
             }
-            let rows: Vec<Row> = self
+            let rows: Vec<MysqlRow> = self
                 .conn
                 .query(format!(
                     "SELECT * FROM `{}` LIMIT {} OFFSET {}",
@@ -502,14 +502,14 @@ async fn migrate_table<S: SurrealSink>(
             for (i, row) in rows.iter().enumerate() {
                 let row_index = (self.offset + i) as u64;
                 let typed_values = row_to_typed_values_with_config(row, self.config)?;
-                let values: HashMap<String, UniversalValue> = typed_values
+                let values: HashMap<String, Value> = typed_values
                     .into_iter()
                     .map(|(k, tv)| (k, tv.value))
                     .collect();
-                batch.push(UniversalRow::new(
+                batch.push(Row::new(
                     self.table_name.to_string(),
                     row_index,
-                    UniversalValue::Int64(row_index as i64),
+                    Value::Int64(row_index as i64),
                     values,
                 ));
             }
@@ -549,11 +549,11 @@ async fn migrate_table<S: SurrealSink>(
 #[derive(Debug, Clone)]
 pub struct TableChunk {
     /// The converted rows, in primary-key order.
-    pub rows: Vec<UniversalRow>,
+    pub rows: Vec<Row>,
     /// Primary-key values of the last row in `rows`, in primary-key column
     /// order. `None` when no rows were returned. Pass this back as `after` to
     /// read the following chunk.
-    pub last_pk: Option<Vec<UniversalValue>>,
+    pub last_pk: Option<Vec<Value>>,
 }
 
 /// Read a single primary-key-ordered chunk of a table using keyset pagination.
@@ -572,7 +572,7 @@ pub async fn read_table_chunk(
     conn: &mut mysql_async::Conn,
     table_name: &str,
     pk_columns: &[String],
-    after: Option<&[UniversalValue]>,
+    after: Option<&[Value]>,
     limit: usize,
     config: &RowConversionConfig,
 ) -> Result<TableChunk> {
@@ -584,7 +584,7 @@ pub async fn read_table_chunk(
 
     let order_by = pk_columns.join(", ");
 
-    let (where_clause, bind_values): (String, Vec<Value>) = match after {
+    let (where_clause, bind_values): (String, Vec<MysqlValue>) = match after {
         Some(cursor) => {
             if cursor.len() != pk_columns.len() {
                 return Err(anyhow::anyhow!(
@@ -616,17 +616,17 @@ pub async fn read_table_chunk(
         format!("SELECT * FROM {table_name} {where_clause} ORDER BY {order_by} LIMIT {limit}");
     debug!("Chunk-reading table {table_name} with: {query}");
 
-    let rows: Vec<Row> = conn
+    let rows: Vec<MysqlRow> = conn
         .exec(query, Params::Positional(bind_values))
         .await
         .map_err(|e| anyhow::anyhow!("Failed to read chunk from table {table_name}: {e}"))?;
 
     let mut out = Vec::with_capacity(rows.len());
-    let mut last_pk: Option<Vec<UniversalValue>> = None;
+    let mut last_pk: Option<Vec<Value>> = None;
 
     for (row_index, row) in rows.iter().enumerate() {
         let typed_values = row_to_typed_values_with_config(row, config)?;
-        let values: HashMap<String, UniversalValue> = typed_values
+        let values: HashMap<String, Value> = typed_values
             .into_iter()
             .map(|(k, tv)| (k, tv.value))
             .collect();
@@ -644,12 +644,12 @@ pub async fn read_table_chunk(
         }
         last_pk = Some(cursor_values);
 
-        let fields: HashMap<String, UniversalValue> = values
+        let fields: HashMap<String, Value> = values
             .into_iter()
             .filter(|(k, _)| !pk_columns.contains(k))
             .collect();
 
-        out.push(UniversalRow::new(
+        out.push(Row::new(
             table_name.to_string(),
             row_index as u64,
             id,
@@ -660,18 +660,18 @@ pub async fn read_table_chunk(
     Ok(TableChunk { rows: out, last_pk })
 }
 
-/// Convert a primary-key `UniversalValue` into a MySQL bind value for keyset
+/// Convert a primary-key `Value` into a MySQL bind value for keyset
 /// pagination.
-fn pk_value_to_mysql_value(value: &UniversalValue) -> Result<Value> {
+fn pk_value_to_mysql_value(value: &Value) -> Result<MysqlValue> {
     Ok(match value {
-        UniversalValue::Int8 { value, .. } => Value::Int(*value as i64),
-        UniversalValue::Int16(v) => Value::Int(*v as i64),
-        UniversalValue::Int32(v) => Value::Int(*v as i64),
-        UniversalValue::Int64(v) => Value::Int(*v),
-        UniversalValue::Text(v) => Value::Bytes(v.clone().into_bytes()),
-        UniversalValue::VarChar { value, .. } => Value::Bytes(value.clone().into_bytes()),
-        UniversalValue::Char { value, .. } => Value::Bytes(value.clone().into_bytes()),
-        UniversalValue::Uuid(v) => Value::Bytes(v.to_string().into_bytes()),
+        Value::Int8 { value, .. } => MysqlValue::Int(*value as i64),
+        Value::Int16(v) => MysqlValue::Int(*v as i64),
+        Value::Int32(v) => MysqlValue::Int(*v as i64),
+        Value::Int64(v) => MysqlValue::Int(*v),
+        Value::Text(v) => MysqlValue::Bytes(v.clone().into_bytes()),
+        Value::VarChar { value, .. } => MysqlValue::Bytes(value.clone().into_bytes()),
+        Value::Char { value, .. } => MysqlValue::Bytes(value.clone().into_bytes()),
+        Value::Uuid(v) => MysqlValue::Bytes(v.to_string().into_bytes()),
         other => {
             return Err(anyhow::anyhow!(
                 "Unsupported primary key value type for keyset pagination: {other:?}"
@@ -682,9 +682,9 @@ fn pk_value_to_mysql_value(value: &UniversalValue) -> Result<Value> {
 
 /// Extract primary key value from values map
 fn extract_primary_key_value(
-    values: &HashMap<String, UniversalValue>,
+    values: &HashMap<String, Value>,
     pk_columns: &[String],
-) -> Result<UniversalValue> {
+) -> Result<Value> {
     if pk_columns.is_empty() {
         return Err(anyhow::anyhow!(
             "Table has no primary key defined - primary key is required for sync"
@@ -708,9 +708,9 @@ fn extract_primary_key_value(
                 .ok_or_else(|| anyhow::anyhow!("Primary key column '{col}' not found in row"))?;
             pk_values.push(v);
         }
-        Ok(UniversalValue::Array {
+        Ok(Value::Array {
             elements: pk_values,
-            element_type: Box::new(UniversalType::Text),
+            element_type: Box::new(Type::Text),
         })
     }
 }

--- a/crates/mysql-trigger-source/src/interleaved_snapshot.rs
+++ b/crates/mysql-trigger-source/src/interleaved_snapshot.rs
@@ -18,17 +18,15 @@ use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Mutex;
 
 use anyhow::{anyhow, Result};
-use json_types::{convert_id_to_universal_value, JsonValueWithSchema};
-use mysql_async::{prelude::*, Pool, Row, Value};
+use json_types::{convert_id_to_value, JsonValueWithSchema};
+use mysql_async::{prelude::*, Pool, Row as MysqlRow, Value as MysqlValue};
 use surreal_sink::SurrealSink;
 use surreal_sync_interleaved_snapshot::{
     run_interleaved_snapshot_with_transforms, InterleavedSnapshotConfig, InterleavedSnapshotResult,
     PkTuple, ReconciliationEvent, SnapshotCheckpointer, SnapshotSignal, SnapshotTransforms,
     TableSpec, WatermarkKind, WatermarkSource,
 };
-use sync_core::{
-    DatabaseSchema, UniversalChange, UniversalChangeOp, UniversalRow, UniversalType, UniversalValue,
-};
+use sync_core::{Change, ChangeOp, DatabaseSchema, Row, Type, Value};
 use uuid::Uuid;
 
 use crate::change_tracking::setup_mysql_change_tracking;
@@ -199,14 +197,14 @@ impl MySqlWatermarkSource {
         table: &str,
         pk_columns: &[String],
         row_id: &str,
-    ) -> Result<(PkTuple, UniversalValue)> {
+    ) -> Result<(PkTuple, Value)> {
         let table_def = self.schema.get_table(table);
         if pk_columns.len() == 1 {
             let ty = table_def
                 .and_then(|d| d.get_column_type(&pk_columns[0]))
                 .cloned()
-                .unwrap_or(UniversalType::Text);
-            let value = convert_id_to_universal_value(row_id, table, &ty)?;
+                .unwrap_or(Type::Text);
+            let value = convert_id_to_value(row_id, table, &ty)?;
             Ok((PkTuple::new(vec![value.clone()]), value))
         } else {
             let parsed: serde_json::Value = serde_json::from_str(row_id).map_err(|e| {
@@ -227,13 +225,13 @@ impl MySqlWatermarkSource {
                 let ty = table_def
                     .and_then(|d| d.get_column_type(col))
                     .cloned()
-                    .unwrap_or(UniversalType::Text);
-                let part = convert_id_to_universal_value(&json_scalar_to_string(elem), table, &ty)?;
+                    .unwrap_or(Type::Text);
+                let part = convert_id_to_value(&json_scalar_to_string(elem), table, &ty)?;
                 values.push(part);
             }
-            let id = UniversalValue::Array {
+            let id = Value::Array {
                 elements: values.clone(),
-                element_type: Box::new(UniversalType::Text),
+                element_type: Box::new(Type::Text),
             };
             Ok((PkTuple::new(values), id))
         }
@@ -246,7 +244,7 @@ impl MySqlWatermarkSource {
         table: &str,
         pk_columns: &[String],
         json: serde_json::Map<String, serde_json::Value>,
-    ) -> HashMap<String, UniversalValue> {
+    ) -> HashMap<String, Value> {
         let table_def = self.schema.get_table(table);
         let mut fields = HashMap::new();
         for (key, value) in json {
@@ -256,8 +254,8 @@ impl MySqlWatermarkSource {
             let col_type = table_def
                 .and_then(|d| d.get_column_type(&key))
                 .cloned()
-                .unwrap_or(UniversalType::Text);
-            let universal = if let UniversalType::Set { .. } = col_type {
+                .unwrap_or(Type::Text);
+            let universal = if let Type::Set { .. } = col_type {
                 match &value {
                     serde_json::Value::String(s) => {
                         let elements = if s.is_empty() {
@@ -265,7 +263,7 @@ impl MySqlWatermarkSource {
                         } else {
                             s.split(',').map(|v| v.to_string()).collect()
                         };
-                        UniversalValue::set(elements, Vec::new())
+                        Value::set(elements, Vec::new())
                     }
                     _ => {
                         JsonValueWithSchema::new(value, col_type)
@@ -297,7 +295,7 @@ impl WatermarkSource for MySqlWatermarkSource {
         table: &TableSpec,
         after: Option<&PkTuple>,
         limit: usize,
-    ) -> Result<Vec<UniversalRow>> {
+    ) -> Result<Vec<Row>> {
         let mut conn = self.pool.get_conn().await?;
         let config = self.conversion_config(&table.table);
         let after_values = after.map(|pk| pk.0.as_slice());
@@ -345,7 +343,7 @@ impl WatermarkSource for MySqlWatermarkSource {
         let mut conn = self.pool.get_conn().await?;
         let last = self.last_sequence_id.load(Ordering::SeqCst);
 
-        let rows: Vec<Row> = conn
+        let rows: Vec<MysqlRow> = conn
             .exec(
                 format!(
                     "SELECT sequence_id, table_name, operation, row_id, new_data \
@@ -368,7 +366,7 @@ impl WatermarkSource for MySqlWatermarkSource {
             let table_name: String = row.get(1).ok_or_else(|| anyhow!("missing table_name"))?;
             let operation: String = row.get(2).ok_or_else(|| anyhow!("missing operation"))?;
             let row_id: String = row.get(3).ok_or_else(|| anyhow!("missing row_id"))?;
-            let new_data: Option<Value> = row.get(4);
+            let new_data: Option<MysqlValue> = row.get(4);
 
             if sequence_id > max_seq {
                 max_seq = sequence_id;
@@ -384,13 +382,8 @@ impl WatermarkSource for MySqlWatermarkSource {
                     events.push(ReconciliationEvent {
                         position: sequence_id,
                         table: SIGNAL_TABLE.to_string(),
-                        pk: PkTuple::new(vec![UniversalValue::Uuid(id)]),
-                        change: UniversalChange::new(
-                            UniversalChangeOp::Create,
-                            SIGNAL_TABLE,
-                            UniversalValue::Uuid(id),
-                            None,
-                        ),
+                        pk: PkTuple::new(vec![Value::Uuid(id)]),
+                        change: Change::new(ChangeOp::Create, SIGNAL_TABLE, Value::Uuid(id), None),
                     });
                 }
                 continue;
@@ -409,15 +402,15 @@ impl WatermarkSource for MySqlWatermarkSource {
             let (pk, id) = self.pk_and_id(&table_name, &pk_columns, &row_id)?;
 
             let (op, data) = match operation.as_str() {
-                "INSERT" => (UniversalChangeOp::Create, parse_new_data(new_data)?),
-                "UPDATE" => (UniversalChangeOp::Update, parse_new_data(new_data)?),
-                "DELETE" => (UniversalChangeOp::Delete, None),
+                "INSERT" => (ChangeOp::Create, parse_new_data(new_data)?),
+                "UPDATE" => (ChangeOp::Update, parse_new_data(new_data)?),
+                "DELETE" => (ChangeOp::Delete, None),
                 other => return Err(anyhow!("unknown audit operation '{other}'")),
             };
 
             let data = data.map(|obj| self.fields_from_new_data(&table_name, &pk_columns, obj));
 
-            let change = UniversalChange::new(op, table_name.clone(), id, data);
+            let change = Change::new(op, table_name.clone(), id, data);
             events.push(ReconciliationEvent {
                 position: sequence_id,
                 table: table_name,
@@ -446,7 +439,7 @@ impl WatermarkSource for MySqlWatermarkSource {
 
     async fn read_signals(&mut self) -> Result<Vec<SnapshotSignal>> {
         let mut conn = self.pool.get_conn().await?;
-        let rows: Vec<Row> = conn
+        let rows: Vec<MysqlRow> = conn
             .exec(
                 format!(
                     "SELECT id, tables FROM {SIGNAL_TABLE} \
@@ -648,7 +641,7 @@ where
 /// Enumerate the user tables to snapshot, excluding the audit and signal tables
 /// and the usual MySQL system schemas.
 async fn get_snapshot_tables(conn: &mut mysql_async::Conn, database: &str) -> Result<Vec<String>> {
-    let rows: Vec<Row> = conn
+    let rows: Vec<MysqlRow> = conn
         .exec(
             "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES \
              WHERE TABLE_SCHEMA = ? AND TABLE_TYPE = 'BASE TABLE' \
@@ -677,9 +670,9 @@ fn conversions_from_schema(schema: &DatabaseSchema) -> HashMap<String, TableConv
         let mut conv = TableConversion::default();
         for column in table.column_names() {
             match table.get_column_type(column) {
-                Some(UniversalType::Bool) => conv.boolean_columns.push(column.to_string()),
-                Some(UniversalType::Set { .. }) => conv.set_columns.push(column.to_string()),
-                Some(UniversalType::Json) => conv.json_columns.push(column.to_string()),
+                Some(Type::Bool) => conv.boolean_columns.push(column.to_string()),
+                Some(Type::Set { .. }) => conv.set_columns.push(column.to_string()),
+                Some(Type::Json) => conv.json_columns.push(column.to_string()),
                 _ => {}
             }
         }
@@ -690,10 +683,10 @@ fn conversions_from_schema(schema: &DatabaseSchema) -> HashMap<String, TableConv
 
 /// Parse the audit `new_data` column (JSON stored as bytes) into a JSON object.
 fn parse_new_data(
-    new_data: Option<Value>,
+    new_data: Option<MysqlValue>,
 ) -> Result<Option<serde_json::Map<String, serde_json::Value>>> {
     match new_data {
-        Some(Value::Bytes(bytes)) => {
+        Some(MysqlValue::Bytes(bytes)) => {
             let json: serde_json::Value = serde_json::from_slice(&bytes)
                 .map_err(|e| anyhow!("invalid JSON in audit new_data: {e}"))?;
             match json {
@@ -711,42 +704,42 @@ fn parse_new_data(
 /// keys derived here match the ones derived from audit `row_id` strings. For a
 /// composite key the canonical parts are also re-inserted into the row's fields
 /// so the generic loop can recover the key via `PkTuple::from_row`.
-fn normalize_row_pk(row: &mut UniversalRow, pk_columns: &[String]) {
+fn normalize_row_pk(row: &mut Row, pk_columns: &[String]) {
     if pk_columns.len() == 1 {
         row.id = canonicalize_pk_value(&row.id);
         return;
     }
-    if let UniversalValue::Array { elements, .. } = &row.id {
-        let canonical: Vec<UniversalValue> = elements.iter().map(canonicalize_pk_value).collect();
+    if let Value::Array { elements, .. } = &row.id {
+        let canonical: Vec<Value> = elements.iter().map(canonicalize_pk_value).collect();
         for (col, value) in pk_columns.iter().zip(canonical.iter()) {
             row.fields.insert(col.clone(), value.clone());
         }
-        row.id = UniversalValue::Array {
+        row.id = Value::Array {
             elements: canonical,
-            element_type: Box::new(UniversalType::Text),
+            element_type: Box::new(Type::Text),
         };
     }
 }
 
 /// Reduce a primary-key value to the canonical kinds produced by
-/// [`convert_id_to_universal_value`] (`Int64` / `Uuid` / `Text`), so snapshot
+/// [`convert_id_to_value`] (`Int64` / `Uuid` / `Text`), so snapshot
 /// reads and stream events compare equal for the same logical key.
-fn canonicalize_pk_value(value: &UniversalValue) -> UniversalValue {
+fn canonicalize_pk_value(value: &Value) -> Value {
     match value {
-        UniversalValue::Int8 { value, .. } => UniversalValue::Int64(*value as i64),
-        UniversalValue::Int16(v) => UniversalValue::Int64(*v as i64),
-        UniversalValue::Int32(v) => UniversalValue::Int64(*v as i64),
-        UniversalValue::Int64(v) => UniversalValue::Int64(*v),
-        UniversalValue::Uuid(u) => UniversalValue::Uuid(*u),
-        UniversalValue::Char { value, .. } => UniversalValue::Text(value.clone()),
-        UniversalValue::VarChar { value, .. } => UniversalValue::Text(value.clone()),
-        UniversalValue::Text(s) => UniversalValue::Text(s.clone()),
+        Value::Int8 { value, .. } => Value::Int64(*value as i64),
+        Value::Int16(v) => Value::Int64(*v as i64),
+        Value::Int32(v) => Value::Int64(*v as i64),
+        Value::Int64(v) => Value::Int64(*v),
+        Value::Uuid(u) => Value::Uuid(*u),
+        Value::Char { value, .. } => Value::Text(value.clone()),
+        Value::VarChar { value, .. } => Value::Text(value.clone()),
+        Value::Text(s) => Value::Text(s.clone()),
         other => other.clone(),
     }
 }
 
 /// Render a JSON scalar (from a composite `row_id` array) as the string form
-/// expected by [`convert_id_to_universal_value`].
+/// expected by [`convert_id_to_value`].
 fn json_scalar_to_string(value: &serde_json::Value) -> String {
     match value {
         serde_json::Value::String(s) => s.clone(),

--- a/crates/mysql-trigger-source/src/schema.rs
+++ b/crates/mysql-trigger-source/src/schema.rs
@@ -5,11 +5,11 @@
 
 use mysql_types::mysql_column_to_universal_type;
 use std::collections::HashMap;
-use sync_core::{ColumnDefinition, DatabaseSchema, TableDefinition, UniversalType};
+use sync_core::{ColumnDefinition, DatabaseSchema, TableDefinition, Type};
 
 /// Collect schema information for all tables in a MySQL database.
 ///
-/// Returns a `DatabaseSchema` with proper `UniversalType` mapping.
+/// Returns a `DatabaseSchema` with proper `Type` mapping.
 /// This function also queries primary key information for each table.
 #[allow(dead_code)]
 pub async fn collect_mysql_database_schema(
@@ -37,7 +37,7 @@ pub async fn collect_mysql_database_schema(
     let pk_rows: Vec<mysql_async::Row> = conn.query(pk_query).await?;
 
     // Detect JSON columns so MariaDB's `LONGTEXT`-backed JSON (reported as
-    // `longtext`, not `json`) is still mapped to `UniversalType::Json`, matching
+    // `longtext`, not `json`) is still mapped to `Type::Json`, matching
     // native MySQL JSON. This drives the incremental stream path in `source.rs`,
     // which keys conversion off the schema type.
     let json_columns = {
@@ -61,7 +61,7 @@ pub async fn collect_mysql_database_schema(
     }
 
     // Build tables with columns
-    let mut table_columns: HashMap<String, Vec<(String, UniversalType)>> = HashMap::new();
+    let mut table_columns: HashMap<String, Vec<(String, Type)>> = HashMap::new();
 
     for row in column_rows {
         let table_name: String = row
@@ -83,7 +83,7 @@ pub async fn collect_mysql_database_schema(
             .get(&table_name)
             .is_some_and(|cols| cols.contains(&column_name));
         let universal_type = if is_json {
-            UniversalType::Json
+            Type::Json
         } else {
             mysql_column_to_universal_type(&data_type, &column_type, precision, scale)
         };
@@ -120,7 +120,7 @@ pub async fn collect_mysql_database_schema(
         // Use the found PK or create a default one
         let pk = primary_key.unwrap_or_else(|| {
             // If no PK column found, create a synthetic one
-            ColumnDefinition::new(pk_col_name, UniversalType::Int64)
+            ColumnDefinition::new(pk_col_name, Type::Int64)
         });
 
         let mut table_def = TableDefinition::new(table_name, pk, other_columns);

--- a/crates/mysql-trigger-source/src/source.rs
+++ b/crates/mysql-trigger-source/src/source.rs
@@ -7,7 +7,7 @@
 //!
 //! This implementation uses the unified TypedValue conversion path:
 //! ```text
-//! JSON (from audit table) → TypedValue (json-types) → surrealdb::sql::Value (surrealdb-types)
+//! JSON (from audit table) → TypedValue (json-types) → SurrealDB values
 //! ```
 //!
 //! ## Implementation Approach
@@ -25,15 +25,10 @@ use super::checkpoint::MySQLCheckpoint;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use chrono::Utc;
-use json_types::{
-    convert_id_to_universal_value, convert_id_to_universal_with_database_schema,
-    JsonValueWithSchema,
-};
+use json_types::{convert_id_to_value, convert_id_with_database_schema, JsonValueWithSchema};
 use log::info;
-use mysql_async::{prelude::*, Conn, Pool, Row, Value};
-use sync_core::{
-    DatabaseSchema, TypedValue, UniversalChange, UniversalChangeOp, UniversalType, UniversalValue,
-};
+use mysql_async::{prelude::*, Conn, Pool, Row as MysqlRow, Value as MysqlValue};
+use sync_core::{Change, ChangeOp, DatabaseSchema, Type, TypedValue, Value};
 
 // ============================================================================
 // Traits for MySQL incremental sync
@@ -71,13 +66,13 @@ pub trait IncrementalSource: Send + Sync {
 pub trait ChangeStream: Send + Sync {
     /// Get the next change event from the stream
     /// Returns None when no more changes are available
-    async fn next(&mut self) -> Option<Result<UniversalChange>>;
+    async fn next(&mut self) -> Option<Result<Change>>;
 
     /// Like [`ChangeStream::next`], but also yields the source `sequence_id`
     /// (stream position) of the change, so callers can track per-change
     /// positions for watermark-based reconciliation.
     /// Returns None when no more changes are available.
-    async fn next_with_sequence_id(&mut self) -> Option<Result<(i64, UniversalChange)>>;
+    async fn next_with_sequence_id(&mut self) -> Option<Result<(i64, Change)>>;
 
     /// Get the current sink-safe checkpoint of the stream.
     ///
@@ -182,7 +177,7 @@ pub struct MySQLChangeStream {
     #[allow(dead_code)]
     server_id: u32,
     /// Buffered changes, each paired with its source `sequence_id`.
-    buffer: Vec<(i64, UniversalChange)>,
+    buffer: Vec<(i64, Change)>,
     /// Highest sequence_id fetched into the buffer (audit pagination cursor).
     read_sequence_id: i64,
     /// Highest sequence_id successfully sunk (authoritative resume watermark).
@@ -217,7 +212,7 @@ impl MySQLChangeStream {
         field_name: &str,
         table_name: &str,
     ) -> Result<TypedValue> {
-        // Get the UniversalType from schema to check for SET columns
+        // Get the Type from schema to check for SET columns
         let column_type = self
             .database_schema
             .as_ref()
@@ -225,7 +220,7 @@ impl MySQLChangeStream {
             .and_then(|ts| ts.get_column_type(field_name));
 
         // Handle SET columns specially - MySQL JSON_OBJECT stores SET as comma-separated string
-        if let Some(UniversalType::Set { .. }) = column_type {
+        if let Some(Type::Set { .. }) = column_type {
             if let serde_json::Value::String(s) = &value {
                 let values: Vec<String> = if s.is_empty() {
                     Vec::new()
@@ -237,7 +232,7 @@ impl MySQLChangeStream {
         }
 
         // Get the sync type from schema for standard conversion
-        let sync_type = column_type.cloned().unwrap_or(UniversalType::Text); // Default to text if not found
+        let sync_type = column_type.cloned().unwrap_or(Type::Text); // Default to text if not found
 
         // Use json-types for conversion
         let jvs = JsonValueWithSchema::new(value, sync_type);
@@ -294,22 +289,20 @@ impl MySQLChangeStream {
             .unwrap_or_else(|| vec!["id".to_string()])
     }
 
-    /// Convert audit `row_id` (scalar string or JSON array) to a UniversalValue ID.
+    /// Convert audit `row_id` (scalar string or JSON array) to a Value ID.
     fn row_id_to_universal(
         &self,
         row_id: &str,
         table_name: &str,
         pk_columns: &[String],
-    ) -> Result<UniversalValue> {
+    ) -> Result<Value> {
         let schema = self.database_schema.as_ref();
         if pk_columns.len() <= 1 {
             let col = pk_columns.first().map(|s| s.as_str()).unwrap_or("id");
             if let Some(schema) = schema {
-                return convert_id_to_universal_with_database_schema(
-                    row_id, table_name, col, schema,
-                );
+                return convert_id_with_database_schema(row_id, table_name, col, schema);
             }
-            return Ok(UniversalValue::Text(row_id.to_string()));
+            return Ok(Value::Text(row_id.to_string()));
         }
 
         // Composite: triggers store JSON_ARRAY(...) in row_id.
@@ -334,27 +327,27 @@ impl MySQLChangeStream {
                 other => other.to_string(),
             };
             let part = if let Some(schema) = schema {
-                convert_id_to_universal_with_database_schema(&id_str, table_name, col, schema)?
+                convert_id_with_database_schema(&id_str, table_name, col, schema)?
             } else {
-                let ty = UniversalType::Text;
-                convert_id_to_universal_value(&id_str, table_name, &ty)?
+                let ty = Type::Text;
+                convert_id_to_value(&id_str, table_name, &ty)?
             };
             values.push(part);
         }
-        Ok(UniversalValue::Array {
+        Ok(Value::Array {
             elements: values,
-            element_type: Box::new(UniversalType::Text),
+            element_type: Box::new(Type::Text),
         })
     }
 
-    async fn fetch_changes(&mut self) -> Result<Vec<(i64, UniversalChange)>> {
+    async fn fetch_changes(&mut self) -> Result<Vec<(i64, Change)>> {
         let conn = self
             .connection
             .as_mut()
             .ok_or_else(|| anyhow!("No connection available"))?;
 
         // Check if audit table exists before querying
-        let table_exists: Vec<Row> = conn
+        let table_exists: Vec<MysqlRow> = conn
             .query("SELECT 1 FROM information_schema.tables WHERE table_name = 'surreal_sync_changes' AND table_schema = DATABASE()")
             .await?;
 
@@ -373,7 +366,7 @@ impl MySQLChangeStream {
              LIMIT 100"
                 .to_string();
 
-        let rows: Vec<Row> = conn.exec(query, (self.read_sequence_id,)).await?;
+        let rows: Vec<MysqlRow> = conn.exec(query, (self.read_sequence_id,)).await?;
         let mut changes = Vec::new();
 
         for row in rows {
@@ -381,23 +374,23 @@ impl MySQLChangeStream {
             let table_name: String = row.get(1).ok_or_else(|| anyhow!("Missing table_name"))?;
             let operation: String = row.get(2).ok_or_else(|| anyhow!("Missing operation"))?;
             let row_id: String = row.get(3).ok_or_else(|| anyhow!("Missing row_id"))?;
-            let _old_data: Option<Value> = row.get(4);
-            let new_data: Option<Value> = row.get(5);
+            let _old_data: Option<MysqlValue> = row.get(4);
+            let new_data: Option<MysqlValue> = row.get(5);
 
             let op = match operation.as_str() {
-                "INSERT" => UniversalChangeOp::Create,
-                "UPDATE" => UniversalChangeOp::Update,
-                "DELETE" => UniversalChangeOp::Delete,
+                "INSERT" => ChangeOp::Create,
+                "UPDATE" => ChangeOp::Update,
+                "DELETE" => ChangeOp::Delete,
                 _ => {
                     return Err(anyhow!("Unknown operation type: {operation}"));
                 }
             };
 
-            // Convert JSON data to UniversalValue map using TypedValue conversion flow
+            // Convert JSON data to Value map using TypedValue conversion flow
             let pk_columns = self.pk_columns_for(&table_name);
-            let universal_data: Option<HashMap<String, UniversalValue>> = match operation.as_str() {
+            let universal_data: Option<HashMap<String, Value>> = match operation.as_str() {
                 "INSERT" | "UPDATE" => {
-                    if let Some(Value::Bytes(json_data)) = new_data {
+                    if let Some(MysqlValue::Bytes(json_data)) = new_data {
                         if let Ok(json_value) =
                             serde_json::from_slice::<serde_json::Value>(&json_data)
                         {
@@ -424,12 +417,11 @@ impl MySQLChangeStream {
                                         &row_id,
                                     )?;
 
-                                    // Step 2: HashMap<String, TypedValue> → HashMap<String, UniversalValue>
-                                    let universal_map: HashMap<String, UniversalValue> =
-                                        typed_values
-                                            .into_iter()
-                                            .map(|(k, tv)| (k, tv.value))
-                                            .collect();
+                                    // Step 2: HashMap<String, TypedValue> → HashMap<String, Value>
+                                    let universal_map: HashMap<String, Value> = typed_values
+                                        .into_iter()
+                                        .map(|(k, tv)| (k, tv.value))
+                                        .collect();
                                     Some(universal_map)
                                 }
                                 _ => {
@@ -449,15 +441,14 @@ impl MySQLChangeStream {
                 _ => anyhow::bail!("Unknown operation type: {operation}"),
             };
 
-            // Convert the string row_id to UniversalValue using schema information
+            // Convert the string row_id to Value using schema information
             // (scalar or JSON-array composite keys).
-            let record_id: UniversalValue =
-                self.row_id_to_universal(&row_id, &table_name, &pk_columns)?;
+            let record_id: Value = self.row_id_to_universal(&row_id, &table_name, &pk_columns)?;
 
             // Create change record using universal types
             changes.push((
                 sequence_id,
-                UniversalChange::new(op, table_name.clone(), record_id, universal_data),
+                Change::new(op, table_name.clone(), record_id, universal_data),
             ));
 
             // Advance read-head only; sunk watermark waits for commit_sunk.
@@ -470,7 +461,7 @@ impl MySQLChangeStream {
 
 #[async_trait]
 impl ChangeStream for MySQLChangeStream {
-    async fn next(&mut self) -> Option<Result<UniversalChange>> {
+    async fn next(&mut self) -> Option<Result<Change>> {
         match self.next_with_sequence_id().await {
             Some(Ok((_seq, change))) => Some(Ok(change)),
             Some(Err(e)) => Some(Err(e)),
@@ -478,7 +469,7 @@ impl ChangeStream for MySQLChangeStream {
         }
     }
 
-    async fn next_with_sequence_id(&mut self) -> Option<Result<(i64, UniversalChange)>> {
+    async fn next_with_sequence_id(&mut self) -> Option<Result<(i64, Change)>> {
         // Return buffered changes first
         if !self.buffer.is_empty() {
             return Some(Ok(self.buffer.remove(0)));

--- a/crates/mysql-trigger-source/tests/common/mod.rs
+++ b/crates/mysql-trigger-source/tests/common/mod.rs
@@ -23,9 +23,7 @@ use surreal_sync_interleaved_snapshot::{
 };
 use surreal_sync_mysql_trigger_source::testing::MySQLContainer;
 use surreal_sync_mysql_trigger_source::{read_table_chunk, MySqlWatermarkSource};
-use sync_core::{
-    UniversalChange, UniversalRelation, UniversalRelationChange, UniversalRow, UniversalValue,
-};
+use sync_core::{Change, Relation, RelationChange, Row, Value};
 use tokio::sync::Mutex;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -58,7 +56,7 @@ pub fn init_logging() {
 /// In-memory [`SurrealSink`] that records the latest state per record, keyed by
 /// the serialized record id, so tests can assert parity against the source.
 /// table -> (serialized id -> non-key field map)
-type SinkState = BTreeMap<String, BTreeMap<String, HashMap<String, UniversalValue>>>;
+type SinkState = BTreeMap<String, BTreeMap<String, HashMap<String, Value>>>;
 
 #[derive(Default)]
 pub struct MemSink {
@@ -82,13 +80,13 @@ impl MemSink {
     }
 }
 
-pub fn id_key(id: &UniversalValue) -> String {
+pub fn id_key(id: &Value) -> String {
     serde_json::to_string(id).expect("serialize id")
 }
 
 #[async_trait::async_trait]
 impl SurrealSink for MemSink {
-    async fn write_universal_rows(&self, rows: &[UniversalRow]) -> Result<()> {
+    async fn write_rows(&self, rows: &[Row]) -> Result<()> {
         let mut state = self.state.lock().await;
         for row in rows {
             state
@@ -99,21 +97,21 @@ impl SurrealSink for MemSink {
         Ok(())
     }
 
-    async fn write_universal_relations(&self, _relations: &[UniversalRelation]) -> Result<()> {
+    async fn write_relations(&self, _relations: &[Relation]) -> Result<()> {
         Ok(())
     }
 
-    async fn apply_universal_change(&self, change: &UniversalChange) -> Result<()> {
+    async fn apply_change(&self, change: &Change) -> Result<()> {
         let mut state = self.state.lock().await;
         let key = id_key(&change.id);
         match change.operation {
-            sync_core::UniversalChangeOp::Create | sync_core::UniversalChangeOp::Update => {
+            sync_core::ChangeOp::Create | sync_core::ChangeOp::Update => {
                 state
                     .entry(change.table.clone())
                     .or_default()
-                    .insert(key, change.data.clone().unwrap_or_default());
+                    .insert(key, change.fields.clone().unwrap_or_default());
             }
-            sync_core::UniversalChangeOp::Delete => {
+            sync_core::ChangeOp::Delete => {
                 if let Some(rows) = state.get_mut(&change.table) {
                     rows.remove(&key);
                 }
@@ -122,39 +120,36 @@ impl SurrealSink for MemSink {
         Ok(())
     }
 
-    async fn apply_universal_relation_change(
-        &self,
-        _change: &UniversalRelationChange,
-    ) -> Result<()> {
+    async fn apply_relation_change(&self, _change: &RelationChange) -> Result<()> {
         Ok(())
     }
 }
 
 /// Canonicalize a primary-key scalar to the kinds the backend keys records by
 /// (`Int64` / `Uuid` / `Text`), matching the source's internal normalization.
-fn canon_scalar(value: &UniversalValue) -> UniversalValue {
+fn canon_scalar(value: &Value) -> Value {
     match value {
-        UniversalValue::Int8 { value, .. } => UniversalValue::Int64(*value as i64),
-        UniversalValue::Int16(v) => UniversalValue::Int64(*v as i64),
-        UniversalValue::Int32(v) => UniversalValue::Int64(*v as i64),
-        UniversalValue::Int64(v) => UniversalValue::Int64(*v),
-        UniversalValue::Uuid(u) => UniversalValue::Uuid(*u),
-        UniversalValue::Char { value, .. } => UniversalValue::Text(value.clone()),
-        UniversalValue::VarChar { value, .. } => UniversalValue::Text(value.clone()),
-        UniversalValue::Text(s) => UniversalValue::Text(s.clone()),
+        Value::Int8 { value, .. } => Value::Int64(*value as i64),
+        Value::Int16(v) => Value::Int64(*v as i64),
+        Value::Int32(v) => Value::Int64(*v as i64),
+        Value::Int64(v) => Value::Int64(*v),
+        Value::Uuid(u) => Value::Uuid(*u),
+        Value::Char { value, .. } => Value::Text(value.clone()),
+        Value::VarChar { value, .. } => Value::Text(value.clone()),
+        Value::Text(s) => Value::Text(s.clone()),
         other => other.clone(),
     }
 }
 
-fn canon_id_key(row: &UniversalRow, pk_len: usize) -> String {
+fn canon_id_key(row: &Row, pk_len: usize) -> String {
     if pk_len == 1 {
         return id_key(&canon_scalar(&row.id));
     }
     match &row.id {
-        UniversalValue::Array { elements, .. } => {
-            let canon = UniversalValue::Array {
+        Value::Array { elements, .. } => {
+            let canon = Value::Array {
                 elements: elements.iter().map(canon_scalar).collect(),
-                element_type: Box::new(sync_core::UniversalType::Text),
+                element_type: Box::new(sync_core::Type::Text),
             };
             id_key(&canon)
         }
@@ -173,7 +168,7 @@ async fn source_value_map(
     let mut conn = pool.get_conn().await?;
     let config = RowConversionConfig::default();
     let mut out = BTreeMap::new();
-    let mut after: Option<Vec<UniversalValue>> = None;
+    let mut after: Option<Vec<Value>> = None;
     loop {
         let chunk =
             read_table_chunk(&mut conn, table, pk_columns, after.as_deref(), 64, &config).await?;
@@ -210,7 +205,7 @@ async fn drain_stream(source: &mut MySqlWatermarkSource, sink: &MemSink) -> Resu
             if event.pk.single_uuid().is_some() {
                 continue;
             }
-            sink.apply_universal_change(&event.change).await?;
+            sink.apply_change(&event.change).await?;
         }
     }
     Ok(())

--- a/crates/mysql-trigger-source/tests/set_column.rs
+++ b/crates/mysql-trigger-source/tests/set_column.rs
@@ -1,6 +1,6 @@
 //! Integration tests for MySQL SET column type conversion
 //!
-//! This test verifies how MySQL SET columns are converted to UniversalValue types.
+//! This test verifies how MySQL SET columns are converted to Value types.
 //! SET columns store comma-separated values and should be converted to arrays.
 #![allow(clippy::uninlined_format_args)]
 
@@ -8,7 +8,7 @@ use anyhow::{Context, Result};
 use mysql_async::prelude::*;
 use mysql_types::{row_to_typed_values, row_to_typed_values_with_config, RowConversionConfig};
 use surreal_sync_mysql_trigger_source::testing::MySQLContainer;
-use sync_core::UniversalValue;
+use sync_core::Value;
 use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -92,7 +92,7 @@ async fn test_set_column_without_schema_returns_string() -> Result<()> {
 
     // Verify it comes back as a string (Char), NOT as a Set
     match &tags.value {
-        UniversalValue::Char { value, .. } => {
+        Value::Char { value, .. } => {
             assert_eq!(value, "technology,tutorial");
             info!("✓ Confirmed: SET column returns as Char without schema detection");
         }
@@ -110,7 +110,7 @@ async fn test_set_column_without_schema_returns_string() -> Result<()> {
         .get("tags")
         .context("Should have tags field")?;
     assert!(
-        matches!(tags_null.value, UniversalValue::Null),
+        matches!(tags_null.value, Value::Null),
         "NULL SET should be Null, got {:?}",
         tags_null.value
     );
@@ -189,7 +189,7 @@ async fn test_set_column_with_schema_detection() -> Result<()> {
 
     // Verify it's now a proper Set
     match &tags.value {
-        UniversalValue::Set { elements, .. } => {
+        Value::Set { elements, .. } => {
             assert_eq!(elements, &vec!["tech".to_string(), "news".to_string()]);
             info!("✓ SET column correctly converted to Set type with schema detection");
         }

--- a/crates/mysql-trigger-source/tests/transforms.rs
+++ b/crates/mysql-trigger-source/tests/transforms.rs
@@ -11,13 +11,13 @@ use surreal_sync_mysql_trigger_source::{
     run_incremental_sync_with_transforms, setup_mysql_change_tracking, MySQLCheckpoint,
     ReplicationTailOptions, SourceOpts,
 };
-use sync_core::{UniversalChange, UniversalRow, UniversalValue};
+use sync_core::{Change, Row, Value};
 use sync_transform::{ApplyOpts, ChildStdioMode, ExternalTransform, FramerKind, Pipeline};
 
 mod common;
 
 struct CaptureSink {
-    changes: Mutex<Vec<UniversalChange>>,
+    changes: Mutex<Vec<Change>>,
 }
 
 impl CaptureSink {
@@ -30,11 +30,11 @@ impl CaptureSink {
 
 #[async_trait::async_trait]
 impl SurrealSink for CaptureSink {
-    async fn write_universal_rows(&self, rows: &[UniversalRow]) -> anyhow::Result<()> {
+    async fn write_rows(&self, rows: &[Row]) -> anyhow::Result<()> {
         // Homogeneous Update upserts coalesce here; keep observations in `changes`.
         let mut changes = self.changes.lock().expect("lock");
         for row in rows {
-            changes.push(UniversalChange::update(
+            changes.push(Change::update(
                 row.table.clone(),
                 row.id.clone(),
                 row.fields.clone(),
@@ -43,21 +43,18 @@ impl SurrealSink for CaptureSink {
         Ok(())
     }
 
-    async fn write_universal_relations(
-        &self,
-        _relations: &[sync_core::UniversalRelation],
-    ) -> anyhow::Result<()> {
+    async fn write_relations(&self, _relations: &[sync_core::Relation]) -> anyhow::Result<()> {
         Ok(())
     }
 
-    async fn apply_universal_change(&self, change: &UniversalChange) -> anyhow::Result<()> {
+    async fn apply_change(&self, change: &Change) -> anyhow::Result<()> {
         self.changes.lock().expect("lock").push(change.clone());
         Ok(())
     }
 
-    async fn apply_universal_relation_change(
+    async fn apply_relation_change(
         &self,
-        _change: &sync_core::UniversalRelationChange,
+        _change: &sync_core::RelationChange,
     ) -> anyhow::Result<()> {
         Ok(())
     }
@@ -95,10 +92,10 @@ fn ensure_fixture_worker() -> PathBuf {
     path
 }
 
-fn name_field(change: &UniversalChange) -> Option<String> {
-    let data = change.data.as_ref()?;
+fn name_field(change: &Change) -> Option<String> {
+    let data = change.fields.as_ref()?;
     match data.get("name")? {
-        UniversalValue::VarChar { value, .. } | UniversalValue::Text(value) => Some(value.clone()),
+        Value::VarChar { value, .. } | Value::Text(value) => Some(value.clone()),
         other => panic!("unexpected name: {other:?}"),
     }
 }
@@ -246,7 +243,7 @@ async fn composite_pk_entity_writes_surreal_array_record_ids() -> Result<()> {
     )
     .await?;
 
-    use surrealdb::sql::{Id, Thing, Value};
+    use surrealdb::sql::{Id, Thing, Value as SqlValue};
 
     #[derive(Debug, serde::Deserialize)]
     struct LedgerRow {
@@ -270,8 +267,8 @@ async fn composite_pk_entity_writes_surreal_array_record_ids() -> Result<()> {
                     .0
                     .into_iter()
                     .map(|v| match v {
-                        Value::Strand(s) => s.as_string(),
-                        Value::Number(n) => n.to_string(),
+                        SqlValue::Strand(s) => s.as_string(),
+                        SqlValue::Number(n) => n.to_string(),
                         other => panic!("unexpected array id element: {other:?}"),
                     })
                     .collect(),

--- a/crates/mysql-types/src/binlog.rs
+++ b/crates/mysql-types/src/binlog.rs
@@ -1,9 +1,9 @@
-//! Binlog cell → `UniversalValue` conversion.
+//! Binlog cell → `Value` conversion.
 
 use binlog_protocol::column_types::*;
 use binlog_protocol::{CellValue, ColumnMetadata, JsonDiff, JsonDiffOperation};
 use chrono::{NaiveDate, NaiveTime, TimeZone, Utc};
-use sync_core::{TypedValue, UniversalType, UniversalValue};
+use sync_core::{Type, TypedValue, Value};
 
 use crate::reverse::{
     json_to_typed_value_with_config, ConversionError, JsonConversionConfig, RowConversionConfig,
@@ -68,12 +68,12 @@ impl BinlogColumnMeta {
     }
 }
 
-/// Convert a decoded binlog cell into a [`UniversalValue`].
+/// Convert a decoded binlog cell into a [`Value`].
 pub fn binlog_cell_to_universal_value(
     cell: &CellValue,
     column: &BinlogColumnMeta,
     config: &RowConversionConfig,
-) -> Result<UniversalValue, ConversionError> {
+) -> Result<Value, ConversionError> {
     Ok(binlog_cell_to_typed_value(cell, column, config)?.value)
 }
 
@@ -157,10 +157,10 @@ fn binlog_cell_to_typed_value(
         }
         MYSQL_TYPE_DATE => {
             let (year, month, day) = extract_date_parts(cell)?;
-            if UniversalValue::is_mysql_zero_date_ymd(year, month, day) {
+            if Value::is_mysql_zero_date_ymd(year, month, day) {
                 return Ok(TypedValue::zero_temporal(
-                    UniversalType::Date,
-                    Some(UniversalValue::canonical_zero_literal(&UniversalType::Date).to_string()),
+                    Type::Date,
+                    Some(Value::canonical_zero_literal(&Type::Date).to_string()),
                 ));
             }
             let date = NaiveDate::from_ymd_opt(year as i32, month as u32, day as u32).ok_or_else(
@@ -197,13 +197,10 @@ fn binlog_cell_to_typed_value(
                 year, month, day, ..
             } = cell
             {
-                if UniversalValue::is_mysql_zero_date_ymd(*year, *month, *day) {
+                if Value::is_mysql_zero_date_ymd(*year, *month, *day) {
                     return Ok(TypedValue::zero_temporal(
-                        UniversalType::LocalDateTime,
-                        Some(
-                            UniversalValue::canonical_zero_literal(&UniversalType::LocalDateTime)
-                                .to_string(),
-                        ),
+                        Type::LocalDateTime,
+                        Some(Value::canonical_zero_literal(&Type::LocalDateTime).to_string()),
                     ));
                 }
             }
@@ -261,47 +258,47 @@ fn binlog_cell_to_typed_value(
     }
 }
 
-fn column_type_to_sync_type(column: &BinlogColumnMeta) -> UniversalType {
+fn column_type_to_sync_type(column: &BinlogColumnMeta) -> Type {
     if column.is_boolean_column() {
-        return UniversalType::Bool;
+        return Type::Bool;
     }
     match column.column_type {
-        MYSQL_TYPE_TINY => UniversalType::Int8 { width: 4 },
-        MYSQL_TYPE_SHORT => UniversalType::Int16,
-        MYSQL_TYPE_INT24 | MYSQL_TYPE_LONG => UniversalType::Int32,
-        MYSQL_TYPE_LONGLONG => UniversalType::Int64,
-        MYSQL_TYPE_FLOAT => UniversalType::Float32,
-        MYSQL_TYPE_DOUBLE => UniversalType::Float64,
+        MYSQL_TYPE_TINY => Type::Int8 { width: 4 },
+        MYSQL_TYPE_SHORT => Type::Int16,
+        MYSQL_TYPE_INT24 | MYSQL_TYPE_LONG => Type::Int32,
+        MYSQL_TYPE_LONGLONG => Type::Int64,
+        MYSQL_TYPE_FLOAT => Type::Float32,
+        MYSQL_TYPE_DOUBLE => Type::Float64,
         MYSQL_TYPE_DECIMAL | MYSQL_TYPE_NEWDECIMAL => {
             let (precision, scale) = column.decimal_precision_scale();
-            UniversalType::Decimal { precision, scale }
+            Type::Decimal { precision, scale }
         }
-        MYSQL_TYPE_STRING => UniversalType::Char {
+        MYSQL_TYPE_STRING => Type::Char {
             length: column.max_string_length(),
         },
-        MYSQL_TYPE_VAR_STRING | MYSQL_TYPE_VARCHAR => UniversalType::VarChar {
+        MYSQL_TYPE_VAR_STRING | MYSQL_TYPE_VARCHAR => Type::VarChar {
             length: column.max_string_length(),
         },
         MYSQL_TYPE_TINY_BLOB | MYSQL_TYPE_MEDIUM_BLOB | MYSQL_TYPE_BLOB | MYSQL_TYPE_LONG_BLOB => {
             if column.is_binary {
-                UniversalType::Blob
+                Type::Blob
             } else {
-                UniversalType::Text
+                Type::Text
             }
         }
-        MYSQL_TYPE_DATE => UniversalType::Date,
-        MYSQL_TYPE_TIME | MYSQL_TYPE_TIME2 => UniversalType::Time,
-        MYSQL_TYPE_DATETIME | MYSQL_TYPE_DATETIME2 => UniversalType::LocalDateTime,
-        MYSQL_TYPE_TIMESTAMP | MYSQL_TYPE_TIMESTAMP2 => UniversalType::ZonedDateTime,
-        MYSQL_TYPE_YEAR => UniversalType::Int16,
-        MYSQL_TYPE_JSON => UniversalType::Json,
-        MYSQL_TYPE_ENUM => UniversalType::Enum { values: vec![] },
-        MYSQL_TYPE_SET => UniversalType::Set { values: vec![] },
-        MYSQL_TYPE_GEOMETRY => UniversalType::Geometry {
+        MYSQL_TYPE_DATE => Type::Date,
+        MYSQL_TYPE_TIME | MYSQL_TYPE_TIME2 => Type::Time,
+        MYSQL_TYPE_DATETIME | MYSQL_TYPE_DATETIME2 => Type::LocalDateTime,
+        MYSQL_TYPE_TIMESTAMP | MYSQL_TYPE_TIMESTAMP2 => Type::ZonedDateTime,
+        MYSQL_TYPE_YEAR => Type::Int16,
+        MYSQL_TYPE_JSON => Type::Json,
+        MYSQL_TYPE_ENUM => Type::Enum { values: vec![] },
+        MYSQL_TYPE_SET => Type::Set { values: vec![] },
+        MYSQL_TYPE_GEOMETRY => Type::Geometry {
             geometry_type: sync_core::GeometryType::Point,
         },
-        MYSQL_TYPE_BIT => UniversalType::Bytes,
-        _ => UniversalType::Text,
+        MYSQL_TYPE_BIT => Type::Bytes,
+        _ => Type::Text,
     }
 }
 
@@ -1009,13 +1006,13 @@ mod tests {
     use chrono::Datelike;
     use rust_decimal::Decimal;
     use std::str::FromStr;
-    use sync_core::UniversalValue;
+    use sync_core::Value;
 
     fn col(name: &str, column_type: u8, metadata: ColumnMetadata) -> BinlogColumnMeta {
         BinlogColumnMeta::new(name, column_type, metadata)
     }
 
-    fn convert(cell: &CellValue, column: &BinlogColumnMeta) -> UniversalValue {
+    fn convert(cell: &CellValue, column: &BinlogColumnMeta) -> Value {
         binlog_cell_to_universal_value(cell, column, &RowConversionConfig::default()).unwrap()
     }
 
@@ -1039,7 +1036,7 @@ mod tests {
         let column = col("n", MYSQL_TYPE_LONG, ColumnMetadata::None);
         assert!(matches!(
             convert(&CellValue::Int(42), &column),
-            UniversalValue::Int32(42)
+            Value::Int32(42)
         ));
     }
 
@@ -1048,7 +1045,7 @@ mod tests {
         let column = col("n", MYSQL_TYPE_LONGLONG, ColumnMetadata::None);
         assert!(matches!(
             convert(&CellValue::Int(9_223_372_036_854_775_807), &column),
-            UniversalValue::Int64(9_223_372_036_854_775_807)
+            Value::Int64(9_223_372_036_854_775_807)
         ));
     }
 
@@ -1060,7 +1057,7 @@ mod tests {
             ColumnMetadata::String { max_length: 255 },
         );
         let value = convert(&CellValue::String("hello world".into()), &column);
-        if let UniversalValue::VarChar { value, .. } = value {
+        if let Value::VarChar { value, .. } = value {
             assert_eq!(value, "hello world");
         } else {
             panic!("expected VarChar");
@@ -1078,7 +1075,7 @@ mod tests {
             &CellValue::String("550e8400-e29b-41d4-a716-446655440000".into()),
             &column,
         );
-        if let UniversalValue::Uuid(u) = value {
+        if let Value::Uuid(u) = value {
             assert_eq!(u.to_string(), "550e8400-e29b-41d4-a716-446655440000");
         } else {
             panic!("expected Uuid");
@@ -1100,7 +1097,7 @@ mod tests {
             },
             &column,
         );
-        if let UniversalValue::LocalDateTime(dt) = value {
+        if let Value::LocalDateTime(dt) = value {
             assert_eq!(dt.year(), 2024);
             assert_eq!(dt.month(), 6);
             assert_eq!(dt.day(), 15);
@@ -1112,10 +1109,7 @@ mod tests {
     #[test]
     fn test_null_conversion() {
         let column = col("n", MYSQL_TYPE_LONG, ColumnMetadata::None);
-        assert!(matches!(
-            convert(&CellValue::Null, &column),
-            UniversalValue::Null
-        ));
+        assert!(matches!(convert(&CellValue::Null, &column), Value::Null));
     }
 
     #[test]
@@ -1129,7 +1123,7 @@ mod tests {
             &CellValue::JsonText(r#"{"name":"Alice","age":30}"#.into()),
             &column,
         );
-        if let UniversalValue::Json(obj) = value {
+        if let Value::Json(obj) = value {
             assert!(obj.get("name").is_some());
             assert!(obj.get("age").is_some());
         } else {
@@ -1145,10 +1139,7 @@ mod tests {
             ColumnMetadata::Blob { length_bytes: 1 },
         );
         let value = convert(&CellValue::JsonBytes(vec![0x04, 0x01]), &column);
-        assert_eq!(
-            value,
-            UniversalValue::Json(Box::new(serde_json::Value::Bool(true)))
-        );
+        assert_eq!(value, Value::Json(Box::new(serde_json::Value::Bool(true))));
     }
 
     #[test]
@@ -1182,7 +1173,7 @@ mod tests {
             &CellValue::Decimal(Decimal::from_str("123.456").unwrap()),
             &column,
         );
-        if let UniversalValue::Decimal { value, .. } = value {
+        if let Value::Decimal { value, .. } = value {
             assert_eq!(value, "123.456");
         } else {
             panic!("expected Decimal");
@@ -1198,7 +1189,7 @@ mod tests {
         )
         .with_binary(true);
         let data = vec![0x00, 0x01, 0x02, 0xFF];
-        if let UniversalValue::Blob(b) = convert(&CellValue::Bytes(data.clone()), &column) {
+        if let Value::Blob(b) = convert(&CellValue::Bytes(data.clone()), &column) {
             assert_eq!(b, data);
         } else {
             panic!("expected Blob");
@@ -1212,9 +1203,7 @@ mod tests {
             MYSQL_TYPE_BLOB,
             ColumnMetadata::Blob { length_bytes: 2 },
         );
-        if let UniversalValue::Text(s) =
-            convert(&CellValue::String("long text content".into()), &column)
-        {
+        if let Value::Text(s) = convert(&CellValue::String("long text content".into()), &column) {
             assert_eq!(s, "long text content");
         } else {
             panic!("expected Text");
@@ -1226,7 +1215,7 @@ mod tests {
         let column = col("flag", MYSQL_TYPE_TINY, ColumnMetadata::None).with_boolean_hint(true);
         assert!(matches!(
             convert(&CellValue::Int(1), &column),
-            UniversalValue::Bool(true)
+            Value::Bool(true)
         ));
     }
 
@@ -1235,7 +1224,7 @@ mod tests {
         let column = col("flag", MYSQL_TYPE_TINY, ColumnMetadata::None).with_boolean_hint(true);
         assert!(matches!(
             convert(&CellValue::Int(0), &column),
-            UniversalValue::Bool(false)
+            Value::Bool(false)
         ));
     }
 
@@ -1244,7 +1233,7 @@ mod tests {
         let column = col("n", MYSQL_TYPE_TINY, ColumnMetadata::None);
         assert!(matches!(
             convert(&CellValue::Int(1), &column),
-            UniversalValue::Int8 { value: 1, .. }
+            Value::Int8 { value: 1, .. }
         ));
     }
 
@@ -1253,7 +1242,7 @@ mod tests {
         let column = col("flag", MYSQL_TYPE_TINY, ColumnMetadata::None).with_boolean_hint(true);
         assert!(matches!(
             convert(&CellValue::Int(1), &column),
-            UniversalValue::Bool(true)
+            Value::Bool(true)
         ));
     }
 
@@ -1262,7 +1251,7 @@ mod tests {
         let column = col("flag", MYSQL_TYPE_TINY, ColumnMetadata::None).with_boolean_hint(true);
         assert!(matches!(
             convert(&CellValue::Int(0), &column),
-            UniversalValue::Bool(false)
+            Value::Bool(false)
         ));
     }
 
@@ -1271,17 +1260,14 @@ mod tests {
         let column = col("flag", MYSQL_TYPE_TINY, ColumnMetadata::None).with_boolean_hint(true);
         assert!(matches!(
             convert(&CellValue::Int(5), &column),
-            UniversalValue::Int8 { value: 5, .. }
+            Value::Int8 { value: 5, .. }
         ));
     }
 
     #[test]
     fn test_null_boolean_column() {
         let column = col("flag", MYSQL_TYPE_TINY, ColumnMetadata::None).with_boolean_hint(true);
-        assert!(matches!(
-            convert(&CellValue::Null, &column),
-            UniversalValue::Null
-        ));
+        assert!(matches!(convert(&CellValue::Null, &column), Value::Null));
     }
 
     #[test]
@@ -1307,7 +1293,7 @@ mod tests {
             &config,
         )
         .unwrap();
-        if let UniversalValue::Json(root) = value {
+        if let Value::Json(root) = value {
             let settings = root.get("settings").unwrap();
             assert_eq!(
                 settings.get("enabled"),
@@ -1340,7 +1326,7 @@ mod tests {
             &config,
         )
         .unwrap();
-        if let UniversalValue::Json(root) = value {
+        if let Value::Json(root) = value {
             let perms = root.get("permissions").unwrap().as_array().unwrap();
             assert_eq!(perms.len(), 3);
         } else {
@@ -1355,7 +1341,7 @@ mod tests {
             MYSQL_TYPE_JSON,
             ColumnMetadata::Blob { length_bytes: 2 },
         );
-        if let UniversalValue::Json(root) = convert(
+        if let Value::Json(root) = convert(
             &CellValue::JsonText(r#"{"enabled":1,"disabled":0}"#.into()),
             &column,
         ) {
@@ -1431,8 +1417,8 @@ mod tests {
         );
         assert!(matches!(
             value,
-            UniversalValue::ZeroTemporal {
-                intended_type: UniversalType::Date,
+            Value::ZeroTemporal {
+                intended_type: Type::Date,
                 ..
             }
         ));
@@ -1455,8 +1441,8 @@ mod tests {
         );
         assert!(matches!(
             value,
-            UniversalValue::ZeroTemporal {
-                intended_type: UniversalType::LocalDateTime,
+            Value::ZeroTemporal {
+                intended_type: Type::LocalDateTime,
                 ..
             }
         ));
@@ -1507,7 +1493,7 @@ mod tests {
             MYSQL_TYPE_SET,
             ColumnMetadata::EnumSet { max_length: 0 },
         );
-        if let UniversalValue::Set { elements, .. } =
+        if let Value::Set { elements, .. } =
             binlog_cell_to_universal_value(&CellValue::String(String::new()), &column, &config)
                 .unwrap()
         {
@@ -1524,7 +1510,7 @@ mod tests {
             MYSQL_TYPE_SET,
             ColumnMetadata::EnumSet { max_length: 0 },
         );
-        if let UniversalValue::Set { elements, .. } =
+        if let Value::Set { elements, .. } =
             convert(&CellValue::String("read,write,execute".into()), &column)
         {
             assert_eq!(elements, vec!["read", "write", "execute"]);
@@ -1540,9 +1526,7 @@ mod tests {
             MYSQL_TYPE_ENUM,
             ColumnMetadata::EnumSet { max_length: 0 },
         );
-        if let UniversalValue::Enum { value, .. } =
-            convert(&CellValue::String("active".into()), &column)
-        {
+        if let Value::Enum { value, .. } = convert(&CellValue::String("active".into()), &column) {
             assert_eq!(value, "active");
         } else {
             panic!("expected Enum");
@@ -1558,11 +1542,11 @@ mod tests {
         );
         assert!(matches!(
             convert(&CellValue::Bit(vec![0]), &column),
-            UniversalValue::Bool(false)
+            Value::Bool(false)
         ));
         assert!(matches!(
             convert(&CellValue::Bit(vec![1]), &column),
-            UniversalValue::Bool(true)
+            Value::Bool(true)
         ));
     }
 
@@ -1573,7 +1557,7 @@ mod tests {
             MYSQL_TYPE_BIT,
             ColumnMetadata::Bit { length_bits: 8 },
         );
-        if let UniversalValue::Bytes(b) = convert(&CellValue::Bit(vec![0xff]), &column) {
+        if let Value::Bytes(b) = convert(&CellValue::Bit(vec![0xff]), &column) {
             assert_eq!(b, vec![0xff]);
         } else {
             panic!("expected Bytes");
@@ -1590,8 +1574,7 @@ mod tests {
             MYSQL_TYPE_GEOMETRY,
             ColumnMetadata::Blob { length_bytes: 4 },
         );
-        if let UniversalValue::Geometry { data, .. } =
-            convert(&CellValue::Bytes(wkb_point.clone()), &column)
+        if let Value::Geometry { data, .. } = convert(&CellValue::Bytes(wkb_point.clone()), &column)
         {
             let GeometryData(json) = data;
             let expected_b64 = base64::engine::general_purpose::STANDARD.encode(&wkb_point);
@@ -1607,7 +1590,7 @@ mod tests {
         let column = col("y", MYSQL_TYPE_YEAR, ColumnMetadata::None);
         assert!(matches!(
             convert(&CellValue::Year(2024), &column),
-            UniversalValue::Int16(2024)
+            Value::Int16(2024)
         ));
     }
 }

--- a/crates/mysql-types/src/ddl.rs
+++ b/crates/mysql-types/src/ddl.rs
@@ -1,72 +1,68 @@
-//! MySQL DDL generation from UniversalType.
+//! MySQL DDL generation from Type.
 //!
 //! This module provides DDL (Data Definition Language) generation for MySQL,
-//! converting sync-core's `UniversalType` to MySQL column type definitions.
+//! converting sync-core's `Type` to MySQL column type definitions.
 
-use sync_core::{GeometryType, UniversalType};
+use sync_core::{GeometryType, Type};
 
 /// Trait for generating DDL type strings.
 pub trait ToDdl {
-    /// Convert a UniversalType to a DDL type string.
-    fn to_ddl(&self, ext_type: &UniversalType) -> String;
+    /// Convert a Type to a DDL type string.
+    fn to_ddl(&self, ext_type: &Type) -> String;
 
     /// Generate a complete CREATE TABLE statement.
-    fn to_create_table(
-        &self,
-        table_name: &str,
-        columns: &[(String, UniversalType, bool)],
-    ) -> String;
+    fn to_create_table(&self, table_name: &str, columns: &[(String, Type, bool)]) -> String;
 }
 
 /// MySQL DDL generator.
 pub struct MySQLDdl;
 
 impl ToDdl for MySQLDdl {
-    fn to_ddl(&self, ext_type: &UniversalType) -> String {
+    fn to_ddl(&self, ext_type: &Type) -> String {
         match ext_type {
             // Boolean - MySQL uses TINYINT(1)
-            UniversalType::Bool => "TINYINT(1)".to_string(),
+            Type::Bool => "TINYINT(1)".to_string(),
 
             // Integer types
-            UniversalType::Int8 { width } => format!("TINYINT({width})"),
-            UniversalType::Int16 => "SMALLINT".to_string(),
-            UniversalType::Int32 => "INT".to_string(),
-            UniversalType::Int64 => "BIGINT".to_string(),
+            Type::Int8 { width } => format!("TINYINT({width})"),
+            Type::Int16 => "SMALLINT".to_string(),
+            Type::Int32 => "INT".to_string(),
+            Type::Int64 => "BIGINT".to_string(),
 
             // Floating point
-            UniversalType::Float32 => "FLOAT".to_string(),
-            UniversalType::Float64 => "DOUBLE".to_string(),
+            Type::Float32 => "FLOAT".to_string(),
+            Type::Float64 => "DOUBLE".to_string(),
 
             // Exact numeric
-            UniversalType::Decimal { precision, scale } => {
+            Type::Decimal { precision, scale } => {
                 format!("DECIMAL({precision},{scale})")
             }
 
             // String types
-            UniversalType::Char { length } => format!("CHAR({length})"),
-            UniversalType::VarChar { length } => format!("VARCHAR({length})"),
-            UniversalType::Text => "TEXT".to_string(),
+            Type::Char { length } => format!("CHAR({length})"),
+            Type::VarChar { length } => format!("VARCHAR({length})"),
+            Type::Text => "TEXT".to_string(),
 
             // Binary types
-            UniversalType::Blob => "BLOB".to_string(),
-            UniversalType::Bytes => "VARBINARY(65535)".to_string(),
+            Type::Blob => "BLOB".to_string(),
+            Type::Bytes => "VARBINARY(65535)".to_string(),
 
             // Date/time types
-            UniversalType::Date => "DATE".to_string(),
-            UniversalType::Time => "TIME".to_string(),
-            UniversalType::LocalDateTime => "DATETIME(6)".to_string(),
-            UniversalType::LocalDateTimeNano => "DATETIME(6)".to_string(), // MySQL max precision is 6
-            UniversalType::ZonedDateTime => "TIMESTAMP(6)".to_string(),
+            Type::Date => "DATE".to_string(),
+            Type::Time => "TIME".to_string(),
+            Type::LocalDateTime => "DATETIME(6)".to_string(),
+            Type::LocalDateTimeNano => "DATETIME(6)".to_string(), // MySQL max precision is 6
+            Type::ZonedDateTime => "TIMESTAMP(6)".to_string(),
 
             // Special types
-            UniversalType::Uuid => "CHAR(36)".to_string(),
-            UniversalType::Ulid => "CHAR(26)".to_string(), // ULID is 26 chars in string form
-            UniversalType::Json => "JSON".to_string(),
-            UniversalType::Jsonb => "JSON".to_string(), // MySQL doesn't have binary JSON
+            Type::Uuid => "CHAR(36)".to_string(),
+            Type::Ulid => "CHAR(26)".to_string(), // ULID is 26 chars in string form
+            Type::Json => "JSON".to_string(),
+            Type::Jsonb => "JSON".to_string(), // MySQL doesn't have binary JSON
 
             // Collection types - stored as JSON in MySQL
-            UniversalType::Array { .. } => "JSON".to_string(),
-            UniversalType::Set { values } => {
+            Type::Array { .. } => "JSON".to_string(),
+            Type::Set { values } => {
                 let escaped: Vec<String> = values
                     .iter()
                     .map(|v| format!("'{}'", v.replace('\'', "''")))
@@ -75,7 +71,7 @@ impl ToDdl for MySQLDdl {
             }
 
             // Enumeration
-            UniversalType::Enum { values } => {
+            Type::Enum { values } => {
                 let escaped: Vec<String> = values
                     .iter()
                     .map(|v| format!("'{}'", v.replace('\'', "''")))
@@ -84,7 +80,7 @@ impl ToDdl for MySQLDdl {
             }
 
             // Spatial types
-            UniversalType::Geometry { geometry_type } => match geometry_type {
+            Type::Geometry { geometry_type } => match geometry_type {
                 GeometryType::Point => "POINT".to_string(),
                 GeometryType::LineString => "LINESTRING".to_string(),
                 GeometryType::Polygon => "POLYGON".to_string(),
@@ -95,26 +91,22 @@ impl ToDdl for MySQLDdl {
             },
 
             // Duration - store as VARCHAR for ISO 8601 duration string
-            UniversalType::Duration => "VARCHAR(64)".to_string(),
+            Type::Duration => "VARCHAR(64)".to_string(),
 
             // Thing - record reference stored as VARCHAR (table:id format)
-            UniversalType::Thing => "VARCHAR(255)".to_string(),
+            Type::Thing => "VARCHAR(255)".to_string(),
 
             // Object - nested document stored as JSON
-            UniversalType::Object => "JSON".to_string(),
+            Type::Object => "JSON".to_string(),
 
             // TimeTz - MySQL doesn't have native TIMETZ, store as VARCHAR
             // Note: We intentionally use VARCHAR instead of TIME because MySQL TIME
             // doesn't support timezone offsets. Storing as string preserves the original format.
-            UniversalType::TimeTz => "VARCHAR(32)".to_string(),
+            Type::TimeTz => "VARCHAR(32)".to_string(),
         }
     }
 
-    fn to_create_table(
-        &self,
-        table_name: &str,
-        columns: &[(String, UniversalType, bool)],
-    ) -> String {
+    fn to_create_table(&self, table_name: &str, columns: &[(String, Type, bool)]) -> String {
         let column_defs: Vec<String> = columns
             .iter()
             .map(|(name, dtype, nullable)| {
@@ -137,8 +129,8 @@ impl MySQLDdl {
         &self,
         table_name: &str,
         pk_column: &str,
-        pk_type: &UniversalType,
-        columns: &[(String, UniversalType, bool)],
+        pk_type: &Type,
+        columns: &[(String, Type, bool)],
     ) -> String {
         let mut all_columns = vec![(pk_column.to_string(), pk_type.clone(), false)];
         all_columns.extend(columns.iter().cloned());
@@ -164,7 +156,7 @@ impl MySQLDdl {
         &self,
         table_name: &str,
         pk_column: &str,
-        columns: &[(String, UniversalType, bool)],
+        columns: &[(String, Type, bool)],
     ) -> String {
         let column_defs: Vec<String> = columns
             .iter()
@@ -229,30 +221,30 @@ mod tests {
     #[test]
     fn test_bool_ddl() {
         let ddl = MySQLDdl;
-        assert_eq!(ddl.to_ddl(&UniversalType::Bool), "TINYINT(1)");
+        assert_eq!(ddl.to_ddl(&Type::Bool), "TINYINT(1)");
     }
 
     #[test]
     fn test_integer_ddl() {
         let ddl = MySQLDdl;
-        assert_eq!(ddl.to_ddl(&UniversalType::Int8 { width: 4 }), "TINYINT(4)");
-        assert_eq!(ddl.to_ddl(&UniversalType::Int16), "SMALLINT");
-        assert_eq!(ddl.to_ddl(&UniversalType::Int32), "INT");
-        assert_eq!(ddl.to_ddl(&UniversalType::Int64), "BIGINT");
+        assert_eq!(ddl.to_ddl(&Type::Int8 { width: 4 }), "TINYINT(4)");
+        assert_eq!(ddl.to_ddl(&Type::Int16), "SMALLINT");
+        assert_eq!(ddl.to_ddl(&Type::Int32), "INT");
+        assert_eq!(ddl.to_ddl(&Type::Int64), "BIGINT");
     }
 
     #[test]
     fn test_float_ddl() {
         let ddl = MySQLDdl;
-        assert_eq!(ddl.to_ddl(&UniversalType::Float32), "FLOAT");
-        assert_eq!(ddl.to_ddl(&UniversalType::Float64), "DOUBLE");
+        assert_eq!(ddl.to_ddl(&Type::Float32), "FLOAT");
+        assert_eq!(ddl.to_ddl(&Type::Float64), "DOUBLE");
     }
 
     #[test]
     fn test_decimal_ddl() {
         let ddl = MySQLDdl;
         assert_eq!(
-            ddl.to_ddl(&UniversalType::Decimal {
+            ddl.to_ddl(&Type::Decimal {
                 precision: 10,
                 scale: 2
             }),
@@ -263,49 +255,46 @@ mod tests {
     #[test]
     fn test_string_ddl() {
         let ddl = MySQLDdl;
-        assert_eq!(ddl.to_ddl(&UniversalType::Char { length: 10 }), "CHAR(10)");
-        assert_eq!(
-            ddl.to_ddl(&UniversalType::VarChar { length: 255 }),
-            "VARCHAR(255)"
-        );
-        assert_eq!(ddl.to_ddl(&UniversalType::Text), "TEXT");
+        assert_eq!(ddl.to_ddl(&Type::Char { length: 10 }), "CHAR(10)");
+        assert_eq!(ddl.to_ddl(&Type::VarChar { length: 255 }), "VARCHAR(255)");
+        assert_eq!(ddl.to_ddl(&Type::Text), "TEXT");
     }
 
     #[test]
     fn test_binary_ddl() {
         let ddl = MySQLDdl;
-        assert_eq!(ddl.to_ddl(&UniversalType::Blob), "BLOB");
-        assert_eq!(ddl.to_ddl(&UniversalType::Bytes), "VARBINARY(65535)");
+        assert_eq!(ddl.to_ddl(&Type::Blob), "BLOB");
+        assert_eq!(ddl.to_ddl(&Type::Bytes), "VARBINARY(65535)");
     }
 
     #[test]
     fn test_datetime_ddl() {
         let ddl = MySQLDdl;
-        assert_eq!(ddl.to_ddl(&UniversalType::Date), "DATE");
-        assert_eq!(ddl.to_ddl(&UniversalType::Time), "TIME");
-        assert_eq!(ddl.to_ddl(&UniversalType::LocalDateTime), "DATETIME(6)");
-        assert_eq!(ddl.to_ddl(&UniversalType::ZonedDateTime), "TIMESTAMP(6)");
+        assert_eq!(ddl.to_ddl(&Type::Date), "DATE");
+        assert_eq!(ddl.to_ddl(&Type::Time), "TIME");
+        assert_eq!(ddl.to_ddl(&Type::LocalDateTime), "DATETIME(6)");
+        assert_eq!(ddl.to_ddl(&Type::ZonedDateTime), "TIMESTAMP(6)");
     }
 
     #[test]
     fn test_uuid_ddl() {
         let ddl = MySQLDdl;
-        assert_eq!(ddl.to_ddl(&UniversalType::Uuid), "CHAR(36)");
+        assert_eq!(ddl.to_ddl(&Type::Uuid), "CHAR(36)");
     }
 
     #[test]
     fn test_json_ddl() {
         let ddl = MySQLDdl;
-        assert_eq!(ddl.to_ddl(&UniversalType::Json), "JSON");
-        assert_eq!(ddl.to_ddl(&UniversalType::Jsonb), "JSON");
+        assert_eq!(ddl.to_ddl(&Type::Json), "JSON");
+        assert_eq!(ddl.to_ddl(&Type::Jsonb), "JSON");
     }
 
     #[test]
     fn test_array_ddl() {
         let ddl = MySQLDdl;
         assert_eq!(
-            ddl.to_ddl(&UniversalType::Array {
-                element_type: Box::new(UniversalType::Int32)
+            ddl.to_ddl(&Type::Array {
+                element_type: Box::new(Type::Int32)
             }),
             "JSON"
         );
@@ -315,7 +304,7 @@ mod tests {
     fn test_enum_ddl() {
         let ddl = MySQLDdl;
         assert_eq!(
-            ddl.to_ddl(&UniversalType::Enum {
+            ddl.to_ddl(&Type::Enum {
                 values: vec![
                     "active".to_string(),
                     "inactive".to_string(),
@@ -330,7 +319,7 @@ mod tests {
     fn test_set_ddl() {
         let ddl = MySQLDdl;
         assert_eq!(
-            ddl.to_ddl(&UniversalType::Set {
+            ddl.to_ddl(&Type::Set {
                 values: vec![
                     "read".to_string(),
                     "write".to_string(),
@@ -345,13 +334,13 @@ mod tests {
     fn test_geometry_ddl() {
         let ddl = MySQLDdl;
         assert_eq!(
-            ddl.to_ddl(&UniversalType::Geometry {
+            ddl.to_ddl(&Type::Geometry {
                 geometry_type: GeometryType::Point
             }),
             "POINT"
         );
         assert_eq!(
-            ddl.to_ddl(&UniversalType::Geometry {
+            ddl.to_ddl(&Type::Geometry {
                 geometry_type: GeometryType::Polygon
             }),
             "POLYGON"
@@ -362,17 +351,9 @@ mod tests {
     fn test_create_table() {
         let ddl = MySQLDdl;
         let columns = vec![
-            (
-                "name".to_string(),
-                UniversalType::VarChar { length: 100 },
-                false,
-            ),
-            (
-                "email".to_string(),
-                UniversalType::VarChar { length: 255 },
-                false,
-            ),
-            ("age".to_string(), UniversalType::Int32, true),
+            ("name".to_string(), Type::VarChar { length: 100 }, false),
+            ("email".to_string(), Type::VarChar { length: 255 }, false),
+            ("age".to_string(), Type::Int32, true),
         ];
 
         let sql = ddl.to_create_table("users", &columns);
@@ -386,19 +367,11 @@ mod tests {
     fn test_create_table_with_pk() {
         let ddl = MySQLDdl;
         let columns = vec![
-            (
-                "name".to_string(),
-                UniversalType::VarChar { length: 100 },
-                false,
-            ),
-            (
-                "email".to_string(),
-                UniversalType::VarChar { length: 255 },
-                false,
-            ),
+            ("name".to_string(), Type::VarChar { length: 100 }, false),
+            ("email".to_string(), Type::VarChar { length: 255 }, false),
         ];
 
-        let sql = ddl.to_create_table_with_pk("users", "id", &UniversalType::Uuid, &columns);
+        let sql = ddl.to_create_table_with_pk("users", "id", &Type::Uuid, &columns);
         assert!(sql.contains("CREATE TABLE `users`"));
         assert!(sql.contains("`id` CHAR(36) NOT NULL"));
         assert!(sql.contains("PRIMARY KEY (`id`)"));
@@ -408,16 +381,8 @@ mod tests {
     fn test_create_table_with_auto_pk() {
         let ddl = MySQLDdl;
         let columns = vec![
-            (
-                "name".to_string(),
-                UniversalType::VarChar { length: 100 },
-                false,
-            ),
-            (
-                "email".to_string(),
-                UniversalType::VarChar { length: 255 },
-                false,
-            ),
+            ("name".to_string(), Type::VarChar { length: 100 }, false),
+            ("email".to_string(), Type::VarChar { length: 255 }, false),
         ];
 
         let sql = ddl.to_create_table_with_auto_pk("users", "id", &columns);

--- a/crates/mysql-types/src/forward.rs
+++ b/crates/mysql-types/src/forward.rs
@@ -1,73 +1,73 @@
-//! Forward conversion: UniversalValue/TypedValue → MySQLValue
+//! Forward conversion: Value/TypedValue → MySQLValue
 //!
-//! This module implements `From<UniversalValue>` and `From<TypedValue>` for `MySQLValue`,
+//! This module implements `From<Value>` and `From<TypedValue>` for `MySQLValue`,
 //! converting sync-core's values into MySQL-compatible values for INSERT operations.
-//! The TypedValue implementation delegates to UniversalValue since MySQL doesn't need
+//! The TypedValue implementation delegates to Value since MySQL doesn't need
 //! type metadata for conversion.
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use chrono::{Datelike, Timelike};
-use mysql_async::Value;
-use sync_core::{TypedValue, UniversalValue};
+use mysql_async::Value as MysqlAsyncValue;
+use sync_core::{TypedValue, Value};
 
 #[cfg(test)]
-use sync_core::UniversalType;
+use sync_core::Type;
 
 /// MySQL value wrapper for type-safe conversions.
 #[derive(Debug, Clone)]
-pub struct MySQLValue(pub Value);
+pub struct MySQLValue(pub MysqlAsyncValue);
 
 impl MySQLValue {
     /// Get the inner mysql_async::Value.
-    pub fn into_inner(self) -> Value {
+    pub fn into_inner(self) -> MysqlAsyncValue {
         self.0
     }
 
     /// Get a reference to the inner value.
-    pub fn as_inner(&self) -> &Value {
+    pub fn as_inner(&self) -> &MysqlAsyncValue {
         &self.0
     }
 }
 
-impl From<UniversalValue> for MySQLValue {
-    fn from(value: UniversalValue) -> Self {
+impl From<Value> for MySQLValue {
+    fn from(value: Value) -> Self {
         match value {
             // Null
-            UniversalValue::Null => MySQLValue(Value::NULL),
+            Value::Null => MySQLValue(MysqlAsyncValue::NULL),
 
             // Boolean - MySQL uses TINYINT(1)
-            UniversalValue::Bool(b) => MySQLValue(Value::Int(if b { 1 } else { 0 })),
+            Value::Bool(b) => MySQLValue(MysqlAsyncValue::Int(if b { 1 } else { 0 })),
 
             // Integer types
-            UniversalValue::Int8 { value, .. } => MySQLValue(Value::Int(value as i64)),
-            UniversalValue::Int16(i) => MySQLValue(Value::Int(i as i64)),
-            UniversalValue::Int32(i) => MySQLValue(Value::Int(i as i64)),
-            UniversalValue::Int64(i) => MySQLValue(Value::Int(i)),
+            Value::Int8 { value, .. } => MySQLValue(MysqlAsyncValue::Int(value as i64)),
+            Value::Int16(i) => MySQLValue(MysqlAsyncValue::Int(i as i64)),
+            Value::Int32(i) => MySQLValue(MysqlAsyncValue::Int(i as i64)),
+            Value::Int64(i) => MySQLValue(MysqlAsyncValue::Int(i)),
 
             // Floating point
-            UniversalValue::Float32(f) => MySQLValue(Value::Float(f)),
-            UniversalValue::Float64(f) => MySQLValue(Value::Double(f)),
+            Value::Float32(f) => MySQLValue(MysqlAsyncValue::Float(f)),
+            Value::Float64(f) => MySQLValue(MysqlAsyncValue::Double(f)),
 
             // Decimal - stored as string in MySQL for precision
-            UniversalValue::Decimal { value, .. } => MySQLValue(Value::Bytes(value.into_bytes())),
+            Value::Decimal { value, .. } => MySQLValue(MysqlAsyncValue::Bytes(value.into_bytes())),
 
             // String types
-            UniversalValue::Char { value, .. } => MySQLValue(Value::Bytes(value.into_bytes())),
-            UniversalValue::VarChar { value, .. } => MySQLValue(Value::Bytes(value.into_bytes())),
-            UniversalValue::Text(s) => MySQLValue(Value::Bytes(s.into_bytes())),
+            Value::Char { value, .. } => MySQLValue(MysqlAsyncValue::Bytes(value.into_bytes())),
+            Value::VarChar { value, .. } => MySQLValue(MysqlAsyncValue::Bytes(value.into_bytes())),
+            Value::Text(s) => MySQLValue(MysqlAsyncValue::Bytes(s.into_bytes())),
 
             // Binary types
-            UniversalValue::Blob(b) => MySQLValue(Value::Bytes(b)),
-            UniversalValue::Bytes(b) => MySQLValue(Value::Bytes(b)),
+            Value::Blob(b) => MySQLValue(MysqlAsyncValue::Bytes(b)),
+            Value::Bytes(b) => MySQLValue(MysqlAsyncValue::Bytes(b)),
 
             // UUID - MySQL stores as CHAR(36)
-            UniversalValue::Uuid(u) => MySQLValue(Value::Bytes(u.to_string().into_bytes())),
+            Value::Uuid(u) => MySQLValue(MysqlAsyncValue::Bytes(u.to_string().into_bytes())),
 
             // ULID - MySQL stores as CHAR(26)
-            UniversalValue::Ulid(u) => MySQLValue(Value::Bytes(u.to_string().into_bytes())),
+            Value::Ulid(u) => MySQLValue(MysqlAsyncValue::Bytes(u.to_string().into_bytes())),
 
             // Date - MySQL DATE (only date part, no time)
-            UniversalValue::Date(dt) => MySQLValue(Value::Date(
+            Value::Date(dt) => MySQLValue(MysqlAsyncValue::Date(
                 dt.year() as u16,
                 dt.month() as u8,
                 dt.day() as u8,
@@ -78,7 +78,7 @@ impl From<UniversalValue> for MySQLValue {
             )),
 
             // Time - MySQL TIME
-            UniversalValue::Time(dt) => MySQLValue(Value::Time(
+            Value::Time(dt) => MySQLValue(MysqlAsyncValue::Time(
                 false, // not negative
                 0,     // days
                 dt.hour() as u8,
@@ -88,51 +88,51 @@ impl From<UniversalValue> for MySQLValue {
             )),
 
             // DateTime variants - MySQL DATETIME(6) and TIMESTAMP
-            UniversalValue::LocalDateTime(dt)
-            | UniversalValue::LocalDateTimeNano(dt)
-            | UniversalValue::ZonedDateTime(dt) => MySQLValue(Value::Date(
-                dt.year() as u16,
-                dt.month() as u8,
-                dt.day() as u8,
-                dt.hour() as u8,
-                dt.minute() as u8,
-                dt.second() as u8,
-                dt.nanosecond() / 1000, // MySQL uses microseconds
-            )),
+            Value::LocalDateTime(dt) | Value::LocalDateTimeNano(dt) | Value::ZonedDateTime(dt) => {
+                MySQLValue(MysqlAsyncValue::Date(
+                    dt.year() as u16,
+                    dt.month() as u8,
+                    dt.day() as u8,
+                    dt.hour() as u8,
+                    dt.minute() as u8,
+                    dt.second() as u8,
+                    dt.nanosecond() / 1000, // MySQL uses microseconds
+                ))
+            }
 
             // TimeTz - MySQL doesn't have native TIMETZ, store as VARCHAR
             // Note: We intentionally do NOT use a datetime type because time and datetime
             // are fundamentally different types.
-            UniversalValue::TimeTz(s) => MySQLValue(Value::Bytes(s.into_bytes())),
+            Value::TimeTz(s) => MySQLValue(MysqlAsyncValue::Bytes(s.into_bytes())),
 
             // JSON - MySQL JSON type
-            UniversalValue::Json(json_val) | UniversalValue::Jsonb(json_val) => {
-                MySQLValue(Value::Bytes(json_val.to_string().into_bytes()))
+            Value::Json(json_val) | Value::Jsonb(json_val) => {
+                MySQLValue(MysqlAsyncValue::Bytes(json_val.to_string().into_bytes()))
             }
 
             // Array - MySQL stores as JSON
-            UniversalValue::Array { elements, .. } => {
+            Value::Array { elements, .. } => {
                 let json = generated_array_to_json(elements);
-                MySQLValue(Value::Bytes(json.to_string().into_bytes()))
+                MySQLValue(MysqlAsyncValue::Bytes(json.to_string().into_bytes()))
             }
 
             // Set - MySQL SET type (comma-separated values)
-            UniversalValue::Set { elements, .. } => {
-                MySQLValue(Value::Bytes(elements.join(",").into_bytes()))
+            Value::Set { elements, .. } => {
+                MySQLValue(MysqlAsyncValue::Bytes(elements.join(",").into_bytes()))
             }
 
             // Enum - MySQL ENUM
-            UniversalValue::Enum { value, .. } => MySQLValue(Value::Bytes(value.into_bytes())),
+            Value::Enum { value, .. } => MySQLValue(MysqlAsyncValue::Bytes(value.into_bytes())),
 
             // Geometry - stored as GeoJSON string
-            UniversalValue::Geometry { data, .. } => {
+            Value::Geometry { data, .. } => {
                 use sync_core::values::GeometryData;
                 let GeometryData(json_val) = data;
-                MySQLValue(Value::Bytes(json_val.to_string().into_bytes()))
+                MySQLValue(MysqlAsyncValue::Bytes(json_val.to_string().into_bytes()))
             }
 
             // Duration - store as ISO 8601 duration string
-            UniversalValue::Duration(d) => {
+            Value::Duration(d) => {
                 let secs = d.as_secs();
                 let nanos = d.subsec_nanos();
                 let duration_str = if nanos == 0 {
@@ -140,43 +140,44 @@ impl From<UniversalValue> for MySQLValue {
                 } else {
                     format!("PT{secs}.{nanos:09}S")
                 };
-                MySQLValue(Value::Bytes(duration_str.into_bytes()))
+                MySQLValue(MysqlAsyncValue::Bytes(duration_str.into_bytes()))
             }
 
             // Thing - record reference as "table:id" format
-            UniversalValue::Thing { table, id } => {
+            Value::Thing { table, id } => {
                 let id_str = match id.as_ref() {
-                    UniversalValue::Text(s) => s.clone(),
-                    UniversalValue::Int32(i) => i.to_string(),
-                    UniversalValue::Int64(i) => i.to_string(),
-                    UniversalValue::Uuid(u) => u.to_string(),
+                    Value::Text(s) => s.clone(),
+                    Value::Int32(i) => i.to_string(),
+                    Value::Int64(i) => i.to_string(),
+                    Value::Uuid(u) => u.to_string(),
                     other => panic!(
                         "Unsupported Thing ID type for MySQL: {other:?}. \
                          Supported types: Text, Int32, Int64, Uuid"
                     ),
                 };
-                MySQLValue(Value::Bytes(format!("{table}:{id_str}").into_bytes()))
+                MySQLValue(MysqlAsyncValue::Bytes(
+                    format!("{table}:{id_str}").into_bytes(),
+                ))
             }
 
             // Object - nested document as JSON
-            UniversalValue::Object(map) => {
+            Value::Object(map) => {
                 let obj: serde_json::Map<String, serde_json::Value> = map
                     .into_iter()
                     .map(|(k, v)| (k, generated_to_json(v)))
                     .collect();
                 let json_str =
                     serde_json::to_string(&serde_json::Value::Object(obj)).unwrap_or_default();
-                MySQLValue(Value::Bytes(json_str.into_bytes()))
+                MySQLValue(MysqlAsyncValue::Bytes(json_str.into_bytes()))
             }
 
-            UniversalValue::ZeroTemporal {
+            Value::ZeroTemporal {
                 intended_type,
                 source,
             } => {
-                let s = source.unwrap_or_else(|| {
-                    UniversalValue::canonical_zero_literal(&intended_type).to_string()
-                });
-                MySQLValue(Value::Bytes(s.into_bytes()))
+                let s = source
+                    .unwrap_or_else(|| Value::canonical_zero_literal(&intended_type).to_string());
+                MySQLValue(MysqlAsyncValue::Bytes(s.into_bytes()))
             }
         }
     }
@@ -188,59 +189,57 @@ impl From<TypedValue> for MySQLValue {
     }
 }
 
-/// Convert a UniversalValue array to a serde_json::Value array.
-fn generated_array_to_json(arr: Vec<UniversalValue>) -> serde_json::Value {
+/// Convert a Value array to a serde_json::Value array.
+fn generated_array_to_json(arr: Vec<Value>) -> serde_json::Value {
     let values: Vec<serde_json::Value> = arr.into_iter().map(generated_to_json).collect();
     serde_json::Value::Array(values)
 }
 
-/// Convert any UniversalValue to serde_json::Value.
-fn generated_to_json(gv: UniversalValue) -> serde_json::Value {
+/// Convert any Value to serde_json::Value.
+fn generated_to_json(gv: Value) -> serde_json::Value {
     match gv {
-        UniversalValue::Null => serde_json::Value::Null,
-        UniversalValue::Bool(b) => serde_json::Value::Bool(b),
-        UniversalValue::Int8 { value, .. } => {
-            serde_json::Value::Number(serde_json::Number::from(value))
+        Value::Null => serde_json::Value::Null,
+        Value::Bool(b) => serde_json::Value::Bool(b),
+        Value::Int8 { value, .. } => serde_json::Value::Number(serde_json::Number::from(value)),
+        Value::Int16(i) => serde_json::Value::Number(serde_json::Number::from(i)),
+        Value::Int32(i) => serde_json::Value::Number(serde_json::Number::from(i)),
+        Value::Int64(i) => serde_json::Value::Number(serde_json::Number::from(i)),
+        Value::Float32(f) => serde_json::Number::from_f64(f as f64)
+            .map(serde_json::Value::Number)
+            .unwrap_or(serde_json::Value::Null),
+        Value::Float64(f) => serde_json::Number::from_f64(f)
+            .map(serde_json::Value::Number)
+            .unwrap_or(serde_json::Value::Null),
+        Value::Char { value, .. } => serde_json::Value::String(value),
+        Value::VarChar { value, .. } => serde_json::Value::String(value),
+        Value::Text(s) => serde_json::Value::String(s),
+        Value::Blob(b) => serde_json::Value::String(BASE64.encode(&b)),
+        Value::Bytes(b) => serde_json::Value::String(BASE64.encode(&b)),
+        Value::Uuid(u) => serde_json::Value::String(u.to_string()),
+        Value::Ulid(u) => serde_json::Value::String(u.to_string()),
+        Value::Date(dt) => serde_json::Value::String(dt.format("%Y-%m-%d").to_string()),
+        Value::Time(dt) => serde_json::Value::String(dt.format("%H:%M:%S%.f").to_string()),
+        Value::LocalDateTime(dt) | Value::LocalDateTimeNano(dt) | Value::ZonedDateTime(dt) => {
+            serde_json::Value::String(dt.to_rfc3339())
         }
-        UniversalValue::Int16(i) => serde_json::Value::Number(serde_json::Number::from(i)),
-        UniversalValue::Int32(i) => serde_json::Value::Number(serde_json::Number::from(i)),
-        UniversalValue::Int64(i) => serde_json::Value::Number(serde_json::Number::from(i)),
-        UniversalValue::Float32(f) => serde_json::Number::from_f64(f as f64)
-            .map(serde_json::Value::Number)
-            .unwrap_or(serde_json::Value::Null),
-        UniversalValue::Float64(f) => serde_json::Number::from_f64(f)
-            .map(serde_json::Value::Number)
-            .unwrap_or(serde_json::Value::Null),
-        UniversalValue::Char { value, .. } => serde_json::Value::String(value),
-        UniversalValue::VarChar { value, .. } => serde_json::Value::String(value),
-        UniversalValue::Text(s) => serde_json::Value::String(s),
-        UniversalValue::Blob(b) => serde_json::Value::String(BASE64.encode(&b)),
-        UniversalValue::Bytes(b) => serde_json::Value::String(BASE64.encode(&b)),
-        UniversalValue::Uuid(u) => serde_json::Value::String(u.to_string()),
-        UniversalValue::Ulid(u) => serde_json::Value::String(u.to_string()),
-        UniversalValue::Date(dt) => serde_json::Value::String(dt.format("%Y-%m-%d").to_string()),
-        UniversalValue::Time(dt) => serde_json::Value::String(dt.format("%H:%M:%S%.f").to_string()),
-        UniversalValue::LocalDateTime(dt)
-        | UniversalValue::LocalDateTimeNano(dt)
-        | UniversalValue::ZonedDateTime(dt) => serde_json::Value::String(dt.to_rfc3339()),
-        UniversalValue::TimeTz(s) => serde_json::Value::String(s),
-        UniversalValue::Decimal { value, .. } => serde_json::Value::String(value),
-        UniversalValue::Array { elements, .. } => generated_array_to_json(elements),
-        UniversalValue::Set { elements, .. } => {
+        Value::TimeTz(s) => serde_json::Value::String(s),
+        Value::Decimal { value, .. } => serde_json::Value::String(value),
+        Value::Array { elements, .. } => generated_array_to_json(elements),
+        Value::Set { elements, .. } => {
             let arr: Vec<serde_json::Value> = elements
                 .into_iter()
                 .map(serde_json::Value::String)
                 .collect();
             serde_json::Value::Array(arr)
         }
-        UniversalValue::Enum { value, .. } => serde_json::Value::String(value),
-        UniversalValue::Json(json_val) | UniversalValue::Jsonb(json_val) => *json_val,
-        UniversalValue::Geometry { data, .. } => {
+        Value::Enum { value, .. } => serde_json::Value::String(value),
+        Value::Json(json_val) | Value::Jsonb(json_val) => *json_val,
+        Value::Geometry { data, .. } => {
             use sync_core::values::GeometryData;
             let GeometryData(json_val) = data;
             json_val
         }
-        UniversalValue::Duration(d) => {
+        Value::Duration(d) => {
             let secs = d.as_secs();
             let nanos = d.subsec_nanos();
             if nanos == 0 {
@@ -249,12 +248,12 @@ fn generated_to_json(gv: UniversalValue) -> serde_json::Value {
                 serde_json::Value::String(format!("PT{secs}.{nanos:09}S"))
             }
         }
-        UniversalValue::Thing { table, id } => {
+        Value::Thing { table, id } => {
             let id_str = match id.as_ref() {
-                UniversalValue::Text(s) => s.clone(),
-                UniversalValue::Int32(i) => i.to_string(),
-                UniversalValue::Int64(i) => i.to_string(),
-                UniversalValue::Uuid(u) => u.to_string(),
+                Value::Text(s) => s.clone(),
+                Value::Int32(i) => i.to_string(),
+                Value::Int64(i) => i.to_string(),
+                Value::Uuid(u) => u.to_string(),
                 other => panic!(
                     "Unsupported Thing ID type for MySQL JSON: {other:?}. \
                      Supported types: Text, Int32, Int64, Uuid"
@@ -262,20 +261,19 @@ fn generated_to_json(gv: UniversalValue) -> serde_json::Value {
             };
             serde_json::Value::String(format!("{table}:{id_str}"))
         }
-        UniversalValue::Object(map) => {
+        Value::Object(map) => {
             let obj: serde_json::Map<String, serde_json::Value> = map
                 .into_iter()
                 .map(|(k, v)| (k, generated_to_json(v)))
                 .collect();
             serde_json::Value::Object(obj)
         }
-        UniversalValue::ZeroTemporal {
+        Value::ZeroTemporal {
             intended_type,
             source,
         } => {
-            let s = source.unwrap_or_else(|| {
-                UniversalValue::canonical_zero_literal(&intended_type).to_string()
-            });
+            let s =
+                source.unwrap_or_else(|| Value::canonical_zero_literal(&intended_type).to_string());
             serde_json::Value::String(s)
         }
     }
@@ -291,32 +289,35 @@ mod tests {
     fn test_bool_conversion() {
         let tv = TypedValue::bool(true);
         let mysql_val: MySQLValue = tv.into();
-        assert!(matches!(mysql_val.0, Value::Int(1)));
+        assert!(matches!(mysql_val.0, MysqlAsyncValue::Int(1)));
 
         let tv = TypedValue::bool(false);
         let mysql_val: MySQLValue = tv.into();
-        assert!(matches!(mysql_val.0, Value::Int(0)));
+        assert!(matches!(mysql_val.0, MysqlAsyncValue::Int(0)));
     }
 
     #[test]
     fn test_int_conversion() {
         let tv = TypedValue::int32(42);
         let mysql_val: MySQLValue = tv.into();
-        assert!(matches!(mysql_val.0, Value::Int(42)));
+        assert!(matches!(mysql_val.0, MysqlAsyncValue::Int(42)));
     }
 
     #[test]
     fn test_bigint_conversion() {
         let tv = TypedValue::int64(9_223_372_036_854_775_807i64);
         let mysql_val: MySQLValue = tv.into();
-        assert!(matches!(mysql_val.0, Value::Int(9_223_372_036_854_775_807)));
+        assert!(matches!(
+            mysql_val.0,
+            MysqlAsyncValue::Int(9_223_372_036_854_775_807)
+        ));
     }
 
     #[test]
     fn test_float_conversion() {
         let tv = TypedValue::float32(1.234);
         let mysql_val: MySQLValue = tv.into();
-        if let Value::Float(f) = mysql_val.0 {
+        if let MysqlAsyncValue::Float(f) = mysql_val.0 {
             assert!((f - 1.234).abs() < 0.01);
         } else {
             panic!("Expected Float value");
@@ -327,7 +328,7 @@ mod tests {
     fn test_double_conversion() {
         let tv = TypedValue::float64(1.23456789012345);
         let mysql_val: MySQLValue = tv.into();
-        if let Value::Double(d) = mysql_val.0 {
+        if let MysqlAsyncValue::Double(d) = mysql_val.0 {
             assert!((d - 1.23456789012345).abs() < 0.0001);
         } else {
             panic!("Expected Double value");
@@ -338,7 +339,7 @@ mod tests {
     fn test_string_conversion() {
         let tv = TypedValue::text("hello world".to_string());
         let mysql_val: MySQLValue = tv.into();
-        if let Value::Bytes(b) = mysql_val.0 {
+        if let MysqlAsyncValue::Bytes(b) = mysql_val.0 {
             assert_eq!(String::from_utf8(b).unwrap(), "hello world");
         } else {
             panic!("Expected Bytes value");
@@ -350,7 +351,7 @@ mod tests {
         let uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
         let tv = TypedValue::uuid(uuid);
         let mysql_val: MySQLValue = tv.into();
-        if let Value::Bytes(b) = mysql_val.0 {
+        if let MysqlAsyncValue::Bytes(b) = mysql_val.0 {
             assert_eq!(
                 String::from_utf8(b).unwrap(),
                 "550e8400-e29b-41d4-a716-446655440000"
@@ -365,7 +366,7 @@ mod tests {
         let dt = Utc.with_ymd_and_hms(2024, 6, 15, 10, 30, 45).unwrap();
         let tv = TypedValue::datetime(dt);
         let mysql_val: MySQLValue = tv.into();
-        if let Value::Date(year, month, day, hour, min, sec, _) = mysql_val.0 {
+        if let MysqlAsyncValue::Date(year, month, day, hour, min, sec, _) = mysql_val.0 {
             assert_eq!(year, 2024);
             assert_eq!(month, 6);
             assert_eq!(day, 15);
@@ -379,16 +380,16 @@ mod tests {
 
     #[test]
     fn test_null_conversion() {
-        let tv = TypedValue::null(UniversalType::Text);
+        let tv = TypedValue::null(Type::Text);
         let mysql_val: MySQLValue = tv.into();
-        assert!(matches!(mysql_val.0, Value::NULL));
+        assert!(matches!(mysql_val.0, MysqlAsyncValue::NULL));
     }
 
     #[test]
     fn test_decimal_conversion() {
         let tv = TypedValue::decimal("123.456".to_string(), 10, 3);
         let mysql_val: MySQLValue = tv.into();
-        if let Value::Bytes(b) = mysql_val.0 {
+        if let MysqlAsyncValue::Bytes(b) = mysql_val.0 {
             assert_eq!(String::from_utf8(b).unwrap(), "123.456");
         } else {
             panic!("Expected Bytes value");
@@ -397,14 +398,10 @@ mod tests {
 
     #[test]
     fn test_array_conversion() {
-        let arr = vec![
-            UniversalValue::Int64(1),
-            UniversalValue::Int64(2),
-            UniversalValue::Int64(3),
-        ];
-        let tv = TypedValue::array(arr, UniversalType::Int64);
+        let arr = vec![Value::Int64(1), Value::Int64(2), Value::Int64(3)];
+        let tv = TypedValue::array(arr, Type::Int64);
         let mysql_val: MySQLValue = tv.into();
-        if let Value::Bytes(b) = mysql_val.0 {
+        if let MysqlAsyncValue::Bytes(b) = mysql_val.0 {
             let json: serde_json::Value = serde_json::from_slice(&b).unwrap();
             assert_eq!(json, serde_json::json!([1, 2, 3]));
         } else {
@@ -425,7 +422,7 @@ mod tests {
         );
         let tv = TypedValue::json(serde_json::Value::Object(serde_json::Map::from_iter(obj)));
         let mysql_val: MySQLValue = tv.into();
-        if let Value::Bytes(b) = mysql_val.0 {
+        if let MysqlAsyncValue::Bytes(b) = mysql_val.0 {
             let json: serde_json::Value = serde_json::from_slice(&b).unwrap();
             assert_eq!(json["name"], "Alice");
             assert_eq!(json["age"], 30);

--- a/crates/mysql-types/src/lib.rs
+++ b/crates/mysql-types/src/lib.rs
@@ -7,14 +7,14 @@
 //!
 //! - `forward`: Convert `TypedValue` → `MySQLValue` (for INSERT operations)
 //! - `reverse`: Convert MySQL values → `TypedValue` (for reading data)
-//! - `ddl`: Generate MySQL DDL from `UniversalType`
-//! - `schema`: MySQL column type to UniversalType conversion
+//! - `ddl`: Generate MySQL DDL from `Type`
+//! - `schema`: MySQL column type to Type conversion
 //!
 //! # Example
 //!
 //! ```rust,ignore
 //! use mysql_types::{MySQLValue, MySQLDdl, ToDdl, mysql_column_to_universal_type};
-//! use sync_core::{TypedValue, UniversalType, UniversalValue};
+//! use sync_core::{TypedValue, Type, Value};
 //!
 //! // Forward conversion
 //! let typed_value = TypedValue::bool(true);
@@ -22,11 +22,11 @@
 //!
 //! // DDL generation
 //! let ddl = MySQLDdl;
-//! assert_eq!(ddl.to_ddl(&UniversalType::Bool), "TINYINT(1)");
+//! assert_eq!(ddl.to_ddl(&Type::Bool), "TINYINT(1)");
 //!
 //! // Column type conversion
 //! let ut = mysql_column_to_universal_type("INT", "int(11)", None, None);
-//! assert_eq!(ut, UniversalType::Int32);
+//! assert_eq!(ut, Type::Int32);
 //! ```
 
 pub mod binlog;

--- a/crates/mysql-types/src/reverse.rs
+++ b/crates/mysql-types/src/reverse.rs
@@ -11,7 +11,7 @@
 //! 1. **Column width detection**: When `column_length` is set to 1 for TINYINT,
 //!    values 0 and 1 are converted to boolean.
 //!
-//! 2. **Value-based detection**: Even without column metadata, `TINYINT` values
+//! 2. **MysqlAsyncValue-based detection**: Even without column metadata, `TINYINT` values
 //!    of exactly 0 or 1 can be converted to boolean using `with_boolean_hint(true)`.
 //!
 //! # Schema-Aware Conversion
@@ -21,8 +21,8 @@
 
 use chrono::{NaiveDate, NaiveTime, TimeZone, Utc};
 use mysql_async::consts::{ColumnFlags, ColumnType};
-use mysql_async::Value;
-use sync_core::{TypedValue, UniversalType, UniversalValue};
+use mysql_async::Value as MysqlAsyncValue;
+use sync_core::{Type, TypedValue, Value};
 use thiserror::Error;
 
 // Re-export from json-types for convenience
@@ -34,7 +34,7 @@ pub use json_types::{
 #[derive(Debug, Clone)]
 pub struct MySQLValueWithSchema {
     /// The raw MySQL value.
-    pub value: Value,
+    pub value: MysqlAsyncValue,
     /// The MySQL column type.
     pub column_type: ColumnType,
     /// Column flags (e.g., UNSIGNED, BINARY).
@@ -58,7 +58,10 @@ pub enum ConversionError {
     #[error("Unsupported MySQL type: {0:?}")]
     UnsupportedType(ColumnType),
     #[error("Type mismatch: expected {expected}, got {actual:?}")]
-    TypeMismatch { expected: String, actual: Value },
+    TypeMismatch {
+        expected: String,
+        actual: MysqlAsyncValue,
+    },
     #[error("Invalid UTF-8 in string: {0}")]
     InvalidUtf8(#[from] std::string::FromUtf8Error),
     #[error("Invalid date/time value: {0}")]
@@ -75,7 +78,7 @@ pub enum ConversionError {
 
 impl MySQLValueWithSchema {
     /// Create a new MySQLValueWithSchema.
-    pub fn new(value: Value, column_type: ColumnType, column_flags: ColumnFlags) -> Self {
+    pub fn new(value: MysqlAsyncValue, column_type: ColumnType, column_flags: ColumnFlags) -> Self {
         Self {
             value,
             column_type,
@@ -134,7 +137,7 @@ impl TryFrom<MySQLValueWithSchema> for TypedValue {
         use ColumnType::*;
 
         // Handle NULL first
-        if matches!(mv.value, Value::NULL) {
+        if matches!(mv.value, MysqlAsyncValue::NULL) {
             let ext_type = column_type_to_sync_type(mv.column_type, &mv);
             return Ok(TypedValue::null(ext_type));
         }
@@ -234,11 +237,8 @@ impl TryFrom<MySQLValueWithSchema> for TypedValue {
             MYSQL_TYPE_DATE => {
                 if is_zero_mysql_value(&mv.value) {
                     return Ok(TypedValue::zero_temporal(
-                        UniversalType::Date,
-                        Some(
-                            UniversalValue::canonical_zero_literal(&UniversalType::Date)
-                                .to_string(),
-                        ),
+                        Type::Date,
+                        Some(Value::canonical_zero_literal(&Type::Date).to_string()),
                     ));
                 }
                 let dt = extract_date(&mv.value)?;
@@ -256,11 +256,8 @@ impl TryFrom<MySQLValueWithSchema> for TypedValue {
             MYSQL_TYPE_DATETIME | MYSQL_TYPE_DATETIME2 => {
                 if is_zero_mysql_value(&mv.value) {
                     return Ok(TypedValue::zero_temporal(
-                        UniversalType::LocalDateTime,
-                        Some(
-                            UniversalValue::canonical_zero_literal(&UniversalType::LocalDateTime)
-                                .to_string(),
-                        ),
+                        Type::LocalDateTime,
+                        Some(Value::canonical_zero_literal(&Type::LocalDateTime).to_string()),
                     ));
                 }
                 let dt = extract_datetime(&mv.value)?;
@@ -270,11 +267,8 @@ impl TryFrom<MySQLValueWithSchema> for TypedValue {
             MYSQL_TYPE_TIMESTAMP | MYSQL_TYPE_TIMESTAMP2 => {
                 if is_zero_mysql_value(&mv.value) {
                     return Ok(TypedValue::zero_temporal(
-                        UniversalType::ZonedDateTime,
-                        Some(
-                            UniversalValue::canonical_zero_literal(&UniversalType::ZonedDateTime)
-                                .to_string(),
-                        ),
+                        Type::ZonedDateTime,
+                        Some(Value::canonical_zero_literal(&Type::ZonedDateTime).to_string()),
                     ));
                 }
                 let dt = extract_datetime(&mv.value)?;
@@ -343,64 +337,64 @@ impl TryFrom<MySQLValueWithSchema> for TypedValue {
     }
 }
 
-/// Convert MySQL column type to UniversalType.
-fn column_type_to_sync_type(col_type: ColumnType, mv: &MySQLValueWithSchema) -> UniversalType {
+/// Convert MySQL column type to Type.
+fn column_type_to_sync_type(col_type: ColumnType, mv: &MySQLValueWithSchema) -> Type {
     use ColumnType::*;
     match col_type {
         MYSQL_TYPE_TINY => {
             // Check if this is a boolean column
             if mv.is_boolean_column() {
-                UniversalType::Bool
+                Type::Bool
             } else {
-                UniversalType::Int8 {
+                Type::Int8 {
                     width: mv.column_length.unwrap_or(4) as u8,
                 }
             }
         }
-        MYSQL_TYPE_SHORT => UniversalType::Int16,
-        MYSQL_TYPE_INT24 | MYSQL_TYPE_LONG => UniversalType::Int32,
-        MYSQL_TYPE_LONGLONG => UniversalType::Int64,
-        MYSQL_TYPE_FLOAT => UniversalType::Float32,
-        MYSQL_TYPE_DOUBLE => UniversalType::Float64,
-        MYSQL_TYPE_DECIMAL | MYSQL_TYPE_NEWDECIMAL => UniversalType::Decimal {
+        MYSQL_TYPE_SHORT => Type::Int16,
+        MYSQL_TYPE_INT24 | MYSQL_TYPE_LONG => Type::Int32,
+        MYSQL_TYPE_LONGLONG => Type::Int64,
+        MYSQL_TYPE_FLOAT => Type::Float32,
+        MYSQL_TYPE_DOUBLE => Type::Float64,
+        MYSQL_TYPE_DECIMAL | MYSQL_TYPE_NEWDECIMAL => Type::Decimal {
             precision: mv.precision.unwrap_or(10),
             scale: mv.scale.unwrap_or(0),
         },
-        MYSQL_TYPE_STRING => UniversalType::Char {
+        MYSQL_TYPE_STRING => Type::Char {
             length: mv.column_length.unwrap_or(255) as u16,
         },
-        MYSQL_TYPE_VAR_STRING | MYSQL_TYPE_VARCHAR => UniversalType::VarChar {
+        MYSQL_TYPE_VAR_STRING | MYSQL_TYPE_VARCHAR => Type::VarChar {
             length: mv.column_length.unwrap_or(255) as u16,
         },
         MYSQL_TYPE_TINY_BLOB | MYSQL_TYPE_MEDIUM_BLOB | MYSQL_TYPE_BLOB | MYSQL_TYPE_LONG_BLOB => {
             if mv.column_flags.contains(ColumnFlags::BINARY_FLAG) {
-                UniversalType::Blob
+                Type::Blob
             } else {
-                UniversalType::Text
+                Type::Text
             }
         }
-        MYSQL_TYPE_DATE => UniversalType::Date,
-        MYSQL_TYPE_TIME | MYSQL_TYPE_TIME2 => UniversalType::Time,
-        MYSQL_TYPE_DATETIME | MYSQL_TYPE_DATETIME2 => UniversalType::LocalDateTime,
-        MYSQL_TYPE_TIMESTAMP | MYSQL_TYPE_TIMESTAMP2 => UniversalType::ZonedDateTime,
-        MYSQL_TYPE_YEAR => UniversalType::Int16,
-        MYSQL_TYPE_JSON => UniversalType::Json,
-        MYSQL_TYPE_ENUM => UniversalType::Enum { values: vec![] },
-        MYSQL_TYPE_SET => UniversalType::Set { values: vec![] },
-        MYSQL_TYPE_GEOMETRY => UniversalType::Geometry {
+        MYSQL_TYPE_DATE => Type::Date,
+        MYSQL_TYPE_TIME | MYSQL_TYPE_TIME2 => Type::Time,
+        MYSQL_TYPE_DATETIME | MYSQL_TYPE_DATETIME2 => Type::LocalDateTime,
+        MYSQL_TYPE_TIMESTAMP | MYSQL_TYPE_TIMESTAMP2 => Type::ZonedDateTime,
+        MYSQL_TYPE_YEAR => Type::Int16,
+        MYSQL_TYPE_JSON => Type::Json,
+        MYSQL_TYPE_ENUM => Type::Enum { values: vec![] },
+        MYSQL_TYPE_SET => Type::Set { values: vec![] },
+        MYSQL_TYPE_GEOMETRY => Type::Geometry {
             geometry_type: sync_core::GeometryType::Point,
         },
-        MYSQL_TYPE_BIT => UniversalType::Bytes,
-        _ => UniversalType::Text,
+        MYSQL_TYPE_BIT => Type::Bytes,
+        _ => Type::Text,
     }
 }
 
-/// Extract integer from MySQL Value.
-fn extract_int(value: &Value) -> Result<i64, ConversionError> {
+/// Extract integer from MySQL MysqlAsyncValue.
+fn extract_int(value: &MysqlAsyncValue) -> Result<i64, ConversionError> {
     match value {
-        Value::Int(i) => Ok(*i),
-        Value::UInt(u) => Ok(*u as i64),
-        Value::Bytes(b) => {
+        MysqlAsyncValue::Int(i) => Ok(*i),
+        MysqlAsyncValue::UInt(u) => Ok(*u as i64),
+        MysqlAsyncValue::Bytes(b) => {
             let s = String::from_utf8(b.clone())?;
             s.parse().map_err(|_| ConversionError::TypeMismatch {
                 expected: "integer".to_string(),
@@ -414,14 +408,14 @@ fn extract_int(value: &Value) -> Result<i64, ConversionError> {
     }
 }
 
-/// Extract float from MySQL Value.
-fn extract_float(value: &Value) -> Result<f64, ConversionError> {
+/// Extract float from MySQL MysqlAsyncValue.
+fn extract_float(value: &MysqlAsyncValue) -> Result<f64, ConversionError> {
     match value {
-        Value::Float(f) => Ok(*f as f64),
-        Value::Double(d) => Ok(*d),
-        Value::Int(i) => Ok(*i as f64),
-        Value::UInt(u) => Ok(*u as f64),
-        Value::Bytes(b) => {
+        MysqlAsyncValue::Float(f) => Ok(*f as f64),
+        MysqlAsyncValue::Double(d) => Ok(*d),
+        MysqlAsyncValue::Int(i) => Ok(*i as f64),
+        MysqlAsyncValue::UInt(u) => Ok(*u as f64),
+        MysqlAsyncValue::Bytes(b) => {
             let s = String::from_utf8(b.clone())?;
             s.parse().map_err(|_| ConversionError::TypeMismatch {
                 expected: "float".to_string(),
@@ -435,14 +429,14 @@ fn extract_float(value: &Value) -> Result<f64, ConversionError> {
     }
 }
 
-/// Extract string from MySQL Value.
-fn extract_string(value: &Value) -> Result<String, ConversionError> {
+/// Extract string from MySQL MysqlAsyncValue.
+fn extract_string(value: &MysqlAsyncValue) -> Result<String, ConversionError> {
     match value {
-        Value::Bytes(b) => Ok(String::from_utf8(b.clone())?),
-        Value::Int(i) => Ok(i.to_string()),
-        Value::UInt(u) => Ok(u.to_string()),
-        Value::Float(f) => Ok(f.to_string()),
-        Value::Double(d) => Ok(d.to_string()),
+        MysqlAsyncValue::Bytes(b) => Ok(String::from_utf8(b.clone())?),
+        MysqlAsyncValue::Int(i) => Ok(i.to_string()),
+        MysqlAsyncValue::UInt(u) => Ok(u.to_string()),
+        MysqlAsyncValue::Float(f) => Ok(f.to_string()),
+        MysqlAsyncValue::Double(d) => Ok(d.to_string()),
         _ => Err(ConversionError::TypeMismatch {
             expected: "string".to_string(),
             actual: value.clone(),
@@ -450,10 +444,10 @@ fn extract_string(value: &Value) -> Result<String, ConversionError> {
     }
 }
 
-/// Extract bytes from MySQL Value.
-fn extract_bytes(value: &Value) -> Result<Vec<u8>, ConversionError> {
+/// Extract bytes from MySQL MysqlAsyncValue.
+fn extract_bytes(value: &MysqlAsyncValue) -> Result<Vec<u8>, ConversionError> {
     match value {
-        Value::Bytes(b) => Ok(b.clone()),
+        MysqlAsyncValue::Bytes(b) => Ok(b.clone()),
         _ => Err(ConversionError::TypeMismatch {
             expected: "bytes".to_string(),
             actual: value.clone(),
@@ -461,17 +455,17 @@ fn extract_bytes(value: &Value) -> Result<Vec<u8>, ConversionError> {
     }
 }
 
-/// Extract date from MySQL Value.
-fn extract_date(value: &Value) -> Result<NaiveDate, ConversionError> {
+/// Extract date from MySQL MysqlAsyncValue.
+fn extract_date(value: &MysqlAsyncValue) -> Result<NaiveDate, ConversionError> {
     match value {
-        Value::Date(year, month, day, _, _, _, _) => {
+        MysqlAsyncValue::Date(year, month, day, _, _, _, _) => {
             NaiveDate::from_ymd_opt(*year as i32, *month as u32, *day as u32).ok_or_else(|| {
                 ConversionError::InvalidDateTime(format!(
                     "invalid date components: year={year}, month={month}, day={day}"
                 ))
             })
         }
-        Value::Bytes(b) => {
+        MysqlAsyncValue::Bytes(b) => {
             let s = String::from_utf8(b.clone())?;
             NaiveDate::parse_from_str(&s, "%Y-%m-%d").map_err(|e| {
                 ConversionError::InvalidDateTime(format!(
@@ -487,22 +481,22 @@ fn extract_date(value: &Value) -> Result<NaiveDate, ConversionError> {
 }
 
 /// True when MySQL emits a zero date/datetime (`0000-00-00` / `0000-00-00 00:00:00`).
-fn is_zero_mysql_value(value: &Value) -> bool {
+fn is_zero_mysql_value(value: &MysqlAsyncValue) -> bool {
     match value {
-        Value::Date(year, month, day, _, _, _, _) => {
-            UniversalValue::is_mysql_zero_date_ymd(*year, *month, *day)
+        MysqlAsyncValue::Date(year, month, day, _, _, _, _) => {
+            Value::is_mysql_zero_date_ymd(*year, *month, *day)
         }
-        Value::Bytes(b) => std::str::from_utf8(b)
-            .map(UniversalValue::is_mysql_zero_temporal_literal)
+        MysqlAsyncValue::Bytes(b) => std::str::from_utf8(b)
+            .map(Value::is_mysql_zero_temporal_literal)
             .unwrap_or(false),
         _ => false,
     }
 }
 
-/// Extract time from MySQL Value.
-fn extract_time(value: &Value) -> Result<NaiveTime, ConversionError> {
+/// Extract time from MySQL MysqlAsyncValue.
+fn extract_time(value: &MysqlAsyncValue) -> Result<NaiveTime, ConversionError> {
     match value {
-        Value::Time(_, _, hour, min, sec, micro) => {
+        MysqlAsyncValue::Time(_, _, hour, min, sec, micro) => {
             NaiveTime::from_hms_micro_opt(*hour as u32, *min as u32, *sec as u32, *micro)
                 .ok_or_else(|| {
                     ConversionError::InvalidDateTime(format!(
@@ -510,7 +504,7 @@ fn extract_time(value: &Value) -> Result<NaiveTime, ConversionError> {
                     ))
                 })
         }
-        Value::Bytes(b) => {
+        MysqlAsyncValue::Bytes(b) => {
             let s = String::from_utf8(b.clone())?;
             NaiveTime::parse_from_str(&s, "%H:%M:%S").map_err(|e| {
                 ConversionError::InvalidDateTime(format!(
@@ -525,10 +519,10 @@ fn extract_time(value: &Value) -> Result<NaiveTime, ConversionError> {
     }
 }
 
-/// Extract datetime from MySQL Value.
-fn extract_datetime(value: &Value) -> Result<chrono::DateTime<Utc>, ConversionError> {
+/// Extract datetime from MySQL MysqlAsyncValue.
+fn extract_datetime(value: &MysqlAsyncValue) -> Result<chrono::DateTime<Utc>, ConversionError> {
     match value {
-        Value::Date(year, month, day, hour, min, sec, micro) => {
+        MysqlAsyncValue::Date(year, month, day, hour, min, sec, micro) => {
             let date = NaiveDate::from_ymd_opt(*year as i32, *month as u32, *day as u32)
                 .ok_or_else(|| {
                     ConversionError::InvalidDateTime(format!(
@@ -545,7 +539,7 @@ fn extract_datetime(value: &Value) -> Result<chrono::DateTime<Utc>, ConversionEr
             let naive = chrono::NaiveDateTime::new(date, time);
             Ok(Utc.from_utc_datetime(&naive))
         }
-        Value::Bytes(b) => {
+        MysqlAsyncValue::Bytes(b) => {
             let s = String::from_utf8(b.clone())?;
             // Try various formats
             if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(&s) {
@@ -598,11 +592,11 @@ pub struct RowConversionConfig {
 /// UTF-8 bytes or does not parse as JSON, so callers can fall back to their
 /// standard conversion path.
 fn convert_json_column(
-    raw_value: &Value,
+    raw_value: &MysqlAsyncValue,
     json_config: Option<&JsonConversionConfig>,
 ) -> Option<TypedValue> {
     let bytes = match raw_value {
-        Value::Bytes(bytes) => bytes,
+        MysqlAsyncValue::Bytes(bytes) => bytes,
         _ => return None,
     };
     let s = String::from_utf8(bytes.clone()).ok()?;
@@ -729,45 +723,42 @@ pub fn row_to_typed_values_with_config(
 mod tests {
     use super::*;
     use chrono::Datelike;
-    use sync_core::UniversalValue;
+    use sync_core::Value;
 
     #[test]
     fn test_int_conversion() {
         let mv = MySQLValueWithSchema::new(
-            Value::Int(42),
+            MysqlAsyncValue::Int(42),
             ColumnType::MYSQL_TYPE_LONG,
             ColumnFlags::empty(),
         );
         let tv = mv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::Int32));
-        assert!(matches!(tv.value, UniversalValue::Int32(42)));
+        assert!(matches!(tv.sync_type, Type::Int32));
+        assert!(matches!(tv.value, Value::Int32(42)));
     }
 
     #[test]
     fn test_bigint_conversion() {
         let mv = MySQLValueWithSchema::new(
-            Value::Int(9_223_372_036_854_775_807),
+            MysqlAsyncValue::Int(9_223_372_036_854_775_807),
             ColumnType::MYSQL_TYPE_LONGLONG,
             ColumnFlags::empty(),
         );
         let tv = mv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::Int64));
-        assert!(matches!(
-            tv.value,
-            UniversalValue::Int64(9_223_372_036_854_775_807)
-        ));
+        assert!(matches!(tv.sync_type, Type::Int64));
+        assert!(matches!(tv.value, Value::Int64(9_223_372_036_854_775_807)));
     }
 
     #[test]
     fn test_string_conversion() {
         let mv = MySQLValueWithSchema::new(
-            Value::Bytes(b"hello world".to_vec()),
+            MysqlAsyncValue::Bytes(b"hello world".to_vec()),
             ColumnType::MYSQL_TYPE_VAR_STRING,
             ColumnFlags::empty(),
         );
         let tv = mv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::VarChar { .. }));
-        if let UniversalValue::VarChar { value, .. } = tv.value {
+        assert!(matches!(tv.sync_type, Type::VarChar { .. }));
+        if let Value::VarChar { value, .. } = tv.value {
             assert_eq!(value, "hello world");
         } else {
             panic!("Expected VarChar value, got {:?}", tv.value);
@@ -777,14 +768,14 @@ mod tests {
     #[test]
     fn test_uuid_detection() {
         let mv = MySQLValueWithSchema::new(
-            Value::Bytes(b"550e8400-e29b-41d4-a716-446655440000".to_vec()),
+            MysqlAsyncValue::Bytes(b"550e8400-e29b-41d4-a716-446655440000".to_vec()),
             ColumnType::MYSQL_TYPE_VAR_STRING,
             ColumnFlags::empty(),
         )
         .with_length(36);
         let tv = mv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::Uuid));
-        if let UniversalValue::Uuid(u) = tv.value {
+        assert!(matches!(tv.sync_type, Type::Uuid));
+        if let Value::Uuid(u) = tv.value {
             assert_eq!(u.to_string(), "550e8400-e29b-41d4-a716-446655440000");
         } else {
             panic!("Expected Uuid value");
@@ -794,13 +785,13 @@ mod tests {
     #[test]
     fn test_datetime_conversion() {
         let mv = MySQLValueWithSchema::new(
-            Value::Date(2024, 6, 15, 10, 30, 45, 0),
+            MysqlAsyncValue::Date(2024, 6, 15, 10, 30, 45, 0),
             ColumnType::MYSQL_TYPE_DATETIME,
             ColumnFlags::empty(),
         );
         let tv = mv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::LocalDateTime));
-        if let UniversalValue::LocalDateTime(dt) = tv.value {
+        assert!(matches!(tv.sync_type, Type::LocalDateTime));
+        if let Value::LocalDateTime(dt) = tv.value {
             assert_eq!(dt.year(), 2024);
             assert_eq!(dt.month(), 6);
             assert_eq!(dt.day(), 15);
@@ -812,26 +803,26 @@ mod tests {
     #[test]
     fn test_null_conversion() {
         let mv = MySQLValueWithSchema::new(
-            Value::NULL,
+            MysqlAsyncValue::NULL,
             ColumnType::MYSQL_TYPE_LONG,
             ColumnFlags::empty(),
         );
         let tv = mv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::Int32));
-        assert!(matches!(tv.value, UniversalValue::Null));
+        assert!(matches!(tv.sync_type, Type::Int32));
+        assert!(matches!(tv.value, Value::Null));
     }
 
     #[test]
     fn test_json_conversion() {
         let json_str = r#"{"name":"Alice","age":30}"#;
         let mv = MySQLValueWithSchema::new(
-            Value::Bytes(json_str.as_bytes().to_vec()),
+            MysqlAsyncValue::Bytes(json_str.as_bytes().to_vec()),
             ColumnType::MYSQL_TYPE_JSON,
             ColumnFlags::empty(),
         );
         let tv = mv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::Json));
-        if let UniversalValue::Json(obj) = tv.value {
+        assert!(matches!(tv.sync_type, Type::Json));
+        if let Value::Json(obj) = tv.value {
             if let serde_json::Value::Object(map) = obj.as_ref() {
                 assert!(map.contains_key("name"));
                 assert!(map.contains_key("age"));
@@ -846,19 +837,19 @@ mod tests {
     #[test]
     fn test_decimal_conversion() {
         let mv = MySQLValueWithSchema::new(
-            Value::Bytes(b"123.456".to_vec()),
+            MysqlAsyncValue::Bytes(b"123.456".to_vec()),
             ColumnType::MYSQL_TYPE_NEWDECIMAL,
             ColumnFlags::empty(),
         )
         .with_precision(10, 3);
         let tv = mv.to_typed_value().unwrap();
-        if let UniversalType::Decimal { precision, scale } = tv.sync_type {
+        if let Type::Decimal { precision, scale } = tv.sync_type {
             assert_eq!(precision, 10);
             assert_eq!(scale, 3);
         } else {
             panic!("Expected Decimal type");
         }
-        if let UniversalValue::Decimal { value, .. } = tv.value {
+        if let Value::Decimal { value, .. } = tv.value {
             assert_eq!(value, "123.456");
         } else {
             panic!("Expected Decimal value");
@@ -869,13 +860,13 @@ mod tests {
     fn test_blob_conversion() {
         let binary_data = vec![0x00, 0x01, 0x02, 0xFF];
         let mv = MySQLValueWithSchema::new(
-            Value::Bytes(binary_data.clone()),
+            MysqlAsyncValue::Bytes(binary_data.clone()),
             ColumnType::MYSQL_TYPE_BLOB,
             ColumnFlags::BINARY_FLAG,
         );
         let tv = mv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::Blob));
-        if let UniversalValue::Blob(b) = tv.value {
+        assert!(matches!(tv.sync_type, Type::Blob));
+        if let Value::Blob(b) = tv.value {
             assert_eq!(b, binary_data);
         } else {
             panic!("Expected Blob value, got {:?}", tv.value);
@@ -885,13 +876,13 @@ mod tests {
     #[test]
     fn test_text_conversion() {
         let mv = MySQLValueWithSchema::new(
-            Value::Bytes(b"long text content".to_vec()),
+            MysqlAsyncValue::Bytes(b"long text content".to_vec()),
             ColumnType::MYSQL_TYPE_BLOB,
             ColumnFlags::empty(), // No BINARY flag = TEXT
         );
         let tv = mv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::Text));
-        if let UniversalValue::Text(s) = tv.value {
+        assert!(matches!(tv.sync_type, Type::Text));
+        if let Value::Text(s) = tv.value {
             assert_eq!(s, "long text content");
         } else {
             panic!("Expected String value");
@@ -902,98 +893,98 @@ mod tests {
     fn test_tinyint1_boolean_true() {
         // TINYINT(1) with value 1 should be boolean true
         let mv = MySQLValueWithSchema::new(
-            Value::Int(1),
+            MysqlAsyncValue::Int(1),
             ColumnType::MYSQL_TYPE_TINY,
             ColumnFlags::empty(),
         )
         .with_length(1);
         let tv = mv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::Bool));
-        assert!(matches!(tv.value, UniversalValue::Bool(true)));
+        assert!(matches!(tv.sync_type, Type::Bool));
+        assert!(matches!(tv.value, Value::Bool(true)));
     }
 
     #[test]
     fn test_tinyint1_boolean_false() {
         // TINYINT(1) with value 0 should be boolean false
         let mv = MySQLValueWithSchema::new(
-            Value::Int(0),
+            MysqlAsyncValue::Int(0),
             ColumnType::MYSQL_TYPE_TINY,
             ColumnFlags::empty(),
         )
         .with_length(1);
         let tv = mv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::Bool));
-        assert!(matches!(tv.value, UniversalValue::Bool(false)));
+        assert!(matches!(tv.sync_type, Type::Bool));
+        assert!(matches!(tv.value, Value::Bool(false)));
     }
 
     #[test]
     fn test_tinyint_without_boolean_hint() {
         // TINYINT without length=1 or hint should stay as integer
         let mv = MySQLValueWithSchema::new(
-            Value::Int(1),
+            MysqlAsyncValue::Int(1),
             ColumnType::MYSQL_TYPE_TINY,
             ColumnFlags::empty(),
         );
         let tv = mv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::Int8 { .. }));
-        assert!(matches!(tv.value, UniversalValue::Int8 { value: 1, .. }));
+        assert!(matches!(tv.sync_type, Type::Int8 { .. }));
+        assert!(matches!(tv.value, Value::Int8 { value: 1, .. }));
     }
 
     #[test]
     fn test_tinyint_with_boolean_hint_true() {
         // TINYINT with boolean_hint=true should convert 0/1 to boolean
         let mv = MySQLValueWithSchema::new(
-            Value::Int(1),
+            MysqlAsyncValue::Int(1),
             ColumnType::MYSQL_TYPE_TINY,
             ColumnFlags::empty(),
         )
         .with_boolean_hint(true);
         let tv = mv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::Bool));
-        assert!(matches!(tv.value, UniversalValue::Bool(true)));
+        assert!(matches!(tv.sync_type, Type::Bool));
+        assert!(matches!(tv.value, Value::Bool(true)));
     }
 
     #[test]
     fn test_tinyint_with_boolean_hint_false() {
         // TINYINT with boolean_hint=true should convert 0/1 to boolean
         let mv = MySQLValueWithSchema::new(
-            Value::Int(0),
+            MysqlAsyncValue::Int(0),
             ColumnType::MYSQL_TYPE_TINY,
             ColumnFlags::empty(),
         )
         .with_boolean_hint(true);
         let tv = mv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::Bool));
-        assert!(matches!(tv.value, UniversalValue::Bool(false)));
+        assert!(matches!(tv.sync_type, Type::Bool));
+        assert!(matches!(tv.value, Value::Bool(false)));
     }
 
     #[test]
     fn test_tinyint_non_boolean_value() {
         // Even with TINYINT(1), values other than 0/1 should stay as int
         let mv = MySQLValueWithSchema::new(
-            Value::Int(5),
+            MysqlAsyncValue::Int(5),
             ColumnType::MYSQL_TYPE_TINY,
             ColumnFlags::empty(),
         )
         .with_length(1);
         let tv = mv.to_typed_value().unwrap();
         // The type still says TinyInt, but value is 5
-        assert!(matches!(tv.sync_type, UniversalType::Int8 { .. }));
-        assert!(matches!(tv.value, UniversalValue::Int8 { value: 5, .. }));
+        assert!(matches!(tv.sync_type, Type::Int8 { .. }));
+        assert!(matches!(tv.value, Value::Int8 { value: 5, .. }));
     }
 
     #[test]
     fn test_null_boolean_column() {
         // NULL in a boolean column should preserve the Bool type
         let mv = MySQLValueWithSchema::new(
-            Value::NULL,
+            MysqlAsyncValue::NULL,
             ColumnType::MYSQL_TYPE_TINY,
             ColumnFlags::empty(),
         )
         .with_length(1);
         let tv = mv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::Bool));
-        assert!(matches!(tv.value, UniversalValue::Null));
+        assert!(matches!(tv.sync_type, Type::Bool));
+        assert!(matches!(tv.value, Value::Null));
     }
 
     #[test]
@@ -1015,7 +1006,7 @@ mod tests {
 
         let tv = json_to_typed_value_with_config(json, "", &config);
 
-        if let UniversalValue::Json(root) = tv.value {
+        if let Value::Json(root) = tv.value {
             if let serde_json::Value::Object(root_obj) = root.as_ref() {
                 // Check settings.enabled is now boolean true
                 if let Some(serde_json::Value::Object(settings)) = root_obj.get("settings") {
@@ -1061,7 +1052,7 @@ mod tests {
 
         let tv = json_to_typed_value_with_config(json, "", &config);
 
-        if let UniversalValue::Json(root) = tv.value {
+        if let Value::Json(root) = tv.value {
             if let serde_json::Value::Object(root_obj) = root.as_ref() {
                 // Check permissions is now an array
                 if let Some(serde_json::Value::Array(perms)) = root_obj.get("permissions") {
@@ -1097,7 +1088,7 @@ mod tests {
 
         let tv = json_to_typed_value_with_config(json, "", &config);
 
-        if let UniversalValue::Json(root) = tv.value {
+        if let Value::Json(root) = tv.value {
             if let serde_json::Value::Object(root_obj) = root.as_ref() {
                 assert!(matches!(
                     root_obj.get("enabled"),
@@ -1121,7 +1112,7 @@ mod tests {
     fn test_unsupported_type_error() {
         // MYSQL_TYPE_NULL is an internal MySQL type that shouldn't be used for columns
         let mv = MySQLValueWithSchema::new(
-            Value::Int(42),
+            MysqlAsyncValue::Int(42),
             ColumnType::MYSQL_TYPE_NULL,
             ColumnFlags::empty(),
         );
@@ -1136,7 +1127,7 @@ mod tests {
     fn test_type_mismatch_int_expects_int() {
         // Pass a string value when an integer is expected
         let mv = MySQLValueWithSchema::new(
-            Value::Bytes(b"not a number".to_vec()),
+            MysqlAsyncValue::Bytes(b"not a number".to_vec()),
             ColumnType::MYSQL_TYPE_LONG,
             ColumnFlags::empty(),
         );
@@ -1153,7 +1144,7 @@ mod tests {
     fn test_type_mismatch_float_expects_float() {
         // Pass an invalid float string
         let mv = MySQLValueWithSchema::new(
-            Value::Bytes(b"not_a_float".to_vec()),
+            MysqlAsyncValue::Bytes(b"not_a_float".to_vec()),
             ColumnType::MYSQL_TYPE_DOUBLE,
             ColumnFlags::empty(),
         );
@@ -1168,7 +1159,7 @@ mod tests {
     fn test_invalid_date_error() {
         // Invalid date components (month 13)
         let mv = MySQLValueWithSchema::new(
-            Value::Date(2024, 13, 1, 0, 0, 0, 0),
+            MysqlAsyncValue::Date(2024, 13, 1, 0, 0, 0, 0),
             ColumnType::MYSQL_TYPE_DATE,
             ColumnFlags::empty(),
         );
@@ -1182,15 +1173,15 @@ mod tests {
     #[test]
     fn test_zero_date_emits_zero_temporal() {
         let mv = MySQLValueWithSchema::new(
-            Value::Date(0, 0, 0, 0, 0, 0, 0),
+            MysqlAsyncValue::Date(0, 0, 0, 0, 0, 0, 0),
             ColumnType::MYSQL_TYPE_DATE,
             ColumnFlags::empty(),
         );
         let tv = mv.to_typed_value().unwrap();
         assert!(matches!(
             tv.value,
-            UniversalValue::ZeroTemporal {
-                intended_type: UniversalType::Date,
+            Value::ZeroTemporal {
+                intended_type: Type::Date,
                 ..
             }
         ));
@@ -1199,15 +1190,15 @@ mod tests {
     #[test]
     fn test_zero_datetime_emits_zero_temporal() {
         let mv = MySQLValueWithSchema::new(
-            Value::Date(0, 0, 0, 0, 0, 0, 0),
+            MysqlAsyncValue::Date(0, 0, 0, 0, 0, 0, 0),
             ColumnType::MYSQL_TYPE_DATETIME,
             ColumnFlags::empty(),
         );
         let tv = mv.to_typed_value().unwrap();
         assert!(matches!(
             tv.value,
-            UniversalValue::ZeroTemporal {
-                intended_type: UniversalType::LocalDateTime,
+            Value::ZeroTemporal {
+                intended_type: Type::LocalDateTime,
                 ..
             }
         ));
@@ -1216,15 +1207,15 @@ mod tests {
     #[test]
     fn test_zero_timestamp_emits_zero_temporal() {
         let mv = MySQLValueWithSchema::new(
-            Value::Date(0, 0, 0, 0, 0, 0, 0),
+            MysqlAsyncValue::Date(0, 0, 0, 0, 0, 0, 0),
             ColumnType::MYSQL_TYPE_TIMESTAMP,
             ColumnFlags::empty(),
         );
         let tv = mv.to_typed_value().unwrap();
         assert!(matches!(
             tv.value,
-            UniversalValue::ZeroTemporal {
-                intended_type: UniversalType::ZonedDateTime,
+            Value::ZeroTemporal {
+                intended_type: Type::ZonedDateTime,
                 ..
             }
         ));
@@ -1233,19 +1224,19 @@ mod tests {
     #[test]
     fn test_zero_date_string_emits_zero_temporal() {
         let mv = MySQLValueWithSchema::new(
-            Value::Bytes(b"0000-00-00".to_vec()),
+            MysqlAsyncValue::Bytes(b"0000-00-00".to_vec()),
             ColumnType::MYSQL_TYPE_DATE,
             ColumnFlags::empty(),
         );
         let tv = mv.to_typed_value().unwrap();
-        assert!(matches!(tv.value, UniversalValue::ZeroTemporal { .. }));
+        assert!(matches!(tv.value, Value::ZeroTemporal { .. }));
     }
 
     #[test]
     fn test_invalid_date_string_error() {
         // Invalid date string format
         let mv = MySQLValueWithSchema::new(
-            Value::Bytes(b"not-a-date".to_vec()),
+            MysqlAsyncValue::Bytes(b"not-a-date".to_vec()),
             ColumnType::MYSQL_TYPE_DATE,
             ColumnFlags::empty(),
         );
@@ -1260,7 +1251,7 @@ mod tests {
     fn test_invalid_time_error() {
         // Invalid time components (hour 25)
         let mv = MySQLValueWithSchema::new(
-            Value::Time(false, 0, 25, 0, 0, 0),
+            MysqlAsyncValue::Time(false, 0, 25, 0, 0, 0),
             ColumnType::MYSQL_TYPE_TIME,
             ColumnFlags::empty(),
         );
@@ -1275,7 +1266,7 @@ mod tests {
     fn test_invalid_datetime_string_error() {
         // Invalid datetime string format
         let mv = MySQLValueWithSchema::new(
-            Value::Bytes(b"invalid-datetime".to_vec()),
+            MysqlAsyncValue::Bytes(b"invalid-datetime".to_vec()),
             ColumnType::MYSQL_TYPE_DATETIME,
             ColumnFlags::empty(),
         );
@@ -1291,7 +1282,7 @@ mod tests {
         // Invalid UTF-8 bytes for a string column
         let invalid_utf8 = vec![0xff, 0xfe, 0xfd];
         let mv = MySQLValueWithSchema::new(
-            Value::Bytes(invalid_utf8),
+            MysqlAsyncValue::Bytes(invalid_utf8),
             ColumnType::MYSQL_TYPE_VAR_STRING,
             ColumnFlags::empty(),
         );
@@ -1305,7 +1296,7 @@ mod tests {
     fn test_bytes_type_mismatch() {
         // Pass an Int value when bytes are expected (for BLOB)
         let mv = MySQLValueWithSchema::new(
-            Value::Int(42),
+            MysqlAsyncValue::Int(42),
             ColumnType::MYSQL_TYPE_BLOB,
             ColumnFlags::BINARY_FLAG,
         );
@@ -1320,7 +1311,7 @@ mod tests {
     fn test_date_type_mismatch() {
         // Pass a Time value when a Date is expected
         let mv = MySQLValueWithSchema::new(
-            Value::Time(false, 0, 10, 30, 0, 0),
+            MysqlAsyncValue::Time(false, 0, 10, 30, 0, 0),
             ColumnType::MYSQL_TYPE_DATE,
             ColumnFlags::empty(),
         );
@@ -1336,7 +1327,7 @@ mod tests {
         // Test that error messages are descriptive enough
         let err = ConversionError::TypeMismatch {
             expected: "integer".to_string(),
-            actual: Value::Bytes(b"hello".to_vec()),
+            actual: MysqlAsyncValue::Bytes(b"hello".to_vec()),
         };
         let msg = err.to_string();
         assert!(msg.contains("expected integer"));
@@ -1358,13 +1349,13 @@ mod tests {
     fn test_set_column_empty_string() {
         // SET column with empty string should produce empty array
         let mv = MySQLValueWithSchema::new(
-            Value::Bytes(b"".to_vec()),
+            MysqlAsyncValue::Bytes(b"".to_vec()),
             ColumnType::MYSQL_TYPE_SET,
             ColumnFlags::empty(),
         );
         let tv = mv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::Set { .. }));
-        if let UniversalValue::Set { elements, .. } = tv.value {
+        assert!(matches!(tv.sync_type, Type::Set { .. }));
+        if let Value::Set { elements, .. } = tv.value {
             // Empty string produces one empty element after split
             // This is expected MySQL behavior
             assert_eq!(elements.len(), 1);
@@ -1377,13 +1368,13 @@ mod tests {
     #[test]
     fn test_set_column_multiple_values() {
         let mv = MySQLValueWithSchema::new(
-            Value::Bytes(b"read,write,execute".to_vec()),
+            MysqlAsyncValue::Bytes(b"read,write,execute".to_vec()),
             ColumnType::MYSQL_TYPE_SET,
             ColumnFlags::empty(),
         );
         let tv = mv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::Set { .. }));
-        if let UniversalValue::Set { elements, .. } = tv.value {
+        assert!(matches!(tv.sync_type, Type::Set { .. }));
+        if let Value::Set { elements, .. } = tv.value {
             assert_eq!(elements.len(), 3);
             assert_eq!(elements[0], "read");
             assert_eq!(elements[1], "write");
@@ -1396,13 +1387,13 @@ mod tests {
     #[test]
     fn test_enum_column() {
         let mv = MySQLValueWithSchema::new(
-            Value::Bytes(b"active".to_vec()),
+            MysqlAsyncValue::Bytes(b"active".to_vec()),
             ColumnType::MYSQL_TYPE_ENUM,
             ColumnFlags::empty(),
         );
         let tv = mv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::Enum { .. }));
-        if let UniversalValue::Enum { value, .. } = tv.value {
+        assert!(matches!(tv.sync_type, Type::Enum { .. }));
+        if let Value::Enum { value, .. } = tv.value {
             assert_eq!(value, "active");
         } else {
             panic!("Expected Enum value, got {:?}", tv.value);
@@ -1413,36 +1404,36 @@ mod tests {
     fn test_bit_as_boolean() {
         // BIT(1) with value 0 should be boolean false
         let mv = MySQLValueWithSchema::new(
-            Value::Bytes(vec![0]),
+            MysqlAsyncValue::Bytes(vec![0]),
             ColumnType::MYSQL_TYPE_BIT,
             ColumnFlags::empty(),
         );
         let tv = mv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::Bool));
-        assert!(matches!(tv.value, UniversalValue::Bool(false)));
+        assert!(matches!(tv.sync_type, Type::Bool));
+        assert!(matches!(tv.value, Value::Bool(false)));
 
         // BIT(1) with value 1 should be boolean true
         let mv = MySQLValueWithSchema::new(
-            Value::Bytes(vec![1]),
+            MysqlAsyncValue::Bytes(vec![1]),
             ColumnType::MYSQL_TYPE_BIT,
             ColumnFlags::empty(),
         );
         let tv = mv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::Bool));
-        assert!(matches!(tv.value, UniversalValue::Bool(true)));
+        assert!(matches!(tv.sync_type, Type::Bool));
+        assert!(matches!(tv.value, Value::Bool(true)));
     }
 
     #[test]
     fn test_bit_as_bytes() {
         // BIT(8) should be bytes
         let mv = MySQLValueWithSchema::new(
-            Value::Bytes(vec![0xff]),
+            MysqlAsyncValue::Bytes(vec![0xff]),
             ColumnType::MYSQL_TYPE_BIT,
             ColumnFlags::empty(),
         );
         let tv = mv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::Bytes));
-        if let UniversalValue::Bytes(b) = tv.value {
+        assert!(matches!(tv.sync_type, Type::Bytes));
+        if let Value::Bytes(b) = tv.value {
             assert_eq!(b, vec![0xff]);
         } else {
             panic!("Expected Bytes value");
@@ -1455,13 +1446,13 @@ mod tests {
         use sync_core::values::GeometryData;
         let wkb_point = vec![0x01, 0x01, 0x00, 0x00, 0x00]; // Minimal WKB point prefix
         let mv = MySQLValueWithSchema::new(
-            Value::Bytes(wkb_point.clone()),
+            MysqlAsyncValue::Bytes(wkb_point.clone()),
             ColumnType::MYSQL_TYPE_GEOMETRY,
             ColumnFlags::empty(),
         );
         let tv = mv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::Geometry { .. }));
-        if let UniversalValue::Geometry { data, .. } = tv.value {
+        assert!(matches!(tv.sync_type, Type::Geometry { .. }));
+        if let Value::Geometry { data, .. } = tv.value {
             let GeometryData(json) = data;
             // Verify the GeoJSON contains the base64-encoded WKB
             let expected_b64 = base64::engine::general_purpose::STANDARD.encode(&wkb_point);
@@ -1475,12 +1466,12 @@ mod tests {
     #[test]
     fn test_year_column() {
         let mv = MySQLValueWithSchema::new(
-            Value::Int(2024),
+            MysqlAsyncValue::Int(2024),
             ColumnType::MYSQL_TYPE_YEAR,
             ColumnFlags::empty(),
         );
         let tv = mv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::Int16));
-        assert!(matches!(tv.value, UniversalValue::Int16(2024)));
+        assert!(matches!(tv.sync_type, Type::Int16));
+        assert!(matches!(tv.value, Value::Int16(2024)));
     }
 }

--- a/crates/mysql-types/src/schema.rs
+++ b/crates/mysql-types/src/schema.rs
@@ -1,14 +1,14 @@
 //! MySQL schema column type conversion.
 //!
 //! This module provides conversion from MySQL INFORMATION_SCHEMA column types
-//! to `UniversalType` for schema introspection during incremental sync.
+//! to `Type` for schema introspection during incremental sync.
 
-use sync_core::UniversalType;
+use sync_core::Type;
 
-/// Convert MySQL INFORMATION_SCHEMA column type to UniversalType.
+/// Convert MySQL INFORMATION_SCHEMA column type to Type.
 ///
 /// This function maps MySQL data types (as returned by `information_schema.columns`)
-/// to the appropriate `UniversalType` for use in schema-aware type conversion.
+/// to the appropriate `Type` for use in schema-aware type conversion.
 ///
 /// # Arguments
 ///
@@ -19,86 +19,84 @@ use sync_core::UniversalType;
 ///
 /// # Returns
 ///
-/// The corresponding `UniversalType` for the MySQL column type.
+/// The corresponding `Type` for the MySQL column type.
 ///
 /// # Example
 ///
 /// ```
 /// use mysql_types::mysql_column_to_universal_type;
-/// use sync_core::UniversalType;
+/// use sync_core::Type;
 ///
 /// let ut = mysql_column_to_universal_type("INT", "int(11)", None, None);
-/// assert_eq!(ut, UniversalType::Int32);
+/// assert_eq!(ut, Type::Int32);
 ///
 /// // TINYINT(1) is treated as boolean in MySQL
 /// let ut = mysql_column_to_universal_type("TINYINT", "tinyint(1)", None, None);
-/// assert_eq!(ut, UniversalType::Bool);
+/// assert_eq!(ut, Type::Bool);
 /// ```
 pub fn mysql_column_to_universal_type(
     data_type: &str,
     column_type: &str,
     precision: Option<u32>,
     scale: Option<u32>,
-) -> UniversalType {
+) -> Type {
     match data_type.to_uppercase().as_str() {
         // Numeric types
         "TINYINT" => {
             // TINYINT(1) is commonly used for boolean in MySQL
             if column_type.to_lowercase().starts_with("tinyint(1)") {
-                UniversalType::Bool
+                Type::Bool
             } else {
                 // Extract width from column_type (e.g., "tinyint(4)" -> 4)
                 let width = extract_length_from_column_type(column_type)
                     .map(|l| l as u8)
                     .unwrap_or(4);
-                UniversalType::Int8 { width }
+                Type::Int8 { width }
             }
         }
-        "SMALLINT" => UniversalType::Int16,
-        "MEDIUMINT" | "INT" | "INTEGER" => UniversalType::Int32,
-        "BIGINT" => UniversalType::Int64,
-        "FLOAT" => UniversalType::Float32,
-        "DOUBLE" | "REAL" => UniversalType::Float64,
-        "DECIMAL" | "NUMERIC" => UniversalType::Decimal {
-            // precision/scale are u32 but UniversalType expects u8, cap at 38
+        "SMALLINT" => Type::Int16,
+        "MEDIUMINT" | "INT" | "INTEGER" => Type::Int32,
+        "BIGINT" => Type::Int64,
+        "FLOAT" => Type::Float32,
+        "DOUBLE" | "REAL" => Type::Float64,
+        "DECIMAL" | "NUMERIC" => Type::Decimal {
+            // precision/scale are u32 but Type expects u8, cap at 38
             precision: precision.map(|p| p.min(38) as u8).unwrap_or(10),
             scale: scale.map(|s| s.min(38) as u8).unwrap_or(0),
         },
 
         // Boolean
-        "BOOLEAN" | "BOOL" => UniversalType::Bool,
+        "BOOLEAN" | "BOOL" => Type::Bool,
 
         // String types
         "VARCHAR" => {
             // Try to extract length from column_type
             let length = extract_length_from_column_type(column_type);
             match length {
-                Some(len) => UniversalType::VarChar { length: len },
-                None => UniversalType::Text,
+                Some(len) => Type::VarChar { length: len },
+                None => Type::Text,
             }
         }
         "CHAR" => {
             let length = extract_length_from_column_type(column_type).unwrap_or(1);
-            UniversalType::Char { length }
+            Type::Char { length }
         }
-        "TEXT" | "TINYTEXT" | "MEDIUMTEXT" | "LONGTEXT" => UniversalType::Text,
+        "TEXT" | "TINYTEXT" | "MEDIUMTEXT" | "LONGTEXT" => Type::Text,
 
         // Binary types
-        "BINARY" | "VARBINARY" | "BLOB" | "TINYBLOB" | "MEDIUMBLOB" | "LONGBLOB" => {
-            UniversalType::Bytes
-        }
+        "BINARY" | "VARBINARY" | "BLOB" | "TINYBLOB" | "MEDIUMBLOB" | "LONGBLOB" => Type::Bytes,
 
         // Date/Time types
-        "DATE" => UniversalType::Date,
-        "TIME" => UniversalType::Time,
-        "TIMESTAMP" | "DATETIME" => UniversalType::LocalDateTime,
+        "DATE" => Type::Date,
+        "TIME" => Type::Time,
+        "TIMESTAMP" | "DATETIME" => Type::LocalDateTime,
 
         // JSON
-        "JSON" => UniversalType::Json,
+        "JSON" => Type::Json,
 
         // Geometry types
         "GEOMETRY" | "POINT" | "LINESTRING" | "POLYGON" | "MULTIPOINT" | "MULTILINESTRING"
-        | "MULTIPOLYGON" | "GEOMETRYCOLLECTION" => UniversalType::Geometry {
+        | "MULTIPOLYGON" | "GEOMETRYCOLLECTION" => Type::Geometry {
             geometry_type: sync_core::GeometryType::Point, // Generic fallback
         },
 
@@ -106,21 +104,21 @@ pub fn mysql_column_to_universal_type(
         "SET" => {
             // Extract values from column_type (e.g., "set('a','b','c')")
             let values = extract_set_or_enum_values(column_type);
-            UniversalType::Set { values }
+            Type::Set { values }
         }
 
         // ENUM type - stores list of allowed values
         "ENUM" => {
             // Extract values from column_type (e.g., "enum('small','medium','large')")
             let values = extract_set_or_enum_values(column_type);
-            UniversalType::Enum { values }
+            Type::Enum { values }
         }
 
         // UUID if using a UUID column type (MySQL 8.0+)
-        "UUID" => UniversalType::Uuid,
+        "UUID" => Type::Uuid,
 
         // Fallback to Text for unknown types
-        _ => UniversalType::Text,
+        _ => Type::Text,
     }
 }
 
@@ -175,23 +173,23 @@ mod tests {
     fn test_mysql_int_types() {
         assert!(matches!(
             mysql_column_to_universal_type("TINYINT", "tinyint(4)", None, None),
-            UniversalType::Int8 { width: 4 }
+            Type::Int8 { width: 4 }
         ));
         assert_eq!(
             mysql_column_to_universal_type("SMALLINT", "smallint(6)", None, None),
-            UniversalType::Int16
+            Type::Int16
         );
         assert_eq!(
             mysql_column_to_universal_type("INT", "int(11)", None, None),
-            UniversalType::Int32
+            Type::Int32
         );
         assert_eq!(
             mysql_column_to_universal_type("INTEGER", "int(11)", None, None),
-            UniversalType::Int32
+            Type::Int32
         );
         assert_eq!(
             mysql_column_to_universal_type("BIGINT", "bigint(20)", None, None),
-            UniversalType::Int64
+            Type::Int64
         );
     }
 
@@ -200,12 +198,12 @@ mod tests {
         // TINYINT(1) is treated as boolean in MySQL
         assert_eq!(
             mysql_column_to_universal_type("TINYINT", "tinyint(1)", None, None),
-            UniversalType::Bool
+            Type::Bool
         );
         // But TINYINT(4) is a regular integer
         assert!(matches!(
             mysql_column_to_universal_type("TINYINT", "tinyint(4)", None, None),
-            UniversalType::Int8 { width: 4 }
+            Type::Int8 { width: 4 }
         ));
     }
 
@@ -214,7 +212,7 @@ mod tests {
         let ut = mysql_column_to_universal_type("DECIMAL", "decimal(10,2)", Some(10), Some(2));
         assert!(matches!(
             ut,
-            UniversalType::Decimal {
+            Type::Decimal {
                 precision: 10,
                 scale: 2
             }
@@ -223,7 +221,7 @@ mod tests {
         let ut = mysql_column_to_universal_type("NUMERIC", "numeric(18,4)", Some(18), Some(4));
         assert!(matches!(
             ut,
-            UniversalType::Decimal {
+            Type::Decimal {
                 precision: 18,
                 scale: 4
             }
@@ -234,19 +232,19 @@ mod tests {
     fn test_mysql_string_types() {
         assert_eq!(
             mysql_column_to_universal_type("VARCHAR", "varchar(255)", None, None),
-            UniversalType::VarChar { length: 255 }
+            Type::VarChar { length: 255 }
         );
         assert_eq!(
             mysql_column_to_universal_type("CHAR", "char(10)", None, None),
-            UniversalType::Char { length: 10 }
+            Type::Char { length: 10 }
         );
         assert_eq!(
             mysql_column_to_universal_type("TEXT", "text", None, None),
-            UniversalType::Text
+            Type::Text
         );
         assert_eq!(
             mysql_column_to_universal_type("LONGTEXT", "longtext", None, None),
-            UniversalType::Text
+            Type::Text
         );
     }
 
@@ -254,19 +252,19 @@ mod tests {
     fn test_mysql_datetime_types() {
         assert_eq!(
             mysql_column_to_universal_type("TIMESTAMP", "timestamp", None, None),
-            UniversalType::LocalDateTime
+            Type::LocalDateTime
         );
         assert_eq!(
             mysql_column_to_universal_type("DATETIME", "datetime", None, None),
-            UniversalType::LocalDateTime
+            Type::LocalDateTime
         );
         assert_eq!(
             mysql_column_to_universal_type("DATE", "date", None, None),
-            UniversalType::Date
+            Type::Date
         );
         assert_eq!(
             mysql_column_to_universal_type("TIME", "time", None, None),
-            UniversalType::Time
+            Type::Time
         );
     }
 
@@ -274,25 +272,25 @@ mod tests {
     fn test_mysql_json_type() {
         assert_eq!(
             mysql_column_to_universal_type("JSON", "json", None, None),
-            UniversalType::Json
+            Type::Json
         );
     }
 
     #[test]
     fn test_mysql_set_type() {
         let ut = mysql_column_to_universal_type("SET", "set('a','b','c')", None, None);
-        assert!(matches!(ut, UniversalType::Set { .. }));
+        assert!(matches!(ut, Type::Set { .. }));
     }
 
     #[test]
     fn test_mysql_bool_types() {
         assert_eq!(
             mysql_column_to_universal_type("BOOLEAN", "boolean", None, None),
-            UniversalType::Bool
+            Type::Bool
         );
         assert_eq!(
             mysql_column_to_universal_type("BOOL", "bool", None, None),
-            UniversalType::Bool
+            Type::Bool
         );
     }
 
@@ -300,15 +298,15 @@ mod tests {
     fn test_mysql_bytes_types() {
         assert_eq!(
             mysql_column_to_universal_type("BLOB", "blob", None, None),
-            UniversalType::Bytes
+            Type::Bytes
         );
         assert_eq!(
             mysql_column_to_universal_type("BINARY", "binary(16)", None, None),
-            UniversalType::Bytes
+            Type::Bytes
         );
         assert_eq!(
             mysql_column_to_universal_type("VARBINARY", "varbinary(255)", None, None),
-            UniversalType::Bytes
+            Type::Bytes
         );
     }
 
@@ -321,7 +319,7 @@ mod tests {
                 None,
                 None,
             );
-            assert!(matches!(ut, UniversalType::Geometry { .. }));
+            assert!(matches!(ut, Type::Geometry { .. }));
         }
     }
 

--- a/crates/neo4j-source/src/full_sync.rs
+++ b/crates/neo4j-source/src/full_sync.rs
@@ -6,7 +6,7 @@ use neo4rs::{ConfigBuilder, Graph, Query};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use surreal_sink::SurrealSink;
-use sync_core::{UniversalRelation, UniversalRow, UniversalThingRef, UniversalValue};
+use sync_core::{Relation, Row, ThingRef, Value};
 use sync_transform::{ApplyOpts, Pipeline};
 
 use crate::neo4j_checkpoint::Neo4jCheckpoint;
@@ -381,7 +381,7 @@ async fn migrate_neo4j_nodes<S: SurrealSink>(
             while let Some(row) = node_result.next().await? {
                 let universal_row =
                     convert_neo4j_row_to_universal_row(&row, &label, ctx, &from_opts.id_property)?;
-                if let Some(UniversalValue::LocalDateTime(ts)) =
+                if let Some(Value::LocalDateTime(ts)) =
                     universal_row.get_field(&from_opts.change_tracking_property)
                 {
                     min_timestamp = Some(min_timestamp.map_or(*ts, |min| min.min(*ts)));
@@ -414,7 +414,7 @@ async fn migrate_neo4j_nodes<S: SurrealSink>(
 
         #[async_trait]
         impl RowChunkSource for Neo4jNodeChunks<'_> {
-            async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<UniversalRow>>> {
+            async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<Row>>> {
                 if self.exhausted {
                     return Ok(None);
                 }
@@ -432,7 +432,7 @@ async fn migrate_neo4j_nodes<S: SurrealSink>(
                                 self.ctx,
                                 self.id_property,
                             )?;
-                            if let Some(UniversalValue::LocalDateTime(ts)) =
+                            if let Some(Value::LocalDateTime(ts)) =
                                 universal_row.get_field(self.tracking_property)
                             {
                                 *self.min_timestamp =
@@ -551,7 +551,7 @@ async fn migrate_neo4j_relationships<S: SurrealSink>(
             while let Some(row) = rel_result.next().await? {
                 let r = row_to_relation(&row, Some(rel_type.clone()), None)?;
                 let universal_relation = r.to_universal_relation(ctx)?;
-                if let Some(UniversalValue::LocalDateTime(ts)) = universal_relation
+                if let Some(Value::LocalDateTime(ts)) = universal_relation
                     .data
                     .get(&from_opts.change_tracking_property)
                 {
@@ -586,7 +586,7 @@ async fn migrate_neo4j_relationships<S: SurrealSink>(
 
         #[async_trait]
         impl RelationChunkSource for Neo4jRelChunks<'_> {
-            async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<UniversalRelation>>> {
+            async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<Relation>>> {
                 if self.exhausted {
                     return Ok(None);
                 }
@@ -600,7 +600,7 @@ async fn migrate_neo4j_relationships<S: SurrealSink>(
                         Some(row) => {
                             let r = row_to_relation(&row, Some(self.rel_type.clone()), None)?;
                             let universal_relation = r.to_universal_relation(self.ctx)?;
-                            if let Some(UniversalValue::LocalDateTime(ts)) =
+                            if let Some(Value::LocalDateTime(ts)) =
                                 universal_relation.data.get(self.tracking_property)
                             {
                                 *self.min_timestamp =
@@ -659,7 +659,7 @@ async fn migrate_neo4j_relationships<S: SurrealSink>(
     Ok((total_migrated, min_timestamp, max_timestamp))
 }
 
-// Convert Neo4j node row to UniversalRow
+// Convert Neo4j node row to Row
 /// Resolve a Neo4j node's SurrealDB record ID from its `id` property, falling back to the
 /// internal Neo4j node ID. This ensures that both node records and relationship endpoints
 /// use the same ID, so that RELATE statements reference existing records.
@@ -667,24 +667,24 @@ pub(crate) fn resolve_node_id(
     prop_id: Option<&neo4rs::BoltType>,
     internal_id: i64,
     ctx: &Neo4jConversionContext,
-) -> anyhow::Result<UniversalValue> {
+) -> anyhow::Result<Value> {
     match prop_id {
         Some(bolt_value) => {
             let universal =
                 convert_neo4j_type_to_universal_value(bolt_value.clone(), &ctx.timezone, false)?;
             match universal {
-                UniversalValue::Text(s) => {
+                Value::Text(s) => {
                     // String ID - try to parse as integer first (common case: numeric strings)
                     if let Ok(n) = s.parse::<i64>() {
-                        Ok(UniversalValue::Int64(n))
+                        Ok(Value::Int64(n))
                     } else {
-                        Ok(UniversalValue::Text(s))
+                        Ok(Value::Text(s))
                     }
                 }
-                UniversalValue::Int64(n) => Ok(UniversalValue::Int64(n)),
-                UniversalValue::Null => {
+                Value::Int64(n) => Ok(Value::Int64(n)),
+                Value::Null => {
                     // Node has no 'id' property (Neo4j returned null) - use internal node_id
-                    Ok(UniversalValue::Int64(internal_id))
+                    Ok(Value::Int64(internal_id))
                 }
                 other => Err(anyhow::anyhow!(
                     "Node with internal id '{internal_id}' has unsupported 'id' property type: {other:?}. \
@@ -694,7 +694,7 @@ pub(crate) fn resolve_node_id(
         }
         None => {
             // No 'id' property in query results - use Neo4j's internal node_id
-            Ok(UniversalValue::Int64(internal_id))
+            Ok(Value::Int64(internal_id))
         }
     }
 }
@@ -704,7 +704,7 @@ fn convert_neo4j_row_to_universal_row(
     label: &str,
     ctx: &Neo4jConversionContext,
     id_property: &str,
-) -> anyhow::Result<UniversalRow> {
+) -> anyhow::Result<Row> {
     let node: neo4rs::Node = row.get("n")?;
     let node_id: i64 = row.get("node_id")?;
 
@@ -715,14 +715,14 @@ fn convert_neo4j_row_to_universal_row(
     // strings as String, etc. We convert each type to the appropriate ID type.
     let id = match data.remove(id_property) {
         Some(universal) => match universal {
-            UniversalValue::Text(s) => {
+            Value::Text(s) => {
                 if let Ok(n) = s.parse::<i64>() {
-                    UniversalValue::Int64(n)
+                    Value::Int64(n)
                 } else {
-                    UniversalValue::Text(s)
+                    Value::Text(s)
                 }
             }
-            UniversalValue::Int64(n) => UniversalValue::Int64(n),
+            Value::Int64(n) => Value::Int64(n),
             other => {
                 return Err(anyhow::anyhow!(
                         "Node with label '{label}' and id '{node_id}' has unsupported 'id' property type: {other:?}. \
@@ -732,16 +732,11 @@ fn convert_neo4j_row_to_universal_row(
         },
         None => {
             // No 'id' property - use Neo4j's internal node_id
-            UniversalValue::Int64(node_id)
+            Value::Int64(node_id)
         }
     };
 
-    Ok(UniversalRow::new(
-        label.to_lowercase(),
-        node_id as u64,
-        id,
-        data,
-    ))
+    Ok(Row::new(label.to_lowercase(), node_id as u64, id, data))
 }
 
 /// Convert Neo4j node to keys and universal values
@@ -750,21 +745,20 @@ fn convert_neo4j_node_to_universal_kvs(
     node_id: i64,
     label: &str,
     ctx: &Neo4jConversionContext,
-) -> anyhow::Result<HashMap<String, UniversalValue>> {
+) -> anyhow::Result<HashMap<String, Value>> {
     let mut kvs = HashMap::new();
 
     // Add neo4j_id as a field (preserve original Neo4j ID)
-    kvs.insert("neo4j_id".to_string(), UniversalValue::Int64(node_id));
+    kvs.insert("neo4j_id".to_string(), Value::Int64(node_id));
 
     // Add labels as an array
     let labels: Vec<String> = node.labels().into_iter().map(|s| s.to_string()).collect();
-    let labels_universal_values: Vec<UniversalValue> =
-        labels.into_iter().map(UniversalValue::Text).collect();
+    let labels_universal_values: Vec<Value> = labels.into_iter().map(Value::Text).collect();
     kvs.insert(
         "labels".to_string(),
-        UniversalValue::Array {
+        Value::Array {
             elements: labels_universal_values,
-            element_type: Box::new(sync_core::UniversalType::Text),
+            element_type: Box::new(sync_core::Type::Text),
         },
     );
 
@@ -788,7 +782,8 @@ fn convert_neo4j_node_to_universal_kvs(
     Ok(kvs)
 }
 
-pub struct Relation {
+#[derive(Debug, Clone)]
+pub struct Neo4jRelation {
     pub rel_type: String,
     pub id: i64,
     pub start_labels: Vec<String>,
@@ -801,14 +796,11 @@ pub struct Relation {
     pub updated_at: i64,
 }
 
-impl Relation {
-    pub fn to_universal_relation(
-        &self,
-        ctx: &Neo4jConversionContext,
-    ) -> anyhow::Result<UniversalRelation> {
-        let id = UniversalValue::Int64(self.id);
+impl Neo4jRelation {
+    pub fn to_universal_relation(&self, ctx: &Neo4jConversionContext) -> anyhow::Result<Relation> {
+        let id = Value::Int64(self.id);
 
-        let input = UniversalThingRef::new(
+        let input = ThingRef::new(
             self.start_labels
                 .first()
                 .map(|s| s.to_lowercase())
@@ -816,7 +808,7 @@ impl Relation {
             resolve_node_id(self.start_prop_id.as_ref(), self.start_node_id, ctx)?,
         );
 
-        let output = UniversalThingRef::new(
+        let output = ThingRef::new(
             self.end_labels
                 .first()
                 .map(|s| s.to_lowercase())
@@ -832,7 +824,7 @@ impl Relation {
             data.insert(k.to_string(), v);
         }
 
-        Ok(UniversalRelation::new(
+        Ok(Relation::new(
             self.rel_type.to_lowercase(),
             id,
             input,
@@ -847,7 +839,7 @@ pub fn row_to_relation(
     row: &neo4rs::Row,
     rel_type: Option<String>,
     change_tracking_property: Option<String>,
-) -> anyhow::Result<Relation> {
+) -> anyhow::Result<Neo4jRelation> {
     let relationship: neo4rs::Relation = row.get("r")?;
     let rel_id: i64 = row.get("rel_id")?;
     let rel_type: String = if let Some(t) = rel_type {
@@ -883,7 +875,7 @@ pub fn row_to_relation(
         None
     };
 
-    anyhow::Ok(Relation {
+    anyhow::Ok(Neo4jRelation {
         rel_type,
         id: rel_id,
         start_labels,
@@ -897,7 +889,7 @@ pub fn row_to_relation(
     })
 }
 
-/// Convert Neo4j BoltType to UniversalValue
+/// Convert Neo4j BoltType to Value
 ///
 /// The timezone parameter specifies which timezone to use when converting Neo4j local datetime and time values.
 /// This should be an IANA timezone name (e.g., "America/New_York", "Europe/London", "UTC").
@@ -907,7 +899,7 @@ pub fn convert_neo4j_type_to_universal_value(
     value: neo4rs::BoltType,
     timezone: &str,
     should_parse_json: bool,
-) -> anyhow::Result<UniversalValue> {
+) -> anyhow::Result<Value> {
     use neo4j_types::reverse::ConversionConfig;
 
     // Create conversion config
@@ -916,7 +908,7 @@ pub fn convert_neo4j_type_to_universal_value(
         parse_json_strings: should_parse_json,
     };
 
-    // Convert BoltType → UniversalValue using neo4j-types
+    // Convert BoltType → Value using neo4j-types
     neo4j_types::convert_bolt_to_universal_value(value, &config).map_err(|e| anyhow::anyhow!("{e}"))
 }
 
@@ -937,7 +929,7 @@ mod tests {
 
         // Neo4j Date converts to LocalDateTime (midnight in the configured timezone)
         match result {
-            UniversalValue::LocalDateTime(dt) => {
+            Value::LocalDateTime(dt) => {
                 // Date should be at midnight UTC on 2024-01-15
                 assert_eq!(dt.year(), 2024);
                 assert_eq!(dt.month(), 1);
@@ -962,7 +954,7 @@ mod tests {
 
         // Neo4j Date converts to LocalDateTime (midnight in the configured timezone, then converted to UTC)
         match result {
-            UniversalValue::LocalDateTime(dt) => {
+            Value::LocalDateTime(dt) => {
                 // Date at midnight in New York (EST = UTC-5) should be 5 AM UTC
                 assert_eq!(dt.year(), 2024);
                 assert_eq!(dt.month(), 1);
@@ -989,7 +981,7 @@ mod tests {
         let result = convert_neo4j_type_to_universal_value(bolt_type, "UTC", false).unwrap();
 
         match result {
-            UniversalValue::LocalDateTime(dt) => {
+            Value::LocalDateTime(dt) => {
                 // Should be same time in UTC
                 assert_eq!(dt.year(), 2024);
                 assert_eq!(dt.month(), 1);
@@ -1016,7 +1008,7 @@ mod tests {
         let result = convert_neo4j_type_to_universal_value(bolt_type, "Asia/Tokyo", false).unwrap();
 
         match result {
-            UniversalValue::LocalDateTime(dt) => {
+            Value::LocalDateTime(dt) => {
                 // 14:30 in Tokyo (JST = UTC+9) should be 05:30 UTC
                 assert_eq!(dt.year(), 2024);
                 assert_eq!(dt.month(), 1);
@@ -1058,7 +1050,7 @@ mod tests {
         // The conversion should either succeed with an adjusted time or fail gracefully
         // depending on how chrono-tz handles DST gaps
         match result {
-            Ok(UniversalValue::LocalDateTime(_)) => {
+            Ok(Value::LocalDateTime(_)) => {
                 // If it succeeds, that's fine - chrono-tz adjusted the time
             }
             Err(e) => {
@@ -1084,7 +1076,7 @@ mod tests {
         let result = convert_neo4j_type_to_universal_value(bolt_type, "UTC", false).unwrap();
 
         match result {
-            UniversalValue::ZonedDateTime(dt) => {
+            Value::ZonedDateTime(dt) => {
                 // Should be same time in UTC
                 assert_eq!(dt.year(), 2024);
                 assert_eq!(dt.month(), 1);
@@ -1112,7 +1104,7 @@ mod tests {
         let result = convert_neo4j_type_to_universal_value(bolt_type, "UTC", false).unwrap();
 
         match result {
-            UniversalValue::ZonedDateTime(dt) => {
+            Value::ZonedDateTime(dt) => {
                 // 14:30 EST (UTC-5) should be 19:30 UTC
                 assert_eq!(dt.year(), 2024);
                 assert_eq!(dt.month(), 1);
@@ -1140,7 +1132,7 @@ mod tests {
         let result = convert_neo4j_type_to_universal_value(bolt_type, "UTC", false).unwrap();
 
         match result {
-            UniversalValue::ZonedDateTime(dt) => {
+            Value::ZonedDateTime(dt) => {
                 // 14:30 JST (UTC+9) should be 05:30 UTC
                 assert_eq!(dt.year(), 2024);
                 assert_eq!(dt.month(), 1);
@@ -1168,7 +1160,7 @@ mod tests {
         let result = convert_neo4j_type_to_universal_value(bolt_type, "UTC", false).unwrap();
 
         match result {
-            UniversalValue::ZonedDateTime(dt) => {
+            Value::ZonedDateTime(dt) => {
                 // 14:30 BST (UTC+1) should be 13:30 UTC
                 assert_eq!(dt.year(), 2024);
                 assert_eq!(dt.month(), 7);
@@ -1196,7 +1188,7 @@ mod tests {
         let result = convert_neo4j_type_to_universal_value(bolt_type, "UTC", false).unwrap();
 
         match result {
-            UniversalValue::ZonedDateTime(dt) => {
+            Value::ZonedDateTime(dt) => {
                 // 08:15:30 HST (UTC-10) should be 18:15:30 UTC
                 assert_eq!(dt.year(), 2024);
                 assert_eq!(dt.month(), 6);
@@ -1218,9 +1210,9 @@ mod tests {
         // Convert with JSON parsing enabled
         let result = convert_neo4j_type_to_universal_value(bolt_type.clone(), "UTC", true).unwrap();
 
-        // neo4j-types returns UniversalValue::Json when JSON parsing is enabled
+        // neo4j-types returns Value::Json when JSON parsing is enabled
         match result {
-            UniversalValue::Json(json_val) => {
+            Value::Json(json_val) => {
                 // Verify the JSON was parsed correctly
                 let obj = json_val.as_object().expect("Expected JSON object");
                 assert!(obj.contains_key("preferences"));
@@ -1247,7 +1239,7 @@ mod tests {
         let result_no_parse =
             convert_neo4j_type_to_universal_value(bolt_type, "UTC", false).unwrap();
         match result_no_parse {
-            UniversalValue::Text(s) => {
+            Value::Text(s) => {
                 assert_eq!(s, json_string);
             }
             _ => panic!("Expected Text, got {result_no_parse:?}"),
@@ -1304,7 +1296,7 @@ mod tests {
         let bolt = neo4rs::BoltType::String(neo4rs::BoltString::new("user_001"));
         let result = resolve_node_id(Some(&bolt), 99, &ctx).unwrap();
         assert!(
-            matches!(result, UniversalValue::Text(ref s) if s == "user_001"),
+            matches!(result, Value::Text(ref s) if s == "user_001"),
             "Expected Text(\"user_001\"), got {result:?}"
         );
     }
@@ -1315,7 +1307,7 @@ mod tests {
         let bolt = neo4rs::BoltType::String(neo4rs::BoltString::new("123"));
         let result = resolve_node_id(Some(&bolt), 99, &ctx).unwrap();
         assert!(
-            matches!(result, UniversalValue::Int64(123)),
+            matches!(result, Value::Int64(123)),
             "Expected Int64(123), got {result:?}"
         );
     }
@@ -1326,7 +1318,7 @@ mod tests {
         let bolt = neo4rs::BoltType::Integer(neo4rs::BoltInteger::new(42));
         let result = resolve_node_id(Some(&bolt), 99, &ctx).unwrap();
         assert!(
-            matches!(result, UniversalValue::Int64(42)),
+            matches!(result, Value::Int64(42)),
             "Expected Int64(42), got {result:?}"
         );
     }
@@ -1337,7 +1329,7 @@ mod tests {
         let bolt = neo4rs::BoltType::Null(neo4rs::BoltNull);
         let result = resolve_node_id(Some(&bolt), 77, &ctx).unwrap();
         assert!(
-            matches!(result, UniversalValue::Int64(77)),
+            matches!(result, Value::Int64(77)),
             "Expected Int64(77) fallback, got {result:?}"
         );
     }
@@ -1347,7 +1339,7 @@ mod tests {
         let ctx = test_ctx();
         let result = resolve_node_id(None, 55, &ctx).unwrap();
         assert!(
-            matches!(result, UniversalValue::Int64(55)),
+            matches!(result, Value::Int64(55)),
             "Expected Int64(55) fallback, got {result:?}"
         );
     }

--- a/crates/neo4j-source/src/incremental_sync.rs
+++ b/crates/neo4j-source/src/incremental_sync.rs
@@ -23,10 +23,7 @@ use neo4rs::{Graph, Query};
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use surreal_sink::SurrealSink;
-use sync_core::{
-    UniversalChange, UniversalRelation, UniversalRelationChange, UniversalRow, UniversalType,
-    UniversalValue,
-};
+use sync_core::{Change, Relation, RelationChange, Row, Type, Value};
 use sync_transform::{
     ApplyOpts, CheckpointPolicy, Pipeline, PositionedEvent, SourceDriver, SourceRuntimeOpts,
     StopReason,
@@ -36,9 +33,9 @@ use sync_transform::{
 #[derive(Debug, Clone)]
 pub enum IncrementalChange {
     /// A node upsert
-    Node(UniversalRow),
+    Node(Row),
     /// A relationship upsert (boxed to reduce enum size variance)
-    Relation(Box<UniversalRelation>),
+    Relation(Box<Relation>),
 }
 
 /// Sink-ordered apply position: timestamp plus keyset tie-breaks.
@@ -234,7 +231,7 @@ impl Neo4jChangeStream {
         let mut max_checkpoint = self.read_checkpoint;
         let mut last_node_id_at_max = i64::MIN;
         let mut last_rel_id_at_max = i64::MIN;
-        let mut record_id: UniversalValue;
+        let mut record_id: Value;
 
         while let Some(row) = result.next().await? {
             let node: neo4rs::Node = row.get("n")?;
@@ -265,19 +262,17 @@ impl Neo4jChangeStream {
             }
 
             // Convert node to universal data
-            let mut fields: HashMap<String, UniversalValue> = HashMap::new();
-            fields.insert("neo4j_id".to_string(), UniversalValue::Int64(node_id));
-            record_id = UniversalValue::Int64(node_id);
+            let mut fields: HashMap<String, Value> = HashMap::new();
+            fields.insert("neo4j_id".to_string(), Value::Int64(node_id));
+            record_id = Value::Int64(node_id);
 
-            let universal_labels: Vec<UniversalValue> = labels
-                .iter()
-                .map(|s| UniversalValue::Text(s.clone()))
-                .collect();
+            let universal_labels: Vec<Value> =
+                labels.iter().map(|s| Value::Text(s.clone())).collect();
             fields.insert(
                 "labels".to_string(),
-                UniversalValue::Array {
+                Value::Array {
                     elements: universal_labels,
-                    element_type: Box::new(UniversalType::Text),
+                    element_type: Box::new(Type::Text),
                 },
             );
 
@@ -294,18 +289,18 @@ impl Neo4jChangeStream {
                     ) {
                         // Rename id property field to avoid conflict with SurrealDB record ID
                         let field_name = if key == self.id_property {
-                            // Extract ID from the UniversalValue
+                            // Extract ID from the Value
                             record_id = match &v {
-                                UniversalValue::Int64(n) => UniversalValue::Int64(*n),
-                                UniversalValue::Text(s) => {
+                                Value::Int64(n) => Value::Int64(*n),
+                                Value::Text(s) => {
                                     // Try to parse as integer first (common case: numeric strings)
                                     if let Ok(n) = s.parse::<i64>() {
-                                        UniversalValue::Int64(n)
+                                        Value::Int64(n)
                                     } else {
-                                        UniversalValue::Text(s.clone())
+                                        Value::Text(s.clone())
                                     }
                                 }
-                                _ => UniversalValue::Int64(node_id),
+                                _ => Value::Int64(node_id),
                             };
                             "neo4j_original_id".to_string()
                         } else {
@@ -321,7 +316,7 @@ impl Neo4jChangeStream {
                 .map(|s| s.to_lowercase())
                 .unwrap_or_else(|| "node".to_string());
 
-            batch_changes.push(IncrementalChange::Node(UniversalRow::new(
+            batch_changes.push(IncrementalChange::Node(Row::new(
                 table,
                 node_id as u64,
                 record_id,
@@ -505,7 +500,7 @@ fn incremental_change_to_positioned(
             let ts = tracking_millis_from_fields(&row.fields, tracking_property)
                 .unwrap_or(prev.timestamp_millis);
             let node_id = match row.fields.get("neo4j_id") {
-                Some(UniversalValue::Int64(id)) => *id,
+                Some(Value::Int64(id)) => *id,
                 _ => row.index as i64,
             };
             let position = if ts > prev.timestamp_millis {
@@ -521,14 +516,14 @@ fn incremental_change_to_positioned(
                     after_rel_id: prev.after_rel_id,
                 }
             };
-            let uc = UniversalChange::update(row.table, row.id, row.fields);
+            let uc = Change::update(row.table, row.id, row.fields);
             (PositionedEvent::change(uc, position), position)
         }
         IncrementalChange::Relation(rel) => {
             let ts = tracking_millis_from_fields(&rel.data, tracking_property)
                 .unwrap_or(prev.timestamp_millis);
             let rel_id = match &rel.id {
-                UniversalValue::Int64(id) => *id,
+                Value::Int64(id) => *id,
                 _ => prev.after_rel_id,
             };
             let position = if ts > prev.timestamp_millis {
@@ -544,7 +539,7 @@ fn incremental_change_to_positioned(
                     after_rel_id: rel_id,
                 }
             };
-            let rc = UniversalRelationChange::update(*rel);
+            let rc = RelationChange::update(*rel);
             (PositionedEvent::relation_change(rc, position), position)
         }
     }
@@ -647,7 +642,7 @@ pub async fn run_incremental_sync_with_transforms<S: SurrealSink>(
                 IncrementalChange::Node(row) => {
                     let ts = tracking_millis_from_fields(&row.fields, &tracking).unwrap_or(0);
                     let node_id = match row.fields.get("neo4j_id") {
-                        Some(UniversalValue::Int64(id)) => *id,
+                        Some(Value::Int64(id)) => *id,
                         _ => row.index as i64,
                     };
                     Neo4jApplyPos {
@@ -659,7 +654,7 @@ pub async fn run_incremental_sync_with_transforms<S: SurrealSink>(
                 IncrementalChange::Relation(rel) => {
                     let ts = tracking_millis_from_fields(&rel.data, &tracking).unwrap_or(0);
                     let rel_id = match &rel.id {
-                        UniversalValue::Int64(id) => *id,
+                        Value::Int64(id) => *id,
                         _ => i64::MIN,
                     };
                     Neo4jApplyPos {
@@ -830,14 +825,14 @@ impl SourceDriver for Neo4jSourceDriver<'_> {
 }
 
 fn tracking_millis_from_fields(
-    fields: &HashMap<String, UniversalValue>,
+    fields: &HashMap<String, Value>,
     tracking_property: &str,
 ) -> Option<i64> {
     match fields.get(tracking_property) {
-        Some(UniversalValue::LocalDateTime(ts)) | Some(UniversalValue::ZonedDateTime(ts)) => {
+        Some(Value::LocalDateTime(ts)) | Some(Value::ZonedDateTime(ts)) => {
             Some(ts.timestamp_millis())
         }
-        Some(UniversalValue::Int64(ms)) => Some(*ms),
+        Some(Value::Int64(ms)) => Some(*ms),
         _ => None,
     }
 }

--- a/crates/neo4j-source/src/lib.rs
+++ b/crates/neo4j-source/src/lib.rs
@@ -10,8 +10,8 @@ pub mod testing;
 
 pub use full_sync::{
     convert_neo4j_type_to_universal_value, row_to_relation, run_full_sync,
-    run_full_sync_with_transforms, Neo4jConversionContext, Neo4jJsonProperty, Relation, SourceOpts,
-    SyncOpts,
+    run_full_sync_with_transforms, Neo4jConversionContext, Neo4jJsonProperty, Neo4jRelation,
+    SourceOpts, SyncOpts,
 };
 pub use incremental_sync::{
     apply_incremental_changes, run_incremental_sync, run_incremental_sync_with_transforms,

--- a/crates/neo4j-source/tests/transforms.rs
+++ b/crates/neo4j-source/tests/transforms.rs
@@ -12,16 +12,14 @@ use surreal_sync_neo4j_source::{
     run_full_sync_with_transforms, run_incremental_sync_with_transforms, Neo4jCheckpoint,
     ReplicationTailOptions, SourceOpts, SyncOpts,
 };
-use sync_core::{
-    UniversalChange, UniversalRelation, UniversalRelationChange, UniversalRow, UniversalValue,
-};
+use sync_core::{Change, Relation, RelationChange, Row, Value};
 use sync_transform::{ApplyOpts, ChildStdioMode, ExternalTransform, FramerKind, Pipeline};
 
 struct CaptureSink {
-    changes: Mutex<Vec<UniversalChange>>,
-    rows: Mutex<Vec<UniversalRow>>,
-    relation_changes: Mutex<Vec<UniversalRelationChange>>,
-    relations: Mutex<Vec<UniversalRelation>>,
+    changes: Mutex<Vec<Change>>,
+    rows: Mutex<Vec<Row>>,
+    relation_changes: Mutex<Vec<RelationChange>>,
+    relations: Mutex<Vec<Relation>>,
     /// Combined apply order: `change:{id}` or `relation:{id}`.
     apply_order: Mutex<Vec<String>>,
 }
@@ -42,17 +40,17 @@ impl CaptureSink {
     }
 }
 
-fn id_display(id: &UniversalValue) -> String {
+fn id_display(id: &Value) -> String {
     match id {
-        UniversalValue::Int64(n) => n.to_string(),
-        UniversalValue::Int32(n) => n.to_string(),
+        Value::Int64(n) => n.to_string(),
+        Value::Int32(n) => n.to_string(),
         other => format!("{other:?}"),
     }
 }
 
 #[async_trait::async_trait]
 impl SurrealSink for CaptureSink {
-    async fn write_universal_rows(&self, rows: &[UniversalRow]) -> anyhow::Result<()> {
+    async fn write_rows(&self, rows: &[Row]) -> anyhow::Result<()> {
         // Homogeneous Update upserts coalesce here. Mirror into `changes` /
         // `apply_order` so incremental tests that assert apply observations still
         // see coalesced writes (full sync keeps asserting on `rows`).
@@ -61,7 +59,7 @@ impl SurrealSink for CaptureSink {
         let mut changes = self.changes.lock().expect("lock");
         for row in rows {
             apply_order.push(format!("change:{}", id_display(&row.id)));
-            changes.push(UniversalChange::update(
+            changes.push(Change::update(
                 row.table.clone(),
                 row.id.clone(),
                 row.fields.clone(),
@@ -70,10 +68,7 @@ impl SurrealSink for CaptureSink {
         Ok(())
     }
 
-    async fn write_universal_relations(
-        &self,
-        relations: &[UniversalRelation],
-    ) -> anyhow::Result<()> {
+    async fn write_relations(&self, relations: &[Relation]) -> anyhow::Result<()> {
         self.relations
             .lock()
             .expect("lock")
@@ -82,12 +77,12 @@ impl SurrealSink for CaptureSink {
         let mut relation_changes = self.relation_changes.lock().expect("lock");
         for relation in relations {
             apply_order.push(format!("relation:{}", id_display(&relation.id)));
-            relation_changes.push(UniversalRelationChange::update(relation.clone()));
+            relation_changes.push(RelationChange::update(relation.clone()));
         }
         Ok(())
     }
 
-    async fn apply_universal_change(&self, change: &UniversalChange) -> anyhow::Result<()> {
+    async fn apply_change(&self, change: &Change) -> anyhow::Result<()> {
         self.apply_order
             .lock()
             .expect("lock")
@@ -96,10 +91,7 @@ impl SurrealSink for CaptureSink {
         Ok(())
     }
 
-    async fn apply_universal_relation_change(
-        &self,
-        change: &UniversalRelationChange,
-    ) -> anyhow::Result<()> {
+    async fn apply_relation_change(&self, change: &RelationChange) -> anyhow::Result<()> {
         self.apply_order
             .lock()
             .expect("lock")
@@ -144,29 +136,29 @@ fn ensure_fixture_worker() -> PathBuf {
     path
 }
 
-fn name_field(change: &UniversalChange) -> Option<String> {
-    let data = change.data.as_ref()?;
+fn name_field(change: &Change) -> Option<String> {
+    let data = change.fields.as_ref()?;
     match data.get("name")? {
-        UniversalValue::Text(value) => Some(value.clone()),
+        Value::Text(value) => Some(value.clone()),
         other => panic!("unexpected name: {other:?}"),
     }
 }
 
-fn row_name_field(row: &UniversalRow) -> Option<String> {
+fn row_name_field(row: &Row) -> Option<String> {
     match row.fields.get("name")? {
-        UniversalValue::Text(value) => Some(value.clone()),
+        Value::Text(value) => Some(value.clone()),
         other => panic!("unexpected name: {other:?}"),
     }
 }
 
-fn relation_name_field(rel: &UniversalRelation) -> Option<String> {
+fn relation_name_field(rel: &Relation) -> Option<String> {
     match rel.data.get("name")? {
-        UniversalValue::Text(value) => Some(value.clone()),
+        Value::Text(value) => Some(value.clone()),
         other => panic!("unexpected relation name: {other:?}"),
     }
 }
 
-fn relation_change_name(change: &UniversalRelationChange) -> Option<String> {
+fn relation_change_name(change: &RelationChange) -> Option<String> {
     relation_name_field(&change.relation)
 }
 

--- a/crates/neo4j-types/src/forward.rs
+++ b/crates/neo4j-types/src/forward.rs
@@ -1,13 +1,13 @@
-//! Forward conversion: TypedValue/UniversalValue → Neo4j Cypher literals.
+//! Forward conversion: TypedValue/Value → Neo4j Cypher literals.
 //!
-//! This module converts sync-core's `TypedValue` and `UniversalValue` to Neo4j Cypher
+//! This module converts sync-core's `TypedValue` and `Value` to Neo4j Cypher
 //! literal strings for use in CREATE/SET queries.
 //!
 //! Unlike other type conversion modules, this module returns `Result` for all conversions
 //! and never silently falls back to default values.
 
 use crate::error::{Neo4jTypesError, Result};
-use sync_core::{TypedValue, UniversalType, UniversalValue};
+use sync_core::{Type, TypedValue, Value};
 
 /// Convert a TypedValue to a Neo4j Cypher literal string.
 ///
@@ -33,7 +33,7 @@ pub fn typed_to_cypher_literal(typed: &TypedValue) -> Result<String> {
     universal_to_cypher_literal(&typed.value, Some(&typed.sync_type))
 }
 
-/// Convert a UniversalValue to a Neo4j Cypher literal string.
+/// Convert a Value to a Neo4j Cypher literal string.
 ///
 /// The `parent_type` is used for array element type resolution. Pass `None` for
 /// top-level values.
@@ -43,22 +43,19 @@ pub fn typed_to_cypher_literal(typed: &TypedValue) -> Result<String> {
 /// Returns an error if:
 /// - Float value is NaN or infinite
 /// - JSON serialization fails
-pub fn universal_to_cypher_literal(
-    value: &UniversalValue,
-    parent_type: Option<&UniversalType>,
-) -> Result<String> {
+pub fn universal_to_cypher_literal(value: &Value, parent_type: Option<&Type>) -> Result<String> {
     match value {
-        UniversalValue::Null => Ok("null".to_string()),
-        UniversalValue::Bool(b) => Ok(b.to_string()),
+        Value::Null => Ok("null".to_string()),
+        Value::Bool(b) => Ok(b.to_string()),
 
         // Integer types
-        UniversalValue::Int8 { value, .. } => Ok(value.to_string()),
-        UniversalValue::Int16(i) => Ok(i.to_string()),
-        UniversalValue::Int32(i) => Ok(i.to_string()),
-        UniversalValue::Int64(i) => Ok(i.to_string()),
+        Value::Int8 { value, .. } => Ok(value.to_string()),
+        Value::Int16(i) => Ok(i.to_string()),
+        Value::Int32(i) => Ok(i.to_string()),
+        Value::Int64(i) => Ok(i.to_string()),
 
         // Float types - error on NaN/Infinity instead of silent fallback
-        UniversalValue::Float32(f) => {
+        Value::Float32(f) => {
             if f.is_nan() {
                 Err(Neo4jTypesError::NanFloat)
             } else if f.is_infinite() {
@@ -67,7 +64,7 @@ pub fn universal_to_cypher_literal(
                 Ok(f.to_string())
             }
         }
-        UniversalValue::Float64(f) => {
+        Value::Float64(f) => {
             if f.is_nan() {
                 Err(Neo4jTypesError::NanFloat)
             } else if f.is_infinite() {
@@ -78,57 +75,57 @@ pub fn universal_to_cypher_literal(
         }
 
         // Decimal - store as numeric string
-        UniversalValue::Decimal { value, .. } => Ok(value.to_string()),
+        Value::Decimal { value, .. } => Ok(value.to_string()),
 
         // String types
-        UniversalValue::Text(s) => Ok(escape_neo4j_string(s)),
-        UniversalValue::Char { value, .. } => Ok(escape_neo4j_string(value)),
-        UniversalValue::VarChar { value, .. } => Ok(escape_neo4j_string(value)),
+        Value::Text(s) => Ok(escape_neo4j_string(s)),
+        Value::Char { value, .. } => Ok(escape_neo4j_string(value)),
+        Value::VarChar { value, .. } => Ok(escape_neo4j_string(value)),
 
         // UUID
-        UniversalValue::Uuid(u) => Ok(escape_neo4j_string(&u.to_string())),
+        Value::Uuid(u) => Ok(escape_neo4j_string(&u.to_string())),
 
         // ULID
-        UniversalValue::Ulid(u) => Ok(escape_neo4j_string(&u.to_string())),
+        Value::Ulid(u) => Ok(escape_neo4j_string(&u.to_string())),
 
         // DateTime types - use Neo4j datetime() function
-        UniversalValue::LocalDateTime(dt) => Ok(format!(
+        Value::LocalDateTime(dt) => Ok(format!(
             "datetime('{}')",
             dt.format("%Y-%m-%dT%H:%M:%S%.fZ")
         )),
-        UniversalValue::LocalDateTimeNano(dt) => Ok(format!(
+        Value::LocalDateTimeNano(dt) => Ok(format!(
             "datetime('{}')",
             dt.format("%Y-%m-%dT%H:%M:%S%.fZ")
         )),
-        UniversalValue::ZonedDateTime(dt) => Ok(format!(
+        Value::ZonedDateTime(dt) => Ok(format!(
             "datetime('{}')",
             dt.format("%Y-%m-%dT%H:%M:%S%.fZ")
         )),
 
         // Date - use Neo4j date() function
-        UniversalValue::Date(dt) => Ok(format!("date('{}')", dt.format("%Y-%m-%d"))),
+        Value::Date(dt) => Ok(format!("date('{}')", dt.format("%Y-%m-%d"))),
 
         // Time - use Neo4j time() function with fractional seconds
-        UniversalValue::Time(dt) => Ok(format!("time('{}')", dt.format("%H:%M:%S%.f"))),
+        Value::Time(dt) => Ok(format!("time('{}')", dt.format("%H:%M:%S%.f"))),
 
         // TimeTz - store as string to preserve timezone format
         // Note: We intentionally do NOT use datetime here because time and datetime
         // are fundamentally different types. Datetime implies a specific point in time,
         // while TIMETZ represents a daily recurring time in a specific timezone.
-        UniversalValue::TimeTz(s) => Ok(escape_neo4j_string(s)),
+        Value::TimeTz(s) => Ok(escape_neo4j_string(s)),
 
         // Binary types - store as hex string (Neo4j doesn't have native bytes)
-        UniversalValue::Bytes(b) => {
+        Value::Bytes(b) => {
             let hex: String = b.iter().map(|byte| format!("{byte:02x}")).collect();
             Ok(escape_neo4j_string(&hex))
         }
-        UniversalValue::Blob(b) => {
+        Value::Blob(b) => {
             let hex: String = b.iter().map(|byte| format!("{byte:02x}")).collect();
             Ok(escape_neo4j_string(&hex))
         }
 
         // JSON types - serialize and store as escaped string
-        UniversalValue::Json(json_val) => {
+        Value::Json(json_val) => {
             let json_str =
                 serde_json::to_string(&json_val).map_err(|e| Neo4jTypesError::JsonParseError {
                     property: "json".to_string(),
@@ -136,7 +133,7 @@ pub fn universal_to_cypher_literal(
                 })?;
             Ok(escape_neo4j_string(&json_str))
         }
-        UniversalValue::Jsonb(json_val) => {
+        Value::Jsonb(json_val) => {
             let json_str =
                 serde_json::to_string(&json_val).map_err(|e| Neo4jTypesError::JsonParseError {
                     property: "jsonb".to_string(),
@@ -146,17 +143,17 @@ pub fn universal_to_cypher_literal(
         }
 
         // Enum type
-        UniversalValue::Enum { value, .. } => Ok(escape_neo4j_string(value)),
+        Value::Enum { value, .. } => Ok(escape_neo4j_string(value)),
 
         // Set type - Neo4j list of strings
-        UniversalValue::Set { elements, .. } => {
+        Value::Set { elements, .. } => {
             let element_strs: Vec<String> =
                 elements.iter().map(|s| escape_neo4j_string(s)).collect();
             Ok(format!("[{}]", element_strs.join(", ")))
         }
 
         // Geometry type - store as GeoJSON string
-        UniversalValue::Geometry { data, .. } => {
+        Value::Geometry { data, .. } => {
             use sync_core::GeometryData;
             let GeometryData(json) = data;
             let json_str =
@@ -168,10 +165,10 @@ pub fn universal_to_cypher_literal(
         }
 
         // Array type - Neo4j list with recursive element conversion
-        UniversalValue::Array { elements, .. } => {
+        Value::Array { elements, .. } => {
             // Get element type from parent_type if available
             let element_type = match parent_type {
-                Some(UniversalType::Array { element_type }) => Some(element_type.as_ref()),
+                Some(Type::Array { element_type }) => Some(element_type.as_ref()),
                 _ => None,
             };
 
@@ -184,7 +181,7 @@ pub fn universal_to_cypher_literal(
         }
 
         // Duration type - use Neo4j duration() function
-        UniversalValue::Duration(d) => {
+        Value::Duration(d) => {
             // Neo4j duration format: PT<seconds>S or PT<seconds>.<nanos>S
             let secs = d.as_secs();
             let nanos = d.subsec_nanos();
@@ -197,12 +194,12 @@ pub fn universal_to_cypher_literal(
         }
 
         // Thing - record reference as string in "table:id" format
-        UniversalValue::Thing { table, id } => {
+        Value::Thing { table, id } => {
             let id_str = match id.as_ref() {
-                UniversalValue::Text(s) => s.clone(),
-                UniversalValue::Int32(i) => i.to_string(),
-                UniversalValue::Int64(i) => i.to_string(),
-                UniversalValue::Uuid(u) => u.to_string(),
+                Value::Text(s) => s.clone(),
+                Value::Int32(i) => i.to_string(),
+                Value::Int64(i) => i.to_string(),
+                Value::Uuid(u) => u.to_string(),
                 other => panic!(
                     "Unsupported Thing ID type for Neo4j: {other:?}. \
                      Supported types: Text, Int32, Int64, Uuid"
@@ -212,7 +209,7 @@ pub fn universal_to_cypher_literal(
         }
 
         // Object - nested document, convert to JSON-like map syntax for Neo4j
-        UniversalValue::Object(map) => {
+        Value::Object(map) => {
             let entries: Vec<String> = map
                 .iter()
                 .map(|(k, v)| {
@@ -226,13 +223,13 @@ pub fn universal_to_cypher_literal(
         }
 
         // Zero temporal - preserve as escaped MySQL-style literal string
-        UniversalValue::ZeroTemporal {
+        Value::ZeroTemporal {
             intended_type,
             source,
         } => {
             let s = source
                 .as_deref()
-                .unwrap_or_else(|| UniversalValue::canonical_zero_literal(intended_type));
+                .unwrap_or_else(|| Value::canonical_zero_literal(intended_type));
             Ok(escape_neo4j_string(s))
         }
     }
@@ -260,7 +257,7 @@ mod tests {
 
     #[test]
     fn test_null_conversion() {
-        let tv = TypedValue::null(UniversalType::Text);
+        let tv = TypedValue::null(Type::Text);
         assert_eq!(typed_to_cypher_literal(&tv).unwrap(), "null");
     }
 
@@ -466,12 +463,8 @@ mod tests {
     #[test]
     fn test_array_int_conversion() {
         let tv = TypedValue::array(
-            vec![
-                UniversalValue::Int32(1),
-                UniversalValue::Int32(2),
-                UniversalValue::Int32(3),
-            ],
-            UniversalType::Int32,
+            vec![Value::Int32(1), Value::Int32(2), Value::Int32(3)],
+            Type::Int32,
         );
         assert_eq!(typed_to_cypher_literal(&tv).unwrap(), "[1, 2, 3]");
     }
@@ -479,11 +472,8 @@ mod tests {
     #[test]
     fn test_array_text_conversion() {
         let tv = TypedValue::array(
-            vec![
-                UniversalValue::Text("a".to_string()),
-                UniversalValue::Text("b".to_string()),
-            ],
-            UniversalType::Text,
+            vec![Value::Text("a".to_string()), Value::Text("b".to_string())],
+            Type::Text,
         );
         assert_eq!(typed_to_cypher_literal(&tv).unwrap(), "['a', 'b']");
     }
@@ -492,10 +482,10 @@ mod tests {
     fn test_array_with_special_chars() {
         let tv = TypedValue::array(
             vec![
-                UniversalValue::Text("it's".to_string()),
-                UniversalValue::Text("a \"test\"".to_string()),
+                Value::Text("it's".to_string()),
+                Value::Text("a \"test\"".to_string()),
             ],
-            UniversalType::Text,
+            Type::Text,
         );
         assert_eq!(
             typed_to_cypher_literal(&tv).unwrap(),

--- a/crates/neo4j-types/src/lib.rs
+++ b/crates/neo4j-types/src/lib.rs
@@ -1,12 +1,12 @@
 //! Neo4j/Bolt type conversions for sync-core types.
 //!
 //! This crate provides bidirectional type conversions between sync-core's
-//! `TypedValue`/`UniversalValue` and Neo4j's Bolt types.
+//! `TypedValue`/`Value` and Neo4j's Bolt types.
 //!
 //! # Modules
 //!
-//! - [`forward`] - TypedValue/UniversalValue → Neo4j Cypher literals
-//! - [`reverse`] - Neo4j BoltType → TypedValue/UniversalValue
+//! - [`forward`] - TypedValue/Value → Neo4j Cypher literals
+//! - [`reverse`] - Neo4j BoltType → TypedValue/Value
 //! - [`error`] - Error types for conversion failures
 //!
 //! # Key Design Principles
@@ -28,7 +28,7 @@
 //!
 //! // Convert BoltType to TypedValue
 //! let bolt_value = neo4rs::BoltType::String("hello".to_string());
-//! let tv = convert_bolt_to_typed_value(bolt_value, &UniversalType::Text, "UTC")?;
+//! let tv = convert_bolt_to_typed_value(bolt_value, &Type::Text, "UTC")?;
 //! ```
 
 pub mod error;

--- a/crates/neo4j-types/src/reverse.rs
+++ b/crates/neo4j-types/src/reverse.rs
@@ -1,7 +1,7 @@
-//! Reverse conversion: Neo4j BoltType → TypedValue/UniversalValue
+//! Reverse conversion: Neo4j BoltType → TypedValue/Value
 //!
 //! This module implements conversion from Neo4j's BoltType to sync-core's TypedValue
-//! and UniversalValue types. This is used when reading data from Neo4j.
+//! and Value types. This is used when reading data from Neo4j.
 //!
 //! ## Timezone Handling
 //!
@@ -20,7 +20,7 @@ use chrono_tz::Tz;
 use neo4rs::BoltType;
 use std::str::FromStr;
 use sync_core::types::GeometryType;
-use sync_core::{TypedValue, UniversalType, UniversalValue};
+use sync_core::{Type, TypedValue, Value};
 
 /// Configuration options for reverse conversion.
 #[derive(Debug, Clone)]
@@ -90,13 +90,10 @@ pub fn convert_bolt_to_typed_value(
     Ok(TypedValue { value, sync_type })
 }
 
-/// Convert a Neo4j BoltType to an UniversalValue.
+/// Convert a Neo4j BoltType to an Value.
 ///
 /// This is a convenience wrapper that discards type information.
-pub fn convert_bolt_to_universal_value(
-    bolt: BoltType,
-    config: &ConversionConfig,
-) -> Result<UniversalValue> {
+pub fn convert_bolt_to_universal_value(bolt: BoltType, config: &ConversionConfig) -> Result<Value> {
     let (value, _) = convert_bolt_to_universal_value_with_type(bolt, config, true)?;
     Ok(value)
 }
@@ -109,15 +106,15 @@ fn convert_bolt_to_universal_value_with_type(
     bolt: BoltType,
     config: &ConversionConfig,
     is_top_level: bool,
-) -> Result<(UniversalValue, UniversalType)> {
+) -> Result<(Value, Type)> {
     match bolt {
-        BoltType::Null(_) => Ok((UniversalValue::Null, UniversalType::Text)),
+        BoltType::Null(_) => Ok((Value::Null, Type::Text)),
 
-        BoltType::Boolean(b) => Ok((UniversalValue::Bool(b.value), UniversalType::Bool)),
+        BoltType::Boolean(b) => Ok((Value::Bool(b.value), Type::Bool)),
 
         BoltType::Integer(i) => {
             // Neo4j integers are i64
-            Ok((UniversalValue::Int64(i.value), UniversalType::Int64))
+            Ok((Value::Int64(i.value), Type::Int64))
         }
 
         BoltType::Float(f) => {
@@ -129,7 +126,7 @@ fn convert_bolt_to_universal_value_with_type(
             if f_val.is_infinite() {
                 return Err(Neo4jTypesError::InfinityFloat);
             }
-            Ok((UniversalValue::Float64(f_val), UniversalType::Float64))
+            Ok((Value::Float64(f_val), Type::Float64))
         }
 
         BoltType::String(s) => {
@@ -139,23 +136,20 @@ fn convert_bolt_to_universal_value_with_type(
                 if let Ok(json_val) = serde_json::from_str::<serde_json::Value>(&s_val) {
                     // Only convert if it's actually JSON (object or array)
                     if json_val.is_object() || json_val.is_array() {
-                        return Ok((
-                            UniversalValue::Json(Box::new(json_val)),
-                            UniversalType::Json,
-                        ));
+                        return Ok((Value::Json(Box::new(json_val)), Type::Json));
                     }
                 }
             }
-            Ok((UniversalValue::Text(s_val), UniversalType::Text))
+            Ok((Value::Text(s_val), Type::Text))
         }
 
         BoltType::Bytes(b) => {
             let bytes = b.value.to_vec();
-            Ok((UniversalValue::Bytes(bytes), UniversalType::Bytes))
+            Ok((Value::Bytes(bytes), Type::Bytes))
         }
 
         BoltType::List(list) => {
-            let elements: Result<Vec<UniversalValue>> = list
+            let elements: Result<Vec<Value>> = list
                 .value
                 .into_iter()
                 .map(|elem| {
@@ -167,17 +161,17 @@ fn convert_bolt_to_universal_value_with_type(
 
             // Determine element type from first element, default to Text
             let element_type = if elements.is_empty() {
-                UniversalType::Text
+                Type::Text
             } else {
                 infer_element_type(&elements[0])
             };
 
             Ok((
-                UniversalValue::Array {
+                Value::Array {
                     elements,
                     element_type: Box::new(element_type.clone()),
                 },
-                UniversalType::Array {
+                Type::Array {
                     element_type: Box::new(element_type),
                 },
             ))
@@ -191,8 +185,8 @@ fn convert_bolt_to_universal_value_with_type(
                 json_obj.insert(key.to_string(), universal_value_to_json(&uval));
             }
             Ok((
-                UniversalValue::Json(Box::new(serde_json::Value::Object(json_obj))),
-                UniversalType::Json,
+                Value::Json(Box::new(serde_json::Value::Object(json_obj))),
+                Type::Json,
             ))
         }
 
@@ -217,8 +211,8 @@ fn convert_bolt_to_universal_value_with_type(
                 })?;
 
             Ok((
-                UniversalValue::LocalDateTime(datetime.with_timezone(&Utc)),
-                UniversalType::LocalDateTime,
+                Value::LocalDateTime(datetime.with_timezone(&Utc)),
+                Type::LocalDateTime,
             ))
         }
 
@@ -238,10 +232,7 @@ fn convert_bolt_to_universal_value_with_type(
                 "offset_seconds": offset.local_minus_utc()
             });
 
-            Ok((
-                UniversalValue::Json(Box::new(json_obj)),
-                UniversalType::Json,
-            ))
+            Ok((Value::Json(Box::new(json_obj)), Type::Json))
         }
 
         BoltType::LocalTime(local_time) => {
@@ -257,10 +248,7 @@ fn convert_bolt_to_universal_value_with_type(
                 "nanosecond": naive_time.nanosecond()
             });
 
-            Ok((
-                UniversalValue::Json(Box::new(json_obj)),
-                UniversalType::Json,
-            ))
+            Ok((Value::Json(Box::new(json_obj)), Type::Json))
         }
 
         BoltType::DateTime(dt) => {
@@ -272,8 +260,8 @@ fn convert_bolt_to_universal_value_with_type(
                     })?;
 
             Ok((
-                UniversalValue::ZonedDateTime(dt_with_offset.with_timezone(&Utc)),
-                UniversalType::ZonedDateTime,
+                Value::ZonedDateTime(dt_with_offset.with_timezone(&Utc)),
+                Type::ZonedDateTime,
             ))
         }
 
@@ -296,8 +284,8 @@ fn convert_bolt_to_universal_value_with_type(
             })?;
 
             Ok((
-                UniversalValue::LocalDateTime(datetime.with_timezone(&Utc)),
-                UniversalType::LocalDateTime,
+                Value::LocalDateTime(datetime.with_timezone(&Utc)),
+                Type::LocalDateTime,
             ))
         }
 
@@ -312,8 +300,8 @@ fn convert_bolt_to_universal_value_with_type(
                     })?;
 
             Ok((
-                UniversalValue::ZonedDateTime(dt_with_offset.with_timezone(&Utc)),
-                UniversalType::ZonedDateTime,
+                Value::ZonedDateTime(dt_with_offset.with_timezone(&Utc)),
+                Type::ZonedDateTime,
             ))
         }
 
@@ -321,10 +309,7 @@ fn convert_bolt_to_universal_value_with_type(
             // Neo4j Duration converts to std::time::Duration via Into
             let std_duration: std::time::Duration = duration.into();
 
-            Ok((
-                UniversalValue::Duration(std_duration),
-                UniversalType::Duration,
-            ))
+            Ok((Value::Duration(std_duration), Type::Duration))
         }
 
         BoltType::Point2D(point) => {
@@ -336,11 +321,11 @@ fn convert_bolt_to_universal_value_with_type(
             });
 
             Ok((
-                UniversalValue::Geometry {
+                Value::Geometry {
                     geometry_type: GeometryType::Point,
                     data: sync_core::values::GeometryData(geojson),
                 },
-                UniversalType::Geometry {
+                Type::Geometry {
                     geometry_type: GeometryType::Point,
                 },
             ))
@@ -355,11 +340,11 @@ fn convert_bolt_to_universal_value_with_type(
             });
 
             Ok((
-                UniversalValue::Geometry {
+                Value::Geometry {
                     geometry_type: GeometryType::Point,
                     data: sync_core::values::GeometryData(geojson),
                 },
-                UniversalType::Geometry {
+                Type::Geometry {
                     geometry_type: GeometryType::Point,
                 },
             ))
@@ -384,111 +369,109 @@ fn convert_bolt_to_universal_value_with_type(
     }
 }
 
-/// Infer the UniversalType from an UniversalValue.
-fn infer_element_type(value: &UniversalValue) -> UniversalType {
+/// Infer the Type from an Value.
+fn infer_element_type(value: &Value) -> Type {
     match value {
-        UniversalValue::Null => UniversalType::Text,
-        UniversalValue::Bool(_) => UniversalType::Bool,
-        UniversalValue::Int8 { width, .. } => UniversalType::Int8 { width: *width },
-        UniversalValue::Int16(_) => UniversalType::Int16,
-        UniversalValue::Int32(_) => UniversalType::Int32,
-        UniversalValue::Int64(_) => UniversalType::Int64,
-        UniversalValue::Float32(_) => UniversalType::Float32,
-        UniversalValue::Float64(_) => UniversalType::Float64,
-        UniversalValue::Decimal {
+        Value::Null => Type::Text,
+        Value::Bool(_) => Type::Bool,
+        Value::Int8 { width, .. } => Type::Int8 { width: *width },
+        Value::Int16(_) => Type::Int16,
+        Value::Int32(_) => Type::Int32,
+        Value::Int64(_) => Type::Int64,
+        Value::Float32(_) => Type::Float32,
+        Value::Float64(_) => Type::Float64,
+        Value::Decimal {
             precision, scale, ..
-        } => UniversalType::Decimal {
+        } => Type::Decimal {
             precision: *precision,
             scale: *scale,
         },
-        UniversalValue::Char { length, .. } => UniversalType::Char { length: *length },
-        UniversalValue::VarChar { length, .. } => UniversalType::VarChar { length: *length },
-        UniversalValue::Text(_) => UniversalType::Text,
-        UniversalValue::Blob(_) => UniversalType::Blob,
-        UniversalValue::Bytes(_) => UniversalType::Bytes,
-        UniversalValue::Uuid(_) => UniversalType::Uuid,
-        UniversalValue::Ulid(_) => UniversalType::Ulid,
-        UniversalValue::Date(_) => UniversalType::Date,
-        UniversalValue::Time(_) => UniversalType::Time,
-        UniversalValue::LocalDateTime(_) => UniversalType::LocalDateTime,
-        UniversalValue::LocalDateTimeNano(_) => UniversalType::LocalDateTimeNano,
-        UniversalValue::ZonedDateTime(_) => UniversalType::ZonedDateTime,
-        UniversalValue::Json(_) => UniversalType::Json,
-        UniversalValue::Jsonb(_) => UniversalType::Jsonb,
-        UniversalValue::Array { element_type, .. } => UniversalType::Array {
+        Value::Char { length, .. } => Type::Char { length: *length },
+        Value::VarChar { length, .. } => Type::VarChar { length: *length },
+        Value::Text(_) => Type::Text,
+        Value::Blob(_) => Type::Blob,
+        Value::Bytes(_) => Type::Bytes,
+        Value::Uuid(_) => Type::Uuid,
+        Value::Ulid(_) => Type::Ulid,
+        Value::Date(_) => Type::Date,
+        Value::Time(_) => Type::Time,
+        Value::LocalDateTime(_) => Type::LocalDateTime,
+        Value::LocalDateTimeNano(_) => Type::LocalDateTimeNano,
+        Value::ZonedDateTime(_) => Type::ZonedDateTime,
+        Value::Json(_) => Type::Json,
+        Value::Jsonb(_) => Type::Jsonb,
+        Value::Array { element_type, .. } => Type::Array {
             element_type: element_type.clone(),
         },
-        UniversalValue::Set { allowed_values, .. } => UniversalType::Set {
+        Value::Set { allowed_values, .. } => Type::Set {
             values: allowed_values.clone(),
         },
-        UniversalValue::Enum { allowed_values, .. } => UniversalType::Enum {
+        Value::Enum { allowed_values, .. } => Type::Enum {
             values: allowed_values.clone(),
         },
-        UniversalValue::Geometry { geometry_type, .. } => UniversalType::Geometry {
+        Value::Geometry { geometry_type, .. } => Type::Geometry {
             geometry_type: geometry_type.clone(),
         },
-        UniversalValue::Duration(_) => UniversalType::Duration,
-        UniversalValue::Thing { .. } => UniversalType::Thing,
-        UniversalValue::Object(_) => UniversalType::Object,
-        UniversalValue::TimeTz(_) => UniversalType::TimeTz,
-        UniversalValue::ZeroTemporal { intended_type, .. } => intended_type.clone(),
+        Value::Duration(_) => Type::Duration,
+        Value::Thing { .. } => Type::Thing,
+        Value::Object(_) => Type::Object,
+        Value::TimeTz(_) => Type::TimeTz,
+        Value::ZeroTemporal { intended_type, .. } => intended_type.clone(),
     }
 }
 
-/// Convert an UniversalValue to serde_json::Value.
-fn universal_value_to_json(value: &UniversalValue) -> serde_json::Value {
+/// Convert an Value to serde_json::Value.
+fn universal_value_to_json(value: &Value) -> serde_json::Value {
     match value {
-        UniversalValue::Null => serde_json::Value::Null,
-        UniversalValue::Bool(b) => serde_json::Value::Bool(*b),
-        UniversalValue::Int8 { value, .. } => serde_json::json!(*value),
-        UniversalValue::Int16(i) => serde_json::json!(*i),
-        UniversalValue::Int32(i) => serde_json::json!(*i),
-        UniversalValue::Int64(i) => serde_json::json!(*i),
-        UniversalValue::Float32(f) => serde_json::Number::from_f64(*f as f64)
+        Value::Null => serde_json::Value::Null,
+        Value::Bool(b) => serde_json::Value::Bool(*b),
+        Value::Int8 { value, .. } => serde_json::json!(*value),
+        Value::Int16(i) => serde_json::json!(*i),
+        Value::Int32(i) => serde_json::json!(*i),
+        Value::Int64(i) => serde_json::json!(*i),
+        Value::Float32(f) => serde_json::Number::from_f64(*f as f64)
             .map(serde_json::Value::Number)
             .unwrap_or(serde_json::Value::Null),
-        UniversalValue::Float64(f) => serde_json::Number::from_f64(*f)
+        Value::Float64(f) => serde_json::Number::from_f64(*f)
             .map(serde_json::Value::Number)
             .unwrap_or(serde_json::Value::Null),
-        UniversalValue::Decimal { value, .. } => serde_json::Value::String(value.clone()),
-        UniversalValue::Char { value, .. } => serde_json::Value::String(value.clone()),
-        UniversalValue::VarChar { value, .. } => serde_json::Value::String(value.clone()),
-        UniversalValue::Text(s) => serde_json::Value::String(s.clone()),
-        UniversalValue::Blob(b) | UniversalValue::Bytes(b) => {
-            serde_json::Value::String(hex::encode(b))
-        }
-        UniversalValue::Uuid(u) => serde_json::Value::String(u.to_string()),
-        UniversalValue::Ulid(u) => serde_json::Value::String(u.to_string()),
-        UniversalValue::Date(dt)
-        | UniversalValue::Time(dt)
-        | UniversalValue::LocalDateTime(dt)
-        | UniversalValue::LocalDateTimeNano(dt)
-        | UniversalValue::ZonedDateTime(dt) => serde_json::Value::String(dt.to_rfc3339()),
-        UniversalValue::Json(j) | UniversalValue::Jsonb(j) => (**j).clone(),
-        UniversalValue::Array { elements, .. } => {
+        Value::Decimal { value, .. } => serde_json::Value::String(value.clone()),
+        Value::Char { value, .. } => serde_json::Value::String(value.clone()),
+        Value::VarChar { value, .. } => serde_json::Value::String(value.clone()),
+        Value::Text(s) => serde_json::Value::String(s.clone()),
+        Value::Blob(b) | Value::Bytes(b) => serde_json::Value::String(hex::encode(b)),
+        Value::Uuid(u) => serde_json::Value::String(u.to_string()),
+        Value::Ulid(u) => serde_json::Value::String(u.to_string()),
+        Value::Date(dt)
+        | Value::Time(dt)
+        | Value::LocalDateTime(dt)
+        | Value::LocalDateTimeNano(dt)
+        | Value::ZonedDateTime(dt) => serde_json::Value::String(dt.to_rfc3339()),
+        Value::Json(j) | Value::Jsonb(j) => (**j).clone(),
+        Value::Array { elements, .. } => {
             serde_json::Value::Array(elements.iter().map(universal_value_to_json).collect())
         }
-        UniversalValue::Set { elements, .. } => serde_json::Value::Array(
+        Value::Set { elements, .. } => serde_json::Value::Array(
             elements
                 .iter()
                 .map(|s| serde_json::Value::String(s.clone()))
                 .collect(),
         ),
-        UniversalValue::Enum { value, .. } => serde_json::Value::String(value.clone()),
-        UniversalValue::Geometry { data, .. } => {
+        Value::Enum { value, .. } => serde_json::Value::String(value.clone()),
+        Value::Geometry { data, .. } => {
             let sync_core::values::GeometryData(json) = data;
             json.clone()
         }
-        UniversalValue::Duration(d) => serde_json::json!({
+        Value::Duration(d) => serde_json::json!({
             "secs": d.as_secs(),
             "nanos": d.subsec_nanos()
         }),
-        UniversalValue::Thing { table, id } => {
+        Value::Thing { table, id } => {
             let id_str = match id.as_ref() {
-                UniversalValue::Text(s) => s.clone(),
-                UniversalValue::Int32(i) => i.to_string(),
-                UniversalValue::Int64(i) => i.to_string(),
-                UniversalValue::Uuid(u) => u.to_string(),
+                Value::Text(s) => s.clone(),
+                Value::Int32(i) => i.to_string(),
+                Value::Int64(i) => i.to_string(),
+                Value::Uuid(u) => u.to_string(),
                 other => panic!(
                     "Unsupported Thing ID type for Neo4j: {other:?}. \
                      Supported types: Text, Int32, Int64, Uuid"
@@ -496,7 +479,7 @@ fn universal_value_to_json(value: &UniversalValue) -> serde_json::Value {
             };
             serde_json::json!(format!("{table}:{id_str}"))
         }
-        UniversalValue::Object(map) => {
+        Value::Object(map) => {
             let obj: serde_json::Map<String, serde_json::Value> = map
                 .iter()
                 .map(|(k, v)| (k.clone(), universal_value_to_json(v)))
@@ -504,14 +487,14 @@ fn universal_value_to_json(value: &UniversalValue) -> serde_json::Value {
             serde_json::Value::Object(obj)
         }
         // TimeTz - stored as string to preserve timezone format
-        UniversalValue::TimeTz(s) => serde_json::Value::String(s.clone()),
-        UniversalValue::ZeroTemporal {
+        Value::TimeTz(s) => serde_json::Value::String(s.clone()),
+        Value::ZeroTemporal {
             intended_type,
             source,
         } => {
             let s = source
                 .as_deref()
-                .unwrap_or_else(|| UniversalValue::canonical_zero_literal(intended_type));
+                .unwrap_or_else(|| Value::canonical_zero_literal(intended_type));
             serde_json::Value::String(s.to_string())
         }
     }
@@ -526,7 +509,7 @@ mod tests {
     fn test_null_conversion() {
         let config = ConversionConfig::default();
         let result = convert_bolt_to_typed_value(BoltType::Null(BoltNull), &config).unwrap();
-        assert!(matches!(result.value, UniversalValue::Null));
+        assert!(matches!(result.value, Value::Null));
     }
 
     #[test]
@@ -535,11 +518,11 @@ mod tests {
 
         let bolt_true = BoltType::Boolean(BoltBoolean::new(true));
         let result = convert_bolt_to_typed_value(bolt_true, &config).unwrap();
-        assert!(matches!(result.value, UniversalValue::Bool(true)));
+        assert!(matches!(result.value, Value::Bool(true)));
 
         let bolt_false = BoltType::Boolean(BoltBoolean::new(false));
         let result = convert_bolt_to_typed_value(bolt_false, &config).unwrap();
-        assert!(matches!(result.value, UniversalValue::Bool(false)));
+        assert!(matches!(result.value, Value::Bool(false)));
     }
 
     #[test]
@@ -548,15 +531,15 @@ mod tests {
 
         let bolt_int = BoltType::Integer(BoltInteger::new(42));
         let result = convert_bolt_to_typed_value(bolt_int, &config).unwrap();
-        assert!(matches!(result.value, UniversalValue::Int64(42)));
+        assert!(matches!(result.value, Value::Int64(42)));
 
         let bolt_big = BoltType::Integer(BoltInteger::new(i64::MAX));
         let result = convert_bolt_to_typed_value(bolt_big, &config).unwrap();
-        assert!(matches!(result.value, UniversalValue::Int64(i64::MAX)));
+        assert!(matches!(result.value, Value::Int64(i64::MAX)));
 
         let bolt_neg = BoltType::Integer(BoltInteger::new(-100));
         let result = convert_bolt_to_typed_value(bolt_neg, &config).unwrap();
-        assert!(matches!(result.value, UniversalValue::Int64(-100)));
+        assert!(matches!(result.value, Value::Int64(-100)));
     }
 
     #[test]
@@ -565,7 +548,7 @@ mod tests {
 
         let bolt_float = BoltType::Float(BoltFloat::new(1.23456789));
         let result = convert_bolt_to_typed_value(bolt_float, &config).unwrap();
-        if let UniversalValue::Float64(f) = result.value {
+        if let Value::Float64(f) = result.value {
             assert!((f - 1.23456789).abs() < 0.0001);
         } else {
             panic!("Expected Double value");
@@ -600,7 +583,7 @@ mod tests {
 
         let bolt_str = BoltType::String(BoltString::new("hello world"));
         let result = convert_bolt_to_typed_value(bolt_str, &config).unwrap();
-        if let UniversalValue::Text(s) = result.value {
+        if let Value::Text(s) = result.value {
             assert_eq!(s, "hello world");
         } else {
             panic!("Expected Text value");
@@ -614,7 +597,7 @@ mod tests {
         let bolt_str = BoltType::String(BoltString::new("{\"key\": \"value\"}"));
         let result = convert_bolt_to_typed_value(bolt_str, &config).unwrap();
         // Should remain as text, not parsed as JSON
-        if let UniversalValue::Text(s) = result.value {
+        if let Value::Text(s) = result.value {
             assert_eq!(s, "{\"key\": \"value\"}");
         } else {
             panic!("Expected Text value");
@@ -628,7 +611,7 @@ mod tests {
         let bolt_str = BoltType::String(BoltString::new("{\"key\": \"value\"}"));
         let result = convert_bolt_to_typed_value(bolt_str, &config).unwrap();
         // Should be parsed as JSON
-        if let UniversalValue::Json(json) = result.value {
+        if let Value::Json(json) = result.value {
             assert_eq!(json["key"], "value");
         } else {
             panic!("Expected Json value");
@@ -642,7 +625,7 @@ mod tests {
         let bytes = vec![0xDE, 0xAD, 0xBE, 0xEF];
         let bolt_bytes = BoltType::Bytes(BoltBytes::new(bytes.clone().into()));
         let result = convert_bolt_to_typed_value(bolt_bytes, &config).unwrap();
-        if let UniversalValue::Bytes(b) = result.value {
+        if let Value::Bytes(b) = result.value {
             assert_eq!(b, bytes);
         } else {
             panic!("Expected Bytes value");
@@ -669,7 +652,7 @@ mod tests {
         let bolt_date = BoltType::Date(BoltDate::from(naive_date));
         let result = convert_bolt_to_typed_value(bolt_date, &config).unwrap();
 
-        if let UniversalValue::LocalDateTime(dt) = result.value {
+        if let Value::LocalDateTime(dt) = result.value {
             assert_eq!(dt.year(), 2024);
             assert_eq!(dt.month(), 6);
             assert_eq!(dt.day(), 15);
@@ -689,7 +672,7 @@ mod tests {
         let bolt_date = BoltType::Date(BoltDate::from(naive_date));
         let result = convert_bolt_to_typed_value(bolt_date, &config).unwrap();
 
-        if let UniversalValue::LocalDateTime(dt) = result.value {
+        if let Value::LocalDateTime(dt) = result.value {
             // Midnight in EST (UTC-5) is 05:00 UTC
             assert_eq!(dt.year(), 2024);
             assert_eq!(dt.month(), 1);
@@ -712,11 +695,11 @@ mod tests {
 
         let result = convert_bolt_to_typed_value(BoltType::List(bolt_list), &config).unwrap();
 
-        if let UniversalValue::Array { elements, .. } = result.value {
+        if let Value::Array { elements, .. } = result.value {
             assert_eq!(elements.len(), 3);
-            assert!(matches!(elements[0], UniversalValue::Int64(1)));
-            assert!(matches!(elements[1], UniversalValue::Int64(2)));
-            assert!(matches!(elements[2], UniversalValue::Int64(3)));
+            assert!(matches!(elements[0], Value::Int64(1)));
+            assert!(matches!(elements[1], Value::Int64(2)));
+            assert!(matches!(elements[2], Value::Int64(3)));
         } else {
             panic!("Expected Array value");
         }
@@ -733,9 +716,9 @@ mod tests {
 
         let result = convert_bolt_to_typed_value(BoltType::List(bolt_list), &config).unwrap();
 
-        if let UniversalValue::Array { elements, .. } = result.value {
+        if let Value::Array { elements, .. } = result.value {
             assert_eq!(elements.len(), 2);
-            if let UniversalValue::Text(s) = &elements[0] {
+            if let Value::Text(s) = &elements[0] {
                 assert_eq!(s, "a");
             } else {
                 panic!("Expected Text value");
@@ -754,7 +737,7 @@ mod tests {
 
         let result = convert_bolt_to_typed_value(BoltType::List(bolt_list), &config).unwrap();
 
-        if let UniversalValue::Array { elements, .. } = result.value {
+        if let Value::Array { elements, .. } = result.value {
             assert!(elements.is_empty());
         } else {
             panic!("Expected Array value");
@@ -772,7 +755,7 @@ mod tests {
 
         let result = convert_bolt_to_typed_value(BoltType::Map(bolt_map), &config).unwrap();
 
-        if let UniversalValue::Json(json) = result.value {
+        if let Value::Json(json) = result.value {
             assert_eq!(json["name"], "Alice");
             assert_eq!(json["age"], 30);
         } else {
@@ -791,9 +774,9 @@ mod tests {
 
         let result = convert_bolt_to_typed_value(BoltType::List(bolt_list), &config).unwrap();
 
-        if let UniversalValue::Array { elements, .. } = result.value {
+        if let Value::Array { elements, .. } = result.value {
             // The nested string should NOT be parsed as JSON
-            if let UniversalValue::Text(s) = &elements[0] {
+            if let Value::Text(s) = &elements[0] {
                 assert_eq!(s, "{\"nested\": true}");
             } else {
                 panic!("Expected nested string to remain as Text");
@@ -816,7 +799,7 @@ mod tests {
         let bolt_local_dt = BoltType::LocalDateTime(BoltLocalDateTime::from(naive_dt));
         let result = convert_bolt_to_typed_value(bolt_local_dt, &config).unwrap();
 
-        if let UniversalValue::LocalDateTime(dt) = result.value {
+        if let Value::LocalDateTime(dt) = result.value {
             assert_eq!(dt.year(), 2024);
             assert_eq!(dt.month(), 6);
             assert_eq!(dt.day(), 15);

--- a/crates/postgresql-pgoutput-source/src/change.rs
+++ b/crates/postgresql-pgoutput-source/src/change.rs
@@ -6,17 +6,15 @@ use anyhow::{anyhow, Result};
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use pg_walstream::RowData;
 use pgoutput_protocol::{CdcChange, RelationMeta, RowChange};
-use postgres_types::Type;
-use sync_core::{
-    DatabaseSchema, UniversalChange, UniversalChangeOp, UniversalType, UniversalValue,
-};
+use postgres_types::Type as PgType;
+use sync_core::{Change, ChangeOp, DatabaseSchema, Type, Value};
 
-pub fn cdc_change_to_universal(
+pub fn cdc_to_change(
     change: &CdcChange,
     relation: &RelationMeta,
     column_names: &[String],
     schema: &DatabaseSchema,
-) -> Result<UniversalChange> {
+) -> Result<Change> {
     let table_def = schema
         .get_table(&change.table)
         .ok_or_else(|| anyhow!("unknown table '{}' in schema", change.table))?;
@@ -27,10 +25,10 @@ pub fn cdc_change_to_universal(
         .map(str::to_string)
         .collect::<Vec<_>>();
 
-    let (op, row_data): (UniversalChangeOp, &RowData) = match &change.operation {
-        RowChange::Insert { new } => (UniversalChangeOp::Create, new),
-        RowChange::Update { new, .. } => (UniversalChangeOp::Update, new.as_ref()),
-        RowChange::Delete { old } => (UniversalChangeOp::Delete, old),
+    let (op, row_data): (ChangeOp, &RowData) = match &change.operation {
+        RowChange::Insert { new } => (ChangeOp::Create, new),
+        RowChange::Update { new, .. } => (ChangeOp::Update, new.as_ref()),
+        RowChange::Delete { old } => (ChangeOp::Delete, old),
     };
 
     let mut values = HashMap::new();
@@ -39,7 +37,7 @@ pub fn cdc_change_to_universal(
             let cell = row_data
                 .get(col_name.as_str())
                 .ok_or_else(|| anyhow!("missing column '{col_name}' in row data"))?;
-            let universal = column_value_to_universal(cell, &Type::TEXT, table_def, col_name)?;
+            let universal = column_value_to_universal(cell, &PgType::TEXT, table_def, col_name)?;
             values.insert(col_name.clone(), universal);
         }
     } else {
@@ -53,40 +51,40 @@ pub fn cdc_change_to_universal(
             let cell = row_data
                 .get(col_name.as_str())
                 .ok_or_else(|| anyhow!("missing column '{col_name}' in row data"))?;
-            let pg_type = Type::from_oid(col_meta.type_id).unwrap_or(Type::TEXT);
+            let pg_type = PgType::from_oid(col_meta.type_id).unwrap_or(PgType::TEXT);
             let universal = column_value_to_universal(cell, &pg_type, table_def, col_name)?;
             values.insert(col_name.clone(), universal);
         }
     }
 
     let id = extract_primary_key(&values, &pk_columns)?;
-    let data = if op == UniversalChangeOp::Delete {
+    let data = if op == ChangeOp::Delete {
         None
     } else {
-        let fields: HashMap<String, UniversalValue> = values
+        let fields: HashMap<String, Value> = values
             .into_iter()
             .filter(|(name, _)| !pk_columns.contains(name))
             .collect();
         Some(fields)
     };
 
-    Ok(UniversalChange::new(op, change.table.clone(), id, data))
+    Ok(Change::new(op, change.table.clone(), id, data))
 }
 
 fn column_value_to_universal(
     cell: &pg_walstream::ColumnValue,
-    pg_type: &Type,
+    pg_type: &PgType,
     table_def: &sync_core::TableDefinition,
     column_name: &str,
-) -> Result<UniversalValue> {
+) -> Result<Value> {
     if cell.is_null() {
-        return Ok(UniversalValue::Null);
+        return Ok(Value::Null);
     }
 
     let universal_type = table_def
         .get_column_type(column_name)
         .cloned()
-        .unwrap_or(UniversalType::Text);
+        .unwrap_or(Type::Text);
 
     match cell {
         pg_walstream::ColumnValue::Text(bytes) => {
@@ -94,95 +92,89 @@ fn column_value_to_universal(
                 .map_err(|e| anyhow!("invalid UTF-8 in column '{column_name}': {e}"))?;
             parse_text_value(text, &universal_type, pg_type)
         }
-        pg_walstream::ColumnValue::Binary(bytes) => Ok(UniversalValue::Bytes(bytes.to_vec())),
-        pg_walstream::ColumnValue::Null => Ok(UniversalValue::Null),
+        pg_walstream::ColumnValue::Binary(bytes) => Ok(Value::Bytes(bytes.to_vec())),
+        pg_walstream::ColumnValue::Null => Ok(Value::Null),
     }
 }
 
-fn parse_text_value(
-    text: &str,
-    universal_type: &UniversalType,
-    pg_type: &Type,
-) -> Result<UniversalValue> {
+fn parse_text_value(text: &str, universal_type: &Type, pg_type: &PgType) -> Result<Value> {
     if text == "null" {
-        return Ok(UniversalValue::Null);
+        return Ok(Value::Null);
     }
     match universal_type {
-        UniversalType::Bool => Ok(UniversalValue::Bool(text == "t" || text == "true")),
-        UniversalType::Int16 => text
+        Type::Bool => Ok(Value::Bool(text == "t" || text == "true")),
+        Type::Int16 => text
             .parse::<i16>()
-            .map(UniversalValue::Int16)
+            .map(Value::Int16)
             .map_err(|e| anyhow!("{e}")),
-        UniversalType::Int32 => text
+        Type::Int32 => text
             .parse::<i32>()
-            .map(UniversalValue::Int32)
+            .map(Value::Int32)
             .map_err(|e| anyhow!("{e}")),
-        UniversalType::Int64 => text
+        Type::Int64 => text
             .parse::<i64>()
-            .map(UniversalValue::Int64)
+            .map(Value::Int64)
             .map_err(|e| anyhow!("{e}")),
-        UniversalType::Float32 => text
+        Type::Float32 => text
             .parse::<f32>()
-            .map(UniversalValue::Float32)
+            .map(Value::Float32)
             .map_err(|e| anyhow!("{e}")),
-        UniversalType::Float64 => text
+        Type::Float64 => text
             .parse::<f64>()
-            .map(UniversalValue::Float64)
+            .map(Value::Float64)
             .map_err(|e| anyhow!("{e}")),
-        UniversalType::Uuid => {
+        Type::Uuid => {
             let u = uuid::Uuid::parse_str(text).map_err(|e| anyhow!("{e}"))?;
-            Ok(UniversalValue::Uuid(u))
+            Ok(Value::Uuid(u))
         }
-        UniversalType::Json | UniversalType::Jsonb => {
+        Type::Json | Type::Jsonb => {
             let parsed: serde_json::Value = serde_json::from_str(text)?;
-            Ok(UniversalValue::Json(Box::new(parsed)))
+            Ok(Value::Json(Box::new(parsed)))
         }
-        UniversalType::Enum { values, .. } => {
+        Type::Enum { values, .. } => {
             if values.iter().any(|v| v == text) {
-                Ok(UniversalValue::Enum {
+                Ok(Value::Enum {
                     value: text.to_string(),
                     allowed_values: values.clone(),
                 })
             } else {
                 tracing::warn!("enum value '{text}' not in allowed set for type {pg_type:?}");
-                Ok(UniversalValue::Text(text.to_string()))
+                Ok(Value::Text(text.to_string()))
             }
         }
-        UniversalType::ZonedDateTime => Ok(UniversalValue::ZonedDateTime(
-            parse_postgres_timestamptz(text)?,
-        )),
-        UniversalType::LocalDateTime => {
+        Type::ZonedDateTime => Ok(Value::ZonedDateTime(parse_postgres_timestamptz(text)?)),
+        Type::LocalDateTime => {
             let naive = parse_postgres_timestamp(text)?;
-            Ok(UniversalValue::LocalDateTime(
+            Ok(Value::LocalDateTime(
                 DateTime::<Utc>::from_naive_utc_and_offset(naive, Utc),
             ))
         }
-        UniversalType::Date => {
+        Type::Date => {
             let date = NaiveDate::parse_from_str(text, "%Y-%m-%d")
                 .map_err(|e| anyhow!("invalid date '{text}': {e}"))?;
             let dt = date
                 .and_hms_opt(0, 0, 0)
                 .ok_or_else(|| anyhow!("invalid date '{text}'"))?;
-            Ok(UniversalValue::Date(
-                DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc),
-            ))
+            Ok(Value::Date(DateTime::<Utc>::from_naive_utc_and_offset(
+                dt, Utc,
+            )))
         }
-        UniversalType::Array { element_type, .. } => parse_postgres_text_array(text, element_type),
-        UniversalType::Decimal { precision, scale } => Ok(UniversalValue::Decimal {
+        Type::Array { element_type, .. } => parse_postgres_text_array(text, element_type),
+        Type::Decimal { precision, scale } => Ok(Value::Decimal {
             value: text.to_string(),
             precision: *precision,
             scale: *scale,
         }),
-        UniversalType::Time => {
+        Type::Time => {
             let time = NaiveTime::parse_from_str(text, "%H:%M:%S%.f")
                 .or_else(|_| NaiveTime::parse_from_str(text, "%H:%M:%S"))
                 .map_err(|e| anyhow!("invalid time '{text}': {e}"))?;
             let dt = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap().and_time(time);
-            Ok(UniversalValue::Time(
-                DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc),
-            ))
+            Ok(Value::Time(DateTime::<Utc>::from_naive_utc_and_offset(
+                dt, Utc,
+            )))
         }
-        _ => Ok(UniversalValue::Text(text.to_string())),
+        _ => Ok(Value::Text(text.to_string())),
     }
 }
 
@@ -205,13 +197,13 @@ fn parse_postgres_timestamptz(text: &str) -> Result<DateTime<Utc>> {
     Ok(DateTime::<Utc>::from_naive_utc_and_offset(naive, Utc))
 }
 
-fn parse_postgres_text_array(text: &str, element_type: &UniversalType) -> Result<UniversalValue> {
+fn parse_postgres_text_array(text: &str, element_type: &Type) -> Result<Value> {
     let inner = text
         .strip_prefix('{')
         .and_then(|s| s.strip_suffix('}'))
         .ok_or_else(|| anyhow!("invalid PostgreSQL array literal: {text}"))?;
     if inner.is_empty() {
-        return Ok(UniversalValue::Array {
+        return Ok(Value::Array {
             elements: Vec::new(),
             element_type: Box::new(element_type.clone()),
         });
@@ -220,10 +212,10 @@ fn parse_postgres_text_array(text: &str, element_type: &UniversalType) -> Result
         .split(',')
         .map(|item| {
             let item = item.trim().trim_matches('"');
-            parse_text_value(item, element_type, &Type::TEXT)
+            parse_text_value(item, element_type, &PgType::TEXT)
         })
         .collect::<Result<Vec<_>>>()?;
-    Ok(UniversalValue::Array {
+    Ok(Value::Array {
         elements,
         element_type: Box::new(element_type.clone()),
     })
@@ -235,17 +227,14 @@ fn parse_postgres_timestamp(text: &str) -> Result<NaiveDateTime> {
         .map_err(|e| anyhow!("invalid timestamp '{text}': {e}"))
 }
 
-fn extract_primary_key(
-    values: &HashMap<String, UniversalValue>,
-    pk_columns: &[String],
-) -> Result<UniversalValue> {
+fn extract_primary_key(values: &HashMap<String, Value>, pk_columns: &[String]) -> Result<Value> {
     if pk_columns.len() == 1 {
         return values
             .get(&pk_columns[0])
             .cloned()
             .ok_or_else(|| anyhow!("missing primary key column '{}'", pk_columns[0]));
     }
-    let elements: Vec<UniversalValue> = pk_columns
+    let elements: Vec<Value> = pk_columns
         .iter()
         .map(|col| {
             values
@@ -254,8 +243,8 @@ fn extract_primary_key(
                 .ok_or_else(|| anyhow!("missing PK column '{col}'"))
         })
         .collect::<Result<_>>()?;
-    Ok(UniversalValue::Array {
+    Ok(Value::Array {
         elements,
-        element_type: Box::new(UniversalType::Text),
+        element_type: Box::new(Type::Text),
     })
 }

--- a/crates/postgresql-pgoutput-source/src/full_sync.rs
+++ b/crates/postgresql-pgoutput-source/src/full_sync.rs
@@ -190,7 +190,7 @@ async fn migrate_table_with_transforms<S: SurrealSink>(
     apply_opts: &ApplyOpts,
 ) -> Result<usize> {
     use surreal_sync_postgresql::{get_primary_key_columns, read_table_chunk};
-    use sync_core::{classify_table, TableKind, UniversalValue};
+    use sync_core::{classify_table, TableKind, Value};
 
     let pk_columns = get_primary_key_columns(client, table_name).await?;
     let table_kind = schema
@@ -238,7 +238,7 @@ async fn migrate_table_with_transforms<S: SurrealSink>(
     }
 
     let mut total_processed = 0usize;
-    let mut after: Option<Vec<UniversalValue>> = None;
+    let mut after: Option<Vec<Value>> = None;
     if sync_opts.dry_run {
         loop {
             if cancel.is_cancelled() {
@@ -268,7 +268,7 @@ async fn migrate_table_with_transforms<S: SurrealSink>(
 
     use async_trait::async_trait;
     use std::sync::Arc;
-    use sync_core::UniversalRow;
+    use sync_core::Row;
     use sync_transform::{
         run_source_runtime_with, RowChunkDriver, RowChunkSource, SourceRuntimeOpts,
     };
@@ -277,7 +277,7 @@ async fn migrate_table_with_transforms<S: SurrealSink>(
         client: &'a Client,
         table_name: &'a str,
         pk_columns: &'a [String],
-        after: Option<Vec<UniversalValue>>,
+        after: Option<Vec<Value>>,
         batch_size: usize,
         schema: Option<&'a sync_core::DatabaseSchema>,
         cancel: &'a tokio_util::sync::CancellationToken,
@@ -286,7 +286,7 @@ async fn migrate_table_with_transforms<S: SurrealSink>(
 
     #[async_trait]
     impl RowChunkSource for PgKeysetChunks<'_> {
-        async fn next_chunk(&mut self) -> Result<Option<Vec<UniversalRow>>> {
+        async fn next_chunk(&mut self) -> Result<Option<Vec<Row>>> {
             if self.exhausted || self.cancel.is_cancelled() {
                 self.exhausted = true;
                 return Ok(None);
@@ -347,7 +347,7 @@ async fn migrate_relation_streaming<S: SurrealSink>(
     use async_trait::async_trait;
     use std::sync::Arc;
     use surreal_sync_postgresql::{read_offset_relation_chunk, read_relation_chunk};
-    use sync_core::{UniversalRelation, UniversalValue};
+    use sync_core::{Relation, Value};
     use sync_transform::{
         run_source_runtime_with, RelationChunkDriver, RelationChunkSource, SourceRuntimeOpts,
     };
@@ -375,7 +375,7 @@ async fn migrate_relation_streaming<S: SurrealSink>(
                 }
             }
         } else {
-            let mut after: Option<Vec<UniversalValue>> = None;
+            let mut after: Option<Vec<Value>> = None;
             let mut row_index_base = 0u64;
             loop {
                 if cancel.is_cancelled() {
@@ -425,7 +425,7 @@ async fn migrate_relation_streaming<S: SurrealSink>(
         }
         #[async_trait]
         impl RelationChunkSource for OffsetRelChunks<'_> {
-            async fn next_chunk(&mut self) -> Result<Option<Vec<UniversalRelation>>> {
+            async fn next_chunk(&mut self) -> Result<Option<Vec<Relation>>> {
                 if self.exhausted || self.cancel.is_cancelled() {
                     self.exhausted = true;
                     return Ok(None);
@@ -477,7 +477,7 @@ async fn migrate_relation_streaming<S: SurrealSink>(
         client: &'a Client,
         table_name: &'a str,
         pk_columns: &'a [String],
-        after: Option<Vec<UniversalValue>>,
+        after: Option<Vec<Value>>,
         batch_size: usize,
         in_fk: &'a sync_core::ForeignKeyDefinition,
         out_fk: &'a sync_core::ForeignKeyDefinition,
@@ -487,7 +487,7 @@ async fn migrate_relation_streaming<S: SurrealSink>(
     }
     #[async_trait]
     impl RelationChunkSource for KeysetRelChunks<'_> {
-        async fn next_chunk(&mut self) -> Result<Option<Vec<UniversalRelation>>> {
+        async fn next_chunk(&mut self) -> Result<Option<Vec<Relation>>> {
             if self.exhausted || self.cancel.is_cancelled() {
                 self.exhausted = true;
                 return Ok(None);
@@ -555,7 +555,7 @@ async fn migrate_offset_rows_streaming<S: SurrealSink>(
     use async_trait::async_trait;
     use std::sync::Arc;
     use surreal_sync_postgresql::read_offset_table_chunk;
-    use sync_core::UniversalRow;
+    use sync_core::Row;
     use sync_transform::{
         run_source_runtime_with, RowChunkDriver, RowChunkSource, SourceRuntimeOpts,
     };
@@ -594,7 +594,7 @@ async fn migrate_offset_rows_streaming<S: SurrealSink>(
     }
     #[async_trait]
     impl RowChunkSource for OffsetRowChunks<'_> {
-        async fn next_chunk(&mut self) -> Result<Option<Vec<UniversalRow>>> {
+        async fn next_chunk(&mut self) -> Result<Option<Vec<Row>>> {
             if self.exhausted || self.cancel.is_cancelled() {
                 self.exhausted = true;
                 return Ok(None);

--- a/crates/postgresql-pgoutput-source/src/incremental_sync.rs
+++ b/crates/postgresql-pgoutput-source/src/incremental_sync.rs
@@ -22,7 +22,7 @@ use crate::catch_up::{
     effective_sync_tables, emit_catch_up_progress, read_catch_up_progress, CatchUpProgress,
     CoverageKind,
 };
-use crate::change::cdc_change_to_universal;
+use crate::change::cdc_to_change;
 use crate::checkpoint::{get_current_checkpoint, PgoutputCheckpoint};
 use crate::client::{
     connect_wal_client, ensure_publication_for_source, new_sql_client, resolve_schema,
@@ -456,12 +456,8 @@ where
                             names
                         };
 
-                    let universal = cdc_change_to_universal(
-                        &change,
-                        &relation,
-                        &column_names,
-                        &self.db_schema,
-                    )?;
+                    let universal =
+                        cdc_to_change(&change, &relation, &column_names, &self.db_schema)?;
                     out.push(PositionedEvent::change(universal, position));
                 }
                 StreamEvent::Control => {}

--- a/crates/postgresql-pgoutput-source/src/lib.rs
+++ b/crates/postgresql-pgoutput-source/src/lib.rs
@@ -20,7 +20,7 @@ pub use catch_up::{
     effective_sync_tables, emit_catch_up_progress, max_pgoutput_checkpoint, read_catch_up_progress,
     tables_pending_snapshot, CatchUpProgress, CoverageKind, TableCoverageEntry,
 };
-pub use change::cdc_change_to_universal;
+pub use change::cdc_to_change;
 pub use checkpoint::{get_current_checkpoint, PgoutputCheckpoint, PgoutputReconciliationPos};
 pub use full_sync::{
     capture_head_checkpoint, run_full_sync, run_full_sync_cancellable,

--- a/crates/postgresql-pgoutput-source/src/watermark_source.rs
+++ b/crates/postgresql-pgoutput-source/src/watermark_source.rs
@@ -14,9 +14,7 @@ use surreal_sync_interleaved_snapshot::{
     WatermarkSource,
 };
 use surreal_sync_postgresql::get_primary_key_columns;
-use sync_core::{
-    DatabaseSchema, UniversalChange, UniversalChangeOp, UniversalRow, UniversalType, UniversalValue,
-};
+use sync_core::{Change, ChangeOp, DatabaseSchema, Row, Type, Value};
 use tokio::sync::Mutex as AsyncMutex;
 use tokio_postgres::Client;
 use tracing::info;
@@ -26,7 +24,7 @@ use crate::catch_up::{
     effective_sync_tables, emit_catch_up_progress, read_catch_up_progress, CatchUpProgress,
     CoverageKind,
 };
-use crate::change::cdc_change_to_universal;
+use crate::change::cdc_to_change;
 use crate::checkpoint::{get_current_checkpoint, PgoutputCheckpoint, PgoutputReconciliationPos};
 use crate::client::{
     connect_wal_client, ensure_publication_for_source, new_sql_client, resolve_schema,
@@ -280,7 +278,7 @@ impl PgoutputWatermarkSource {
             .column_names_by_table
             .get(&change.table)
             .ok_or_else(|| anyhow!("missing column names for table '{}'", change.table))?;
-        let universal = cdc_change_to_universal(change, relation, column_names, &self.db_schema)?;
+        let universal = cdc_to_change(change, relation, column_names, &self.db_schema)?;
         let pk = pk_tuple_from_primary_key(&universal.id);
         Ok(ReconciliationEvent {
             position: PgoutputReconciliationPos::new(change.position),
@@ -360,21 +358,17 @@ impl PgoutputWatermarkSource {
         Ok(types)
     }
 
-    async fn coerce_after(
-        &self,
-        table: &TableSpec,
-        after: &PkTuple,
-    ) -> Result<Vec<UniversalValue>> {
+    async fn coerce_after(&self, table: &TableSpec, after: &PkTuple) -> Result<Vec<Value>> {
         let types = self.column_type_oids(&table.table).await?;
         let mut out = Vec::with_capacity(after.0.len());
         for (col, value) in table.pk_columns.iter().zip(after.0.iter()) {
             let coerced = match (value, types.get(col).copied()) {
-                (UniversalValue::Int64(n), Some(OID_INT4)) => UniversalValue::Int32(*n as i32),
-                (UniversalValue::Int64(n), Some(OID_INT2)) => UniversalValue::Int16(*n as i16),
-                (UniversalValue::Int32(n), Some(OID_INT8)) => UniversalValue::Int64(*n as i64),
-                (UniversalValue::Int32(n), Some(OID_INT2)) => UniversalValue::Int16(*n as i16),
-                (UniversalValue::Int16(n), Some(OID_INT8)) => UniversalValue::Int64(*n as i64),
-                (UniversalValue::Int16(n), Some(OID_INT4)) => UniversalValue::Int32(*n as i32),
+                (Value::Int64(n), Some(OID_INT4)) => Value::Int32(*n as i32),
+                (Value::Int64(n), Some(OID_INT2)) => Value::Int16(*n as i16),
+                (Value::Int32(n), Some(OID_INT8)) => Value::Int64(*n as i64),
+                (Value::Int32(n), Some(OID_INT2)) => Value::Int16(*n as i16),
+                (Value::Int16(n), Some(OID_INT8)) => Value::Int64(*n as i64),
+                (Value::Int16(n), Some(OID_INT4)) => Value::Int32(*n as i32),
                 (other, _) => other.clone(),
             };
             out.push(coerced);
@@ -396,8 +390,8 @@ impl WatermarkSource for PgoutputWatermarkSource {
         table: &TableSpec,
         after: Option<&PkTuple>,
         limit: usize,
-    ) -> Result<Vec<UniversalRow>> {
-        let after_values: Option<Vec<UniversalValue>> = match after {
+    ) -> Result<Vec<Row>> {
+        let after_values: Option<Vec<Value>> = match after {
             Some(pk) => Some(self.coerce_after(table, pk).await?),
             None => None,
         };
@@ -634,13 +628,8 @@ fn signal_insert_to_event(
     Ok(Some(ReconciliationEvent {
         position: PgoutputReconciliationPos::new(change.position),
         table: SIGNAL_TABLE.to_string(),
-        pk: PkTuple::new(vec![UniversalValue::Uuid(id)]),
-        change: UniversalChange::new(
-            UniversalChangeOp::Create,
-            SIGNAL_TABLE,
-            UniversalValue::Uuid(id),
-            None,
-        ),
+        pk: PkTuple::new(vec![Value::Uuid(id)]),
+        change: Change::new(ChangeOp::Create, SIGNAL_TABLE, Value::Uuid(id), None),
     }))
 }
 
@@ -665,42 +654,42 @@ fn signal_uuid_from_row(values: &pg_walstream::RowData) -> Result<Uuid> {
     Uuid::parse_str(&id_str).map_err(|e| anyhow!("invalid signal UUID '{id_str}': {e}"))
 }
 
-fn pk_tuple_from_primary_key(pk: &UniversalValue) -> PkTuple {
+fn pk_tuple_from_primary_key(pk: &Value) -> PkTuple {
     match pk {
-        UniversalValue::Array { elements, .. } => {
+        Value::Array { elements, .. } => {
             PkTuple::new(elements.iter().map(normalize_pk_value).collect())
         }
         single => PkTuple::new(vec![normalize_pk_value(single)]),
     }
 }
 
-fn normalize_pk_value(value: &UniversalValue) -> UniversalValue {
+fn normalize_pk_value(value: &Value) -> Value {
     match value {
-        UniversalValue::Int8 { value, .. } => UniversalValue::Int64(*value as i64),
-        UniversalValue::Int16(v) => UniversalValue::Int64(*v as i64),
-        UniversalValue::Int32(v) => UniversalValue::Int64(*v as i64),
-        UniversalValue::Int64(v) => UniversalValue::Int64(*v),
-        UniversalValue::Uuid(u) => UniversalValue::Uuid(*u),
-        UniversalValue::Char { value, .. } => UniversalValue::Text(value.clone()),
-        UniversalValue::VarChar { value, .. } => UniversalValue::Text(value.clone()),
-        UniversalValue::Text(s) => UniversalValue::Text(s.clone()),
+        Value::Int8 { value, .. } => Value::Int64(*value as i64),
+        Value::Int16(v) => Value::Int64(*v as i64),
+        Value::Int32(v) => Value::Int64(*v as i64),
+        Value::Int64(v) => Value::Int64(*v),
+        Value::Uuid(u) => Value::Uuid(*u),
+        Value::Char { value, .. } => Value::Text(value.clone()),
+        Value::VarChar { value, .. } => Value::Text(value.clone()),
+        Value::Text(s) => Value::Text(s.clone()),
         other => other.clone(),
     }
 }
 
-fn normalize_row_pk(row: &mut UniversalRow, pk_columns: &[String]) {
+fn normalize_row_pk(row: &mut Row, pk_columns: &[String]) {
     if pk_columns.len() == 1 {
         row.id = normalize_pk_value(&row.id);
         return;
     }
-    if let UniversalValue::Array { elements, .. } = &row.id {
-        let canonical: Vec<UniversalValue> = elements.iter().map(normalize_pk_value).collect();
+    if let Value::Array { elements, .. } = &row.id {
+        let canonical: Vec<Value> = elements.iter().map(normalize_pk_value).collect();
         for (col, value) in pk_columns.iter().zip(canonical.iter()) {
             row.fields.insert(col.clone(), value.clone());
         }
-        row.id = UniversalValue::Array {
+        row.id = Value::Array {
             elements: canonical,
-            element_type: Box::new(UniversalType::Text),
+            element_type: Box::new(Type::Text),
         };
     }
 }

--- a/crates/postgresql-pgoutput-source/tests/suite/integration.rs
+++ b/crates/postgresql-pgoutput-source/tests/suite/integration.rs
@@ -4,19 +4,19 @@ use anyhow::Result;
 use surreal_sync_postgresql_pgoutput_source::{
     run_replication_tail_with_checkpoints, ReplicationTailOptions,
 };
-use sync_core::{UniversalChange, UniversalValue};
+use sync_core::{Change, Value};
 
 struct CaptureSink {
-    changes: std::sync::Mutex<Vec<UniversalChange>>,
+    changes: std::sync::Mutex<Vec<Change>>,
 }
 
 #[async_trait::async_trait]
 impl surreal_sink::SurrealSink for CaptureSink {
-    async fn write_universal_rows(&self, rows: &[sync_core::UniversalRow]) -> anyhow::Result<()> {
+    async fn write_rows(&self, rows: &[sync_core::Row]) -> anyhow::Result<()> {
         // Homogeneous Update upserts coalesce here; mirror into `changes`.
         let mut changes = self.changes.lock().expect("lock");
         for row in rows {
-            changes.push(UniversalChange::update(
+            changes.push(Change::update(
                 row.table.clone(),
                 row.id.clone(),
                 row.fields.clone(),
@@ -25,21 +25,18 @@ impl surreal_sink::SurrealSink for CaptureSink {
         Ok(())
     }
 
-    async fn write_universal_relations(
-        &self,
-        _relations: &[sync_core::UniversalRelation],
-    ) -> anyhow::Result<()> {
+    async fn write_relations(&self, _relations: &[sync_core::Relation]) -> anyhow::Result<()> {
         Ok(())
     }
 
-    async fn apply_universal_change(&self, change: &UniversalChange) -> anyhow::Result<()> {
+    async fn apply_change(&self, change: &Change) -> anyhow::Result<()> {
         self.changes.lock().expect("lock").push(change.clone());
         Ok(())
     }
 
-    async fn apply_universal_relation_change(
+    async fn apply_relation_change(
         &self,
-        _change: &sync_core::UniversalRelationChange,
+        _change: &sync_core::RelationChange,
     ) -> anyhow::Result<()> {
         Ok(())
     }
@@ -94,10 +91,10 @@ async fn ddl_refreshes_schema_before_subsequent_rows() -> Result<()> {
     let changes = sink.changes.lock().expect("lock").clone();
     let status = changes
         .iter()
-        .find_map(|change| change.data.as_ref()?.get("status"))
+        .find_map(|change| change.fields.as_ref()?.get("status"))
         .expect("status field should be present after DDL refresh");
     match status {
-        UniversalValue::Enum { value, .. } => assert_eq!(value, "done"),
+        Value::Enum { value, .. } => assert_eq!(value, "done"),
         other => panic!("expected refreshed ENUM label, got {other:?}"),
     }
 

--- a/crates/postgresql-pgoutput-source/tests/suite/interleaved_snapshot.rs
+++ b/crates/postgresql-pgoutput-source/tests/suite/interleaved_snapshot.rs
@@ -81,7 +81,7 @@ async fn drain_to_catch_up(
             if event.table == signal_table {
                 continue;
             }
-            sink.apply_universal_change(&event.change).await?;
+            sink.apply_change(&event.change).await?;
         }
         let pos = source.current_position().await?;
         source.commit_reconciled(pos).await?;

--- a/crates/postgresql-pgoutput-source/tests/suite/no_pk_offset.rs
+++ b/crates/postgresql-pgoutput-source/tests/suite/no_pk_offset.rs
@@ -9,11 +9,11 @@ use surreal_sync_postgresql::{get_primary_key_columns, read_offset_table_chunk};
 use surreal_sync_postgresql_pgoutput_source::{
     run_full_sync_cancellable_with_transforms, SyncOpts,
 };
-use sync_core::{UniversalChange, UniversalRow, UniversalValue};
+use sync_core::{Change, Row, Value};
 use sync_transform::{ApplyOpts, Pipeline};
 
 struct CaptureSink {
-    changes: Mutex<Vec<UniversalChange>>,
+    changes: Mutex<Vec<Change>>,
 }
 
 impl CaptureSink {
@@ -26,11 +26,11 @@ impl CaptureSink {
 
 #[async_trait::async_trait]
 impl SurrealSink for CaptureSink {
-    async fn write_universal_rows(&self, rows: &[UniversalRow]) -> anyhow::Result<()> {
-        // Full sync upserts coalesce to write_universal_rows; mirror into `changes`.
+    async fn write_rows(&self, rows: &[Row]) -> anyhow::Result<()> {
+        // Full sync upserts coalesce to write_rows; mirror into `changes`.
         let mut changes = self.changes.lock().expect("lock");
         for row in rows {
-            changes.push(UniversalChange::update(
+            changes.push(Change::update(
                 row.table.clone(),
                 row.id.clone(),
                 row.fields.clone(),
@@ -39,36 +39,33 @@ impl SurrealSink for CaptureSink {
         Ok(())
     }
 
-    async fn write_universal_relations(
-        &self,
-        _relations: &[sync_core::UniversalRelation],
-    ) -> anyhow::Result<()> {
+    async fn write_relations(&self, _relations: &[sync_core::Relation]) -> anyhow::Result<()> {
         Ok(())
     }
 
-    async fn apply_universal_change(&self, change: &UniversalChange) -> anyhow::Result<()> {
+    async fn apply_change(&self, change: &Change) -> anyhow::Result<()> {
         self.changes.lock().expect("lock").push(change.clone());
         Ok(())
     }
 
-    async fn apply_universal_relation_change(
+    async fn apply_relation_change(
         &self,
-        _change: &sync_core::UniversalRelationChange,
+        _change: &sync_core::RelationChange,
     ) -> anyhow::Result<()> {
         Ok(())
     }
 }
 
-fn name_of_row(row: &UniversalRow) -> String {
+fn name_of_row(row: &Row) -> String {
     match row.fields.get("name") {
-        Some(UniversalValue::VarChar { value, .. } | UniversalValue::Text(value)) => value.clone(),
+        Some(Value::VarChar { value, .. } | Value::Text(value)) => value.clone(),
         other => panic!("unexpected name: {other:?}"),
     }
 }
 
-fn name_of_change(change: &UniversalChange) -> String {
-    match change.data.as_ref().and_then(|d| d.get("name")) {
-        Some(UniversalValue::VarChar { value, .. } | UniversalValue::Text(value)) => value.clone(),
+fn name_of_change(change: &Change) -> String {
+    match change.fields.as_ref().and_then(|d| d.get("name")) {
+        Some(Value::VarChar { value, .. } | Value::Text(value)) => value.clone(),
         other => panic!("unexpected name: {other:?}"),
     }
 }
@@ -117,7 +114,7 @@ async fn read_offset_table_chunk_assigns_synthetic_ids_with_ctid_order() -> Resu
             .collect()
     );
     for (i, row) in all.iter().enumerate() {
-        assert_eq!(row.id, UniversalValue::Int64(i as i64));
+        assert_eq!(row.id, Value::Int64(i as i64));
         assert_eq!(row.index, i as u64);
     }
     Ok(())
@@ -178,7 +175,7 @@ async fn full_sync_streams_no_pk_table_via_offset_chunks() -> Result<()> {
     );
     for change in &changes {
         assert!(
-            matches!(change.id, UniversalValue::Int64(_)),
+            matches!(change.id, Value::Int64(_)),
             "no-PK rows should use synthetic Int64 ids, got {:?}",
             change.id
         );

--- a/crates/postgresql-pgoutput-source/tests/suite/transforms.rs
+++ b/crates/postgresql-pgoutput-source/tests/suite/transforms.rs
@@ -10,12 +10,12 @@ use surreal_sync_postgresql_pgoutput_source::{
     run_full_sync_cancellable_with_transforms, run_replication_tail_with_transforms,
     ReplicationTailOptions, SyncOpts,
 };
-use sync_core::{UniversalChange, UniversalRow, UniversalValue};
+use sync_core::{Change, Row, Value};
 use sync_transform::{ApplyOpts, ChildStdioMode, ExternalTransform, FramerKind, Pipeline};
 
 struct CaptureSink {
-    changes: Mutex<Vec<UniversalChange>>,
-    rows: Mutex<Vec<UniversalRow>>,
+    changes: Mutex<Vec<Change>>,
+    rows: Mutex<Vec<Row>>,
 }
 
 impl CaptureSink {
@@ -29,13 +29,13 @@ impl CaptureSink {
 
 #[async_trait::async_trait]
 impl SurrealSink for CaptureSink {
-    async fn write_universal_rows(&self, rows: &[UniversalRow]) -> anyhow::Result<()> {
+    async fn write_rows(&self, rows: &[Row]) -> anyhow::Result<()> {
         // Homogeneous Update upserts coalesce here; mirror into `changes` for
         // incremental assertions (full sync still reads `rows`).
         self.rows.lock().expect("lock").extend(rows.iter().cloned());
         let mut changes = self.changes.lock().expect("lock");
         for row in rows {
-            changes.push(UniversalChange::update(
+            changes.push(Change::update(
                 row.table.clone(),
                 row.id.clone(),
                 row.fields.clone(),
@@ -44,21 +44,18 @@ impl SurrealSink for CaptureSink {
         Ok(())
     }
 
-    async fn write_universal_relations(
-        &self,
-        _relations: &[sync_core::UniversalRelation],
-    ) -> anyhow::Result<()> {
+    async fn write_relations(&self, _relations: &[sync_core::Relation]) -> anyhow::Result<()> {
         Ok(())
     }
 
-    async fn apply_universal_change(&self, change: &UniversalChange) -> anyhow::Result<()> {
+    async fn apply_change(&self, change: &Change) -> anyhow::Result<()> {
         self.changes.lock().expect("lock").push(change.clone());
         Ok(())
     }
 
-    async fn apply_universal_relation_change(
+    async fn apply_relation_change(
         &self,
-        _change: &sync_core::UniversalRelationChange,
+        _change: &sync_core::RelationChange,
     ) -> anyhow::Result<()> {
         Ok(())
     }
@@ -106,17 +103,17 @@ fn ensure_fixture_worker() -> PathBuf {
     path
 }
 
-fn name_field(change: &UniversalChange) -> Option<String> {
-    let data = change.data.as_ref()?;
+fn name_field(change: &Change) -> Option<String> {
+    let data = change.fields.as_ref()?;
     match data.get("name")? {
-        UniversalValue::VarChar { value, .. } | UniversalValue::Text(value) => Some(value.clone()),
+        Value::VarChar { value, .. } | Value::Text(value) => Some(value.clone()),
         other => panic!("unexpected name value: {other:?}"),
     }
 }
 
-fn row_name_field(row: &UniversalRow) -> Option<String> {
+fn row_name_field(row: &Row) -> Option<String> {
     match row.fields.get("name")? {
-        UniversalValue::VarChar { value, .. } | UniversalValue::Text(value) => Some(value.clone()),
+        Value::VarChar { value, .. } | Value::Text(value) => Some(value.clone()),
         other => panic!("unexpected name value: {other:?}"),
     }
 }

--- a/crates/postgresql-trigger-source/src/full_sync.rs
+++ b/crates/postgresql-trigger-source/src/full_sync.rs
@@ -159,7 +159,7 @@ async fn migrate_one_table_keyset<S: surreal_sink::SurrealSink>(
         get_primary_key_columns, read_offset_relation_chunk, read_offset_table_chunk,
         read_relation_chunk, read_table_chunk,
     };
-    use sync_core::{classify_table, TableKind, UniversalRelation, UniversalRow, UniversalValue};
+    use sync_core::{classify_table, Relation, Row, TableKind, Value};
     use sync_transform::{
         run_source_runtime_with, RelationChunkDriver, RelationChunkSource, RowChunkDriver,
         RowChunkSource, SourceRuntimeOpts,
@@ -192,7 +192,7 @@ async fn migrate_one_table_keyset<S: surreal_sink::SurrealSink>(
                     }
                 }
             } else {
-                let mut after: Option<Vec<UniversalValue>> = None;
+                let mut after: Option<Vec<Value>> = None;
                 let mut base = 0u64;
                 loop {
                     let chunk = read_relation_chunk(
@@ -238,7 +238,7 @@ async fn migrate_one_table_keyset<S: surreal_sink::SurrealSink>(
             }
             #[async_trait]
             impl RelationChunkSource for OffsetRel<'_> {
-                async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<UniversalRelation>>> {
+                async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<Relation>>> {
                     if self.exhausted {
                         return Ok(None);
                     }
@@ -287,7 +287,7 @@ async fn migrate_one_table_keyset<S: surreal_sink::SurrealSink>(
             client: &'a tokio_postgres::Client,
             table_name: &'a str,
             pk_columns: &'a [String],
-            after: Option<Vec<UniversalValue>>,
+            after: Option<Vec<Value>>,
             batch_size: usize,
             in_fk: &'a sync_core::ForeignKeyDefinition,
             out_fk: &'a sync_core::ForeignKeyDefinition,
@@ -296,7 +296,7 @@ async fn migrate_one_table_keyset<S: surreal_sink::SurrealSink>(
         }
         #[async_trait]
         impl RelationChunkSource for KeysetRel<'_> {
-            async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<UniversalRelation>>> {
+            async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<Relation>>> {
                 if self.exhausted {
                     return Ok(None);
                 }
@@ -388,7 +388,7 @@ async fn migrate_one_table_keyset<S: surreal_sink::SurrealSink>(
         }
         #[async_trait]
         impl RowChunkSource for OffsetRows<'_> {
-            async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<UniversalRow>>> {
+            async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<Row>>> {
                 if self.exhausted {
                     return Ok(None);
                 }
@@ -435,7 +435,7 @@ async fn migrate_one_table_keyset<S: surreal_sink::SurrealSink>(
 
     if sync_opts.dry_run {
         let mut total = 0usize;
-        let mut after: Option<Vec<sync_core::UniversalValue>> = None;
+        let mut after: Option<Vec<sync_core::Value>> = None;
         loop {
             let chunk = read_table_chunk(
                 client,
@@ -463,7 +463,7 @@ async fn migrate_one_table_keyset<S: surreal_sink::SurrealSink>(
         client: &'a tokio_postgres::Client,
         table_name: &'a str,
         pk_columns: &'a [String],
-        after: Option<Vec<sync_core::UniversalValue>>,
+        after: Option<Vec<sync_core::Value>>,
         batch_size: usize,
         schema: Option<&'a sync_core::DatabaseSchema>,
         exhausted: bool,
@@ -471,7 +471,7 @@ async fn migrate_one_table_keyset<S: surreal_sink::SurrealSink>(
 
     #[async_trait]
     impl RowChunkSource for PgKeysetChunks<'_> {
-        async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<UniversalRow>>> {
+        async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<Row>>> {
             if self.exhausted {
                 return Ok(None);
             }

--- a/crates/postgresql-trigger-source/src/incremental_sync.rs
+++ b/crates/postgresql-trigger-source/src/incremental_sync.rs
@@ -4,17 +4,14 @@ use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use checkpoint::Checkpoint;
 use chrono::{DateTime, Utc};
-use json_types::{
-    convert_id_to_universal_with_database_schema, json_to_universal_with_table_schema,
-};
+use json_types::{convert_id_with_database_schema, json_to_universal_with_table_schema};
 use log::{error, info, warn};
 use serde_json::Value as JsonValue;
 use std::collections::HashMap;
 use std::sync::Arc;
 use surreal_sink::SurrealSink;
 use sync_core::{
-    classify_table, DatabaseSchema, TableKind, UniversalChange, UniversalChangeOp,
-    UniversalRelationChange, UniversalValue,
+    classify_table, Change, ChangeOp, DatabaseSchema, RelationChange, TableKind, Value,
 };
 use sync_transform::{
     ApplyOpts, CheckpointPolicy, Pipeline, PositionedEvent, SourceDriver, SourceRuntimeOpts,
@@ -59,13 +56,13 @@ pub trait IncrementalSource: Send + Sync {
 pub trait ChangeStream: Send + Sync {
     /// Get the next change event from the stream
     /// Returns None when no more changes are available
-    async fn next(&mut self) -> Option<Result<UniversalChange>>;
+    async fn next(&mut self) -> Option<Result<Change>>;
 
     /// Like [`ChangeStream::next`], but also yields the source `sequence_id`
     /// (stream position) of the change, so callers can track per-change
     /// positions for watermark-based reconciliation.
     /// Returns None when no more changes are available.
-    async fn next_with_sequence_id(&mut self) -> Option<Result<(i64, UniversalChange)>>;
+    async fn next_with_sequence_id(&mut self) -> Option<Result<(i64, Change)>>;
 
     /// Sink-safe checkpoint: advances only via [`ChangeStream::commit_sunk`].
     fn checkpoint(&self) -> Option<PostgreSQLCheckpoint>;
@@ -236,7 +233,7 @@ struct PostgresTriggerSourceDriver<'a> {
 }
 
 impl PostgresTriggerSourceDriver<'_> {
-    fn enrich_at(&self, sequence_id: i64, mut change: UniversalChange) -> PositionedEvent<i64> {
+    fn enrich_at(&self, sequence_id: i64, mut change: Change) -> PositionedEvent<i64> {
         let table_def = self.db_schema.get_table(&change.table);
         let table_kind = table_def.map(|td| classify_table(td, &self.relation_table_overrides));
 
@@ -246,7 +243,7 @@ impl PostgresTriggerSourceDriver<'_> {
                 ref out_fk,
             }) => {
                 let op = change.operation;
-                let data = change.data.take().unwrap_or_default();
+                let data = change.fields.take().unwrap_or_default();
                 let relation = surreal_sync_postgresql::fk_transform::build_relation_from_change(
                     &change.table,
                     change.id,
@@ -254,11 +251,11 @@ impl PostgresTriggerSourceDriver<'_> {
                     in_fk,
                     out_fk,
                 );
-                let rel_change = UniversalRelationChange::new(op, relation);
+                let rel_change = RelationChange::new(op, relation);
                 PositionedEvent::relation_change(rel_change, sequence_id)
             }
             _ => {
-                if let (Some(td), Some(ref mut data)) = (table_def, change.data.as_mut()) {
+                if let (Some(td), Some(ref mut data)) = (table_def, change.fields.as_mut()) {
                     surreal_sync_postgresql::fk_transform::transform_fk_values(data, td);
                 }
                 PositionedEvent::change(change, sequence_id)
@@ -709,7 +706,7 @@ pub struct PostgresChangeStream {
     /// Highest sequence_id successfully sunk (authoritative resume watermark).
     sunk_sequence: i64,
     /// Buffered changes, each paired with its source `sequence_id`.
-    buffer: Vec<(i64, UniversalChange)>,
+    buffer: Vec<(i64, Change)>,
     empty_poll_count: usize,
     database_schema: Option<DatabaseSchema>,
     /// Mapping of table names to their primary key column names
@@ -736,7 +733,7 @@ impl PostgresChangeStream {
         })
     }
 
-    async fn fetch_changes(&mut self) -> Result<Vec<(i64, UniversalChange)>> {
+    async fn fetch_changes(&mut self) -> Result<Vec<(i64, Change)>> {
         log::debug!(
             "PostgresChangeStream::fetch_changes() called, read_sequence: {}",
             self.read_sequence
@@ -788,9 +785,9 @@ impl PostgresChangeStream {
             };
 
             let op = match operation.as_str() {
-                "INSERT" => UniversalChangeOp::Create,
-                "UPDATE" => UniversalChangeOp::Update,
-                "DELETE" => UniversalChangeOp::Delete,
+                "INSERT" => ChangeOp::Create,
+                "UPDATE" => ChangeOp::Update,
+                "DELETE" => ChangeOp::Delete,
                 _ => {
                     warn!("Unknown operation type in audit table: {operation:?}");
                     continue;
@@ -805,9 +802,7 @@ impl PostgresChangeStream {
                 )
             })?;
 
-            let universal_data: HashMap<String, UniversalValue> = if let Some(json_value) =
-                json_data
-            {
+            let universal_data: HashMap<String, Value> = if let Some(json_value) = json_data {
                 // Use schema-aware conversion if schema is available
                 if let Some(table_schema) = self
                     .database_schema
@@ -873,14 +868,14 @@ impl PostgresChangeStream {
                 HashMap::new()
             };
 
-            // Convert row_id to UniversalValue using schema information
+            // Convert row_id to Value using schema information
             // The row_id is a JSONB array (supports composite PKs) where each element
             // is extracted via row_json->>'column', which always returns text in PostgreSQL.
             //
             // We use the pk_columns mapping (populated during setup_tracking) to know which
             // column names correspond to each position in the row_id array, then use the
             // database_schema to look up the proper type for conversion.
-            let record_id: UniversalValue = match row_id {
+            let record_id: Value = match row_id {
                 Some(serde_json::Value::Array(arr)) => {
                     // pk_cols was already retrieved above for filtering content data
                     if arr.len() != pk_cols.len() {
@@ -903,7 +898,7 @@ impl PostgresChangeStream {
 
                         // Use schema-aware conversion if schema is available
                         if let Some(schema) = &self.database_schema {
-                            convert_id_to_universal_with_database_schema(
+                            convert_id_with_database_schema(
                                 &id_str,
                                 &table_name,
                                 pk_column,
@@ -912,11 +907,11 @@ impl PostgresChangeStream {
                         } else {
                             // Fallback to value-based inference if no schema
                             if let Ok(n) = id_str.parse::<i64>() {
-                                UniversalValue::Int64(n)
+                                Value::Int64(n)
                             } else if let Ok(uuid) = uuid::Uuid::parse_str(&id_str) {
-                                UniversalValue::Uuid(uuid)
+                                Value::Uuid(uuid)
                             } else {
-                                UniversalValue::Text(id_str)
+                                Value::Text(id_str)
                             }
                         }
                     } else {
@@ -933,7 +928,7 @@ impl PostgresChangeStream {
 
                             // Use schema-aware conversion if schema is available
                             let universal_id = if let Some(schema) = &self.database_schema {
-                                convert_id_to_universal_with_database_schema(
+                                convert_id_with_database_schema(
                                     &id_str,
                                     &table_name,
                                     pk_column,
@@ -941,14 +936,14 @@ impl PostgresChangeStream {
                                 )?
                             } else {
                                 // Fallback to string if no schema
-                                UniversalValue::Text(id_str)
+                                Value::Text(id_str)
                             };
                             universal_values_array.push(universal_id);
                         }
                         // For composite keys, we store as an array of values
-                        UniversalValue::Array {
+                        Value::Array {
                             elements: universal_values_array,
-                            element_type: Box::new(sync_core::UniversalType::Text),
+                            element_type: Box::new(sync_core::Type::Text),
                         }
                     }
                 }
@@ -957,16 +952,13 @@ impl PostgresChangeStream {
 
             info!("Change event: record_id: {record_id:?}");
 
-            // Create UniversalChange with the converted data
-            let data = if op == UniversalChangeOp::Delete {
+            // Create Change with the converted data
+            let data = if op == ChangeOp::Delete {
                 None
             } else {
                 Some(universal_data)
             };
-            changes.push((
-                sequence_id,
-                UniversalChange::new(op, table_name, record_id, data),
-            ));
+            changes.push((sequence_id, Change::new(op, table_name, record_id, data)));
 
             // Advance read-head only; sunk watermark waits for commit_sunk.
             self.read_sequence = sequence_id;
@@ -978,7 +970,7 @@ impl PostgresChangeStream {
 
 #[async_trait]
 impl ChangeStream for PostgresChangeStream {
-    async fn next(&mut self) -> Option<Result<UniversalChange>> {
+    async fn next(&mut self) -> Option<Result<Change>> {
         match self.next_with_sequence_id().await {
             Some(Ok((_seq, change))) => Some(Ok(change)),
             Some(Err(e)) => Some(Err(e)),
@@ -986,7 +978,7 @@ impl ChangeStream for PostgresChangeStream {
         }
     }
 
-    async fn next_with_sequence_id(&mut self) -> Option<Result<(i64, UniversalChange)>> {
+    async fn next_with_sequence_id(&mut self) -> Option<Result<(i64, Change)>> {
         log::debug!(
             "🔄 PostgresChangeStream::next_with_sequence_id() called, empty_poll_count: {}, read_sequence: {}",
             self.empty_poll_count,

--- a/crates/postgresql-trigger-source/src/interleaved_snapshot.rs
+++ b/crates/postgresql-trigger-source/src/interleaved_snapshot.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use async_trait::async_trait;
 use surreal_sink::SurrealSink;
-use sync_core::{DatabaseSchema, UniversalChange, UniversalRow, UniversalValue};
+use sync_core::{Change, DatabaseSchema, Row, Value};
 use tokio::sync::Mutex;
 use tokio_postgres::Client;
 use uuid::Uuid;
@@ -187,13 +187,13 @@ impl PostgresTriggerWatermarkSource {
 
 /// Build a primary key tuple from a change's record id.
 ///
-/// Composite keys arrive as an [`UniversalValue::Array`]; single keys (and the
+/// Composite keys arrive as an [`Value::Array`]; single keys (and the
 /// UUID-keyed watermark rows) arrive as a scalar. Either way the resulting
 /// [`PkTuple`] matches the buffer keys produced from snapshot rows, and a
 /// single-UUID tuple is recognized by the framework as a watermark.
-fn pk_from_change(change: &UniversalChange) -> PkTuple {
+fn pk_from_change(change: &Change) -> PkTuple {
     match &change.id {
-        UniversalValue::Array { elements, .. } => PkTuple::new(elements.clone()),
+        Value::Array { elements, .. } => PkTuple::new(elements.clone()),
         other => PkTuple::new(vec![other.clone()]),
     }
 }
@@ -211,8 +211,8 @@ impl WatermarkSource for PostgresTriggerWatermarkSource {
         table: &TableSpec,
         after: Option<&PkTuple>,
         limit: usize,
-    ) -> Result<Vec<UniversalRow>> {
-        let after_values: Option<Vec<UniversalValue>> = after.map(|pk| pk.0.clone());
+    ) -> Result<Vec<Row>> {
+        let after_values: Option<Vec<Value>> = after.map(|pk| pk.0.clone());
         let client = self.client.lock().await;
         let chunk = surreal_sync_postgresql::read_table_chunk(
             &client,

--- a/crates/postgresql-trigger-source/src/schema.rs
+++ b/crates/postgresql-trigger-source/src/schema.rs
@@ -5,11 +5,11 @@
 
 use postgresql_types::postgresql_column_to_universal_type;
 use std::collections::HashMap;
-use sync_core::{ColumnDefinition, DatabaseSchema, TableDefinition, UniversalType};
+use sync_core::{ColumnDefinition, DatabaseSchema, TableDefinition, Type};
 
 /// Collect schema information for all tables in a PostgreSQL database.
 ///
-/// Returns a `DatabaseSchema` with proper `UniversalType` mapping.
+/// Returns a `DatabaseSchema` with proper `Type` mapping.
 /// This function also queries primary key information for each table.
 pub async fn collect_postgresql_database_schema(
     client: &tokio_postgres::Client,
@@ -47,7 +47,7 @@ pub async fn collect_postgresql_database_schema(
     }
 
     // Build tables with columns
-    let mut table_columns: HashMap<String, Vec<(String, UniversalType)>> = HashMap::new();
+    let mut table_columns: HashMap<String, Vec<(String, Type)>> = HashMap::new();
 
     for row in column_rows {
         let table_name: String = row.get(0);
@@ -103,7 +103,7 @@ pub async fn collect_postgresql_database_schema(
         // Use the found PK or create a default one
         let pk = primary_key.unwrap_or_else(|| {
             // If no PK column found, create a synthetic one
-            ColumnDefinition::new(pk_col_name, UniversalType::Int64)
+            ColumnDefinition::new(pk_col_name, Type::Int64)
         });
 
         let mut table_def = TableDefinition::new(table_name, pk, other_columns);
@@ -150,13 +150,13 @@ mod tests {
 
     #[test]
     fn test_array_type_maps_to_universal_array() {
-        // Verify the full flow: ARRAY + _text -> UniversalType::Array<Text>
+        // Verify the full flow: ARRAY + _text -> Type::Array<Text>
         let effective_type = get_effective_type("ARRAY", "_text");
         let universal_type = postgresql_column_to_universal_type(effective_type, None, None);
 
         match universal_type {
-            UniversalType::Array { element_type } => {
-                assert_eq!(*element_type, UniversalType::Text);
+            Type::Array { element_type } => {
+                assert_eq!(*element_type, Type::Text);
             }
             other => panic!("Expected Array<Text>, got {other:?}"),
         }

--- a/crates/postgresql-trigger-source/tests/suite/incremental_array_e2e_test.rs
+++ b/crates/postgresql-trigger-source/tests/suite/incremental_array_e2e_test.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 use surreal_sync_postgresql_trigger_source::IncrementalSource;
-use sync_core::UniversalValue;
+use sync_core::Value;
 use tokio::sync::Mutex;
 
 /// Comprehensive E2E test that traces array data through the entire incremental sync flow
@@ -179,7 +179,7 @@ async fn test_incremental_sync_array_e2e() {
     println!("post_categories column type from schema: {col_type:?}");
 
     assert!(
-        matches!(col_type, Some(sync_core::UniversalType::Array { .. })),
+        matches!(col_type, Some(sync_core::Type::Array { .. })),
         "post_categories should be Array type in schema, got {col_type:?}"
     );
 
@@ -202,26 +202,25 @@ async fn test_incremental_sync_array_e2e() {
                 println!("  table: {}", change.table);
                 println!("  id: {:?}", change.id);
 
-                if let Some(ref data) = change.data {
+                if let Some(ref data) = change.fields {
                     println!("  data fields:");
                     for (key, value) in data {
                         println!("    {key}: {value:?}");
                     }
 
                     // Verify post_categories is an array
-                    if let Some(categories) = data.get("post_categories") as Option<&UniversalValue>
-                    {
+                    if let Some(categories) = data.get("post_categories") as Option<&Value> {
                         println!("\n  post_categories value: {categories:?}");
 
                         match categories {
-                            UniversalValue::Array { elements, .. } => {
+                            Value::Array { elements, .. } => {
                                 println!(
                                     "  ✓ post_categories is Array with {} elements",
                                     elements.len()
                                 );
                                 assert_eq!(elements.len(), 2);
                             }
-                            UniversalValue::Null => {
+                            Value::Null => {
                                 println!("  ✗ post_categories is Null - THIS IS THE BUG!");
                                 panic!("post_categories should not be Null");
                             }

--- a/crates/postgresql-trigger-source/tests/suite/interleaved_snapshot_test.rs
+++ b/crates/postgresql-trigger-source/tests/suite/interleaved_snapshot_test.rs
@@ -11,10 +11,7 @@ use std::sync::Mutex;
 use anyhow::Result;
 use async_trait::async_trait;
 use surreal_sink::SurrealSink;
-use sync_core::{
-    UniversalChange, UniversalChangeOp, UniversalRelation, UniversalRelationChange, UniversalRow,
-    UniversalValue,
-};
+use sync_core::{Change, ChangeOp, Relation, RelationChange, Row, Value};
 use tokio_postgres::{Client, NoTls};
 
 use surreal_sync_interleaved_snapshot::{
@@ -28,15 +25,15 @@ use surreal_sync_postgresql_trigger_source::{PostgresTriggerWatermarkSource, Sou
 
 #[derive(Default)]
 struct MockSink {
-    rows: Mutex<HashMap<String, HashMap<String, UniversalValue>>>,
+    rows: Mutex<HashMap<String, HashMap<String, Value>>>,
 }
 
-fn id_key(id: &UniversalValue) -> String {
+fn id_key(id: &Value) -> String {
     serde_json::to_string(id).unwrap()
 }
 
 impl MockSink {
-    fn state(&self) -> HashMap<String, HashMap<String, UniversalValue>> {
+    fn state(&self) -> HashMap<String, HashMap<String, Value>> {
         self.rows.lock().unwrap().clone()
     }
 
@@ -47,7 +44,7 @@ impl MockSink {
 
 #[async_trait]
 impl SurrealSink for MockSink {
-    async fn write_universal_rows(&self, rows: &[UniversalRow]) -> Result<()> {
+    async fn write_rows(&self, rows: &[Row]) -> Result<()> {
         let mut state = self.rows.lock().unwrap();
         for row in rows {
             state.insert(id_key(&row.id), row.fields.clone());
@@ -55,27 +52,27 @@ impl SurrealSink for MockSink {
         Ok(())
     }
 
-    async fn write_universal_relations(&self, _relations: &[UniversalRelation]) -> Result<()> {
+    async fn write_relations(&self, _relations: &[Relation]) -> Result<()> {
         Ok(())
     }
 
-    async fn apply_universal_change(&self, change: &UniversalChange) -> Result<()> {
+    async fn apply_change(&self, change: &Change) -> Result<()> {
         let mut state = self.rows.lock().unwrap();
         match change.operation {
-            UniversalChangeOp::Delete => {
+            ChangeOp::Delete => {
                 state.remove(&id_key(&change.id));
             }
             _ => {
-                state.insert(id_key(&change.id), change.data.clone().unwrap_or_default());
+                state.insert(
+                    id_key(&change.id),
+                    change.fields.clone().unwrap_or_default(),
+                );
             }
         }
         Ok(())
     }
 
-    async fn apply_universal_relation_change(
-        &self,
-        _change: &UniversalRelationChange,
-    ) -> Result<()> {
+    async fn apply_relation_change(&self, _change: &RelationChange) -> Result<()> {
         Ok(())
     }
 }
@@ -140,7 +137,7 @@ async fn drain_remaining(source: &mut PostgresTriggerWatermarkSource, sink: &Moc
         }
         for event in events {
             if event.pk.single_uuid().is_none() {
-                sink.apply_universal_change(&event.change).await.unwrap();
+                sink.apply_change(&event.change).await.unwrap();
             }
         }
     }
@@ -229,12 +226,12 @@ async fn interleaved_snapshot_parity_under_concurrent_writes() {
     );
 
     for (id, val) in expected {
-        let key = id_key(&UniversalValue::Int64(id));
+        let key = id_key(&Value::Int64(id));
         let fields = actual
             .get(&key)
             .unwrap_or_else(|| panic!("sink missing id {id}"));
         match fields.get("val") {
-            Some(UniversalValue::Text(s)) => {
+            Some(Value::Text(s)) => {
                 assert_eq!(s, &val, "value mismatch for id {id}")
             }
             other => panic!("unexpected val for id {id}: {other:?}"),

--- a/crates/postgresql-trigger-source/tests/suite/no_pk_offset.rs
+++ b/crates/postgresql-trigger-source/tests/suite/no_pk_offset.rs
@@ -7,11 +7,11 @@ use anyhow::Result;
 use surreal_sink::SurrealSink;
 use surreal_sync_postgresql::{get_primary_key_columns, read_offset_table_chunk};
 use surreal_sync_postgresql_trigger_source::{run_full_sync_with_transforms, SourceOpts};
-use sync_core::{UniversalChange, UniversalRow, UniversalValue};
+use sync_core::{Change, Row, Value};
 use sync_transform::{ApplyOpts, Pipeline};
 
 struct CaptureSink {
-    changes: Mutex<Vec<UniversalChange>>,
+    changes: Mutex<Vec<Change>>,
 }
 
 impl CaptureSink {
@@ -24,11 +24,11 @@ impl CaptureSink {
 
 #[async_trait::async_trait]
 impl SurrealSink for CaptureSink {
-    async fn write_universal_rows(&self, rows: &[UniversalRow]) -> anyhow::Result<()> {
-        // Full sync upserts coalesce to write_universal_rows; mirror into `changes`.
+    async fn write_rows(&self, rows: &[Row]) -> anyhow::Result<()> {
+        // Full sync upserts coalesce to write_rows; mirror into `changes`.
         let mut changes = self.changes.lock().expect("lock");
         for row in rows {
-            changes.push(UniversalChange::update(
+            changes.push(Change::update(
                 row.table.clone(),
                 row.id.clone(),
                 row.fields.clone(),
@@ -37,36 +37,33 @@ impl SurrealSink for CaptureSink {
         Ok(())
     }
 
-    async fn write_universal_relations(
-        &self,
-        _relations: &[sync_core::UniversalRelation],
-    ) -> anyhow::Result<()> {
+    async fn write_relations(&self, _relations: &[sync_core::Relation]) -> anyhow::Result<()> {
         Ok(())
     }
 
-    async fn apply_universal_change(&self, change: &UniversalChange) -> anyhow::Result<()> {
+    async fn apply_change(&self, change: &Change) -> anyhow::Result<()> {
         self.changes.lock().expect("lock").push(change.clone());
         Ok(())
     }
 
-    async fn apply_universal_relation_change(
+    async fn apply_relation_change(
         &self,
-        _change: &sync_core::UniversalRelationChange,
+        _change: &sync_core::RelationChange,
     ) -> anyhow::Result<()> {
         Ok(())
     }
 }
 
-fn name_of_row(row: &UniversalRow) -> String {
+fn name_of_row(row: &Row) -> String {
     match row.fields.get("name") {
-        Some(UniversalValue::VarChar { value, .. } | UniversalValue::Text(value)) => value.clone(),
+        Some(Value::VarChar { value, .. } | Value::Text(value)) => value.clone(),
         other => panic!("unexpected name: {other:?}"),
     }
 }
 
-fn name_of_change(change: &UniversalChange) -> String {
-    match change.data.as_ref().and_then(|d| d.get("name")) {
-        Some(UniversalValue::VarChar { value, .. } | UniversalValue::Text(value)) => value.clone(),
+fn name_of_change(change: &Change) -> String {
+    match change.fields.as_ref().and_then(|d| d.get("name")) {
+        Some(Value::VarChar { value, .. } | Value::Text(value)) => value.clone(),
         other => panic!("unexpected name: {other:?}"),
     }
 }
@@ -119,7 +116,7 @@ async fn read_offset_table_chunk_assigns_synthetic_ids_with_ctid_order() -> Resu
             .collect()
     );
     for (i, row) in all.iter().enumerate() {
-        assert_eq!(row.id, UniversalValue::Int64(i as i64));
+        assert_eq!(row.id, Value::Int64(i as i64));
         assert_eq!(row.index, i as u64);
     }
     Ok(())
@@ -179,7 +176,7 @@ async fn full_sync_streams_no_pk_table_via_offset_chunks() -> Result<()> {
     );
     for change in &changes {
         assert!(
-            matches!(change.id, UniversalValue::Int64(_)),
+            matches!(change.id, Value::Int64(_)),
             "no-PK rows should use synthetic Int64 ids, got {:?}",
             change.id
         );

--- a/crates/postgresql-trigger-source/tests/suite/post_categories_schema_test.rs
+++ b/crates/postgresql-trigger-source/tests/suite/post_categories_schema_test.rs
@@ -1,10 +1,10 @@
 //! Targeted test for post_categories array handling
 //!
 //! This test verifies the complete flow for array type handling:
-//! 1. Schema collection correctly identifies TEXT[] as UniversalType::Array
+//! 1. Schema collection correctly identifies TEXT[] as Type::Array
 //! 2. JSON conversion correctly handles arrays with schema information
 
-use sync_core::{ColumnDefinition, TableDefinition, UniversalType, UniversalValue};
+use sync_core::{ColumnDefinition, TableDefinition, Type, Value};
 
 /// Test that schema collection correctly identifies array types
 #[tokio::test]
@@ -57,9 +57,9 @@ async fn test_schema_collection_identifies_array_types() {
     println!("tags column type: {tags_type:?}");
 
     match tags_type {
-        Some(UniversalType::Array { element_type }) => {
+        Some(Type::Array { element_type }) => {
             assert!(
-                matches!(**element_type, UniversalType::Text),
+                matches!(**element_type, Type::Text),
                 "Expected Array<Text>, got Array<{element_type:?}>"
             );
         }
@@ -71,9 +71,9 @@ async fn test_schema_collection_identifies_array_types() {
     println!("numbers column type: {numbers_type:?}");
 
     match numbers_type {
-        Some(UniversalType::Array { element_type }) => {
+        Some(Type::Array { element_type }) => {
             assert!(
-                matches!(**element_type, UniversalType::Int32),
+                matches!(**element_type, Type::Int32),
                 "Expected Array<Int32>, got Array<{element_type:?}>"
             );
         }
@@ -93,11 +93,11 @@ fn test_json_array_conversion_with_schema() {
     use json_types::json_to_universal_with_table_schema;
 
     // Create a table schema with Array<Text> column
-    let pk = ColumnDefinition::new("id", UniversalType::Text);
+    let pk = ColumnDefinition::new("id", Type::Text);
     let columns = vec![ColumnDefinition::new(
         "post_categories",
-        UniversalType::Array {
-            element_type: Box::new(UniversalType::Text),
+        Type::Array {
+            element_type: Box::new(Type::Text),
         },
     )];
     let table_schema = TableDefinition::new("all_types_posts", pk, columns);
@@ -111,10 +111,10 @@ fn test_json_array_conversion_with_schema() {
     println!("Conversion result: {result:?}");
 
     match result {
-        UniversalValue::Array { elements, .. } => {
+        Value::Array { elements, .. } => {
             assert_eq!(elements.len(), 2);
-            assert!(matches!(&elements[0], UniversalValue::Text(s) if s == "technology"));
-            assert!(matches!(&elements[1], UniversalValue::Text(s) if s == "tutorial"));
+            assert!(matches!(&elements[0], Value::Text(s) if s == "technology"));
+            assert!(matches!(&elements[1], Value::Text(s) if s == "tutorial"));
         }
         other => panic!("Expected Array, got {other:?}"),
     }
@@ -198,7 +198,7 @@ async fn test_complete_array_flow() {
     println!("Schema column type for post_categories: {col_type:?}");
 
     assert!(
-        matches!(col_type, Some(UniversalType::Array { element_type }) if matches!(**element_type, UniversalType::Text)),
+        matches!(col_type, Some(Type::Array { element_type }) if matches!(**element_type, Type::Text)),
         "Expected Array<Text> in schema, got {col_type:?}"
     );
 
@@ -211,13 +211,13 @@ async fn test_complete_array_flow() {
     )
     .expect("Failed to convert with schema");
 
-    println!("Final UniversalValue: {result:?}");
+    println!("Final Value: {result:?}");
 
     match result {
-        UniversalValue::Array { elements, .. } => {
+        Value::Array { elements, .. } => {
             assert_eq!(elements.len(), 2, "Expected 2 elements");
-            assert!(matches!(&elements[0], UniversalValue::Text(s) if s == "technology"));
-            assert!(matches!(&elements[1], UniversalValue::Text(s) if s == "tutorial"));
+            assert!(matches!(&elements[0], Value::Text(s) if s == "technology"));
+            assert!(matches!(&elements[1], Value::Text(s) if s == "tutorial"));
         }
         other => panic!("Expected Array, got {other:?}"),
     }

--- a/crates/postgresql-trigger-source/tests/suite/transforms.rs
+++ b/crates/postgresql-trigger-source/tests/suite/transforms.rs
@@ -13,13 +13,13 @@ use surreal_sync_postgresql_trigger_source::{
     run_incremental_sync_with_transforms, PostgreSQLCheckpoint, PostgresIncrementalSource,
     ReplicationTailOptions, SourceOpts,
 };
-use sync_core::{UniversalChange, UniversalRelationChange, UniversalRow, UniversalValue};
+use sync_core::{Change, RelationChange, Row, Value};
 use sync_transform::{ApplyOpts, ChildStdioMode, ExternalTransform, FramerKind, Pipeline};
 use tokio::sync::Mutex as TokioMutex;
 
 struct CaptureSink {
-    changes: Mutex<Vec<UniversalChange>>,
-    relation_changes: Mutex<Vec<UniversalRelationChange>>,
+    changes: Mutex<Vec<Change>>,
+    relation_changes: Mutex<Vec<RelationChange>>,
 }
 
 impl CaptureSink {
@@ -33,11 +33,11 @@ impl CaptureSink {
 
 #[async_trait::async_trait]
 impl SurrealSink for CaptureSink {
-    async fn write_universal_rows(&self, rows: &[UniversalRow]) -> anyhow::Result<()> {
+    async fn write_rows(&self, rows: &[Row]) -> anyhow::Result<()> {
         // Homogeneous Update upserts coalesce here; keep observations in `changes`.
         let mut changes = self.changes.lock().expect("lock");
         for row in rows {
-            changes.push(UniversalChange::update(
+            changes.push(Change::update(
                 row.table.clone(),
                 row.id.clone(),
                 row.fields.clone(),
@@ -46,25 +46,22 @@ impl SurrealSink for CaptureSink {
         Ok(())
     }
 
-    async fn write_universal_relations(
-        &self,
-        relations: &[sync_core::UniversalRelation],
-    ) -> anyhow::Result<()> {
+    async fn write_relations(&self, relations: &[sync_core::Relation]) -> anyhow::Result<()> {
         let mut relation_changes = self.relation_changes.lock().expect("lock");
         for relation in relations {
-            relation_changes.push(UniversalRelationChange::update(relation.clone()));
+            relation_changes.push(RelationChange::update(relation.clone()));
         }
         Ok(())
     }
 
-    async fn apply_universal_change(&self, change: &UniversalChange) -> anyhow::Result<()> {
+    async fn apply_change(&self, change: &Change) -> anyhow::Result<()> {
         self.changes.lock().expect("lock").push(change.clone());
         Ok(())
     }
 
-    async fn apply_universal_relation_change(
+    async fn apply_relation_change(
         &self,
-        change: &sync_core::UniversalRelationChange,
+        change: &sync_core::RelationChange,
     ) -> anyhow::Result<()> {
         self.relation_changes
             .lock()
@@ -106,16 +103,16 @@ fn ensure_fixture_worker() -> PathBuf {
     path
 }
 
-fn name_field(change: &UniversalChange) -> String {
+fn name_field(change: &Change) -> String {
     let data = change
-        .data
+        .fields
         .as_ref()
         .unwrap_or_else(|| panic!("change missing data: {change:?}"));
     match data
         .get("name")
         .unwrap_or_else(|| panic!("change missing name: {change:?}"))
     {
-        UniversalValue::VarChar { value, .. } | UniversalValue::Text(value) => value.clone(),
+        Value::VarChar { value, .. } | Value::Text(value) => value.clone(),
         other => panic!("unexpected name: {other:?}"),
     }
 }

--- a/crates/postgresql-types/src/ddl.rs
+++ b/crates/postgresql-types/src/ddl.rs
@@ -1,82 +1,78 @@
-//! PostgreSQL DDL generation from UniversalType.
+//! PostgreSQL DDL generation from Type.
 //!
 //! This module provides DDL (Data Definition Language) generation for PostgreSQL,
-//! converting sync-core's `UniversalType` to PostgreSQL column type definitions.
+//! converting sync-core's `Type` to PostgreSQL column type definitions.
 
-use sync_core::{GeometryType, UniversalType};
+use sync_core::{GeometryType, Type};
 
 /// Trait for generating DDL type strings.
 pub trait ToDdl {
-    /// Convert a UniversalType to a DDL type string.
-    fn to_ddl(&self, sync_type: &UniversalType) -> String;
+    /// Convert a Type to a DDL type string.
+    fn to_ddl(&self, sync_type: &Type) -> String;
 
     /// Generate a complete CREATE TABLE statement.
-    fn to_create_table(
-        &self,
-        table_name: &str,
-        columns: &[(String, UniversalType, bool)],
-    ) -> String;
+    fn to_create_table(&self, table_name: &str, columns: &[(String, Type, bool)]) -> String;
 }
 
 /// PostgreSQL DDL generator.
 pub struct PostgreSQLDdl;
 
 impl ToDdl for PostgreSQLDdl {
-    fn to_ddl(&self, sync_type: &UniversalType) -> String {
+    fn to_ddl(&self, sync_type: &Type) -> String {
         match sync_type {
             // Boolean
-            UniversalType::Bool => "BOOLEAN".to_string(),
+            Type::Bool => "BOOLEAN".to_string(),
 
             // Integer types
-            UniversalType::Int8 { .. } => "SMALLINT".to_string(), // PostgreSQL doesn't have TINYINT
-            UniversalType::Int16 => "SMALLINT".to_string(),
-            UniversalType::Int32 => "INTEGER".to_string(),
-            UniversalType::Int64 => "BIGINT".to_string(),
+            Type::Int8 { .. } => "SMALLINT".to_string(), // PostgreSQL doesn't have TINYINT
+            Type::Int16 => "SMALLINT".to_string(),
+            Type::Int32 => "INTEGER".to_string(),
+            Type::Int64 => "BIGINT".to_string(),
 
             // Floating point
-            UniversalType::Float32 => "REAL".to_string(),
-            UniversalType::Float64 => "DOUBLE PRECISION".to_string(),
+            Type::Float32 => "REAL".to_string(),
+            Type::Float64 => "DOUBLE PRECISION".to_string(),
 
             // Exact numeric
-            UniversalType::Decimal { precision, scale } => {
+            Type::Decimal { precision, scale } => {
                 format!("NUMERIC({precision},{scale})")
             }
 
             // String types
-            UniversalType::Char { length } => format!("CHAR({length})"),
-            UniversalType::VarChar { length } => format!("VARCHAR({length})"),
-            UniversalType::Text => "TEXT".to_string(),
+            Type::Char { length } => format!("CHAR({length})"),
+            Type::VarChar { length } => format!("VARCHAR({length})"),
+            Type::Text => "TEXT".to_string(),
 
             // Binary types
-            UniversalType::Blob => "BYTEA".to_string(),
-            UniversalType::Bytes => "BYTEA".to_string(),
+            Type::Blob => "BYTEA".to_string(),
+            Type::Bytes => "BYTEA".to_string(),
 
             // Date/time types
-            UniversalType::Date => "DATE".to_string(),
-            UniversalType::Time => "TIME".to_string(),
-            UniversalType::LocalDateTime => "TIMESTAMP".to_string(),
-            UniversalType::LocalDateTimeNano => "TIMESTAMP".to_string(), // PostgreSQL TIMESTAMP has microsecond precision
-            UniversalType::ZonedDateTime => "TIMESTAMPTZ".to_string(),
+            Type::Date => "DATE".to_string(),
+            Type::Time => "TIME".to_string(),
+            Type::LocalDateTime => "TIMESTAMP".to_string(),
+            Type::LocalDateTimeNano => "TIMESTAMP".to_string(), // PostgreSQL TIMESTAMP has microsecond precision
+            Type::ZonedDateTime => "TIMESTAMPTZ".to_string(),
 
             // Special types
-            UniversalType::Uuid => "UUID".to_string(),
-            UniversalType::Ulid => "TEXT".to_string(), // ULID stored as string in PostgreSQL
-            UniversalType::Json => "JSON".to_string(),
-            UniversalType::Jsonb => "JSONB".to_string(),
+            Type::Uuid => "UUID".to_string(),
+            Type::Ulid => "TEXT".to_string(), // ULID stored as string in PostgreSQL
+            Type::Json => "JSON".to_string(),
+            Type::Jsonb => "JSONB".to_string(),
 
             // Array types
-            UniversalType::Array { element_type } => {
+            Type::Array { element_type } => {
                 format!("{}[]", self.to_ddl(element_type))
             }
 
             // Set - stored as TEXT[]
-            UniversalType::Set { .. } => "TEXT[]".to_string(),
+            Type::Set { .. } => "TEXT[]".to_string(),
 
             // Enumeration - stored as TEXT (PostgreSQL ENUM would need separate CREATE TYPE)
-            UniversalType::Enum { .. } => "TEXT".to_string(),
+            Type::Enum { .. } => "TEXT".to_string(),
 
             // Spatial types
-            UniversalType::Geometry { geometry_type } => match geometry_type {
+            Type::Geometry { geometry_type } => match geometry_type {
                 GeometryType::Point => "POINT".to_string(),
                 GeometryType::LineString => "PATH".to_string(), // PostgreSQL native path
                 GeometryType::Polygon => "POLYGON".to_string(),
@@ -88,24 +84,20 @@ impl ToDdl for PostgreSQLDdl {
 
             // Duration - stored as TEXT with ISO 8601 duration format
             // (PostgreSQL INTERVAL requires native type support which adds complexity)
-            UniversalType::Duration => "TEXT".to_string(),
+            Type::Duration => "TEXT".to_string(),
 
             // Thing - record reference stored as TEXT (table:id format)
-            UniversalType::Thing => "TEXT".to_string(),
+            Type::Thing => "TEXT".to_string(),
 
             // Object - nested document stored as JSONB
-            UniversalType::Object => "JSONB".to_string(),
+            Type::Object => "JSONB".to_string(),
 
             // TimeTz - time with timezone
-            UniversalType::TimeTz => "TIMETZ".to_string(),
+            Type::TimeTz => "TIMETZ".to_string(),
         }
     }
 
-    fn to_create_table(
-        &self,
-        table_name: &str,
-        columns: &[(String, UniversalType, bool)],
-    ) -> String {
+    fn to_create_table(&self, table_name: &str, columns: &[(String, Type, bool)]) -> String {
         let column_defs: Vec<String> = columns
             .iter()
             .map(|(name, dtype, nullable)| {
@@ -128,8 +120,8 @@ impl PostgreSQLDdl {
         &self,
         table_name: &str,
         pk_column: &str,
-        pk_type: &UniversalType,
-        columns: &[(String, UniversalType, bool)],
+        pk_type: &Type,
+        columns: &[(String, Type, bool)],
     ) -> String {
         let mut all_columns = vec![(pk_column.to_string(), pk_type.clone(), false)];
         all_columns.extend(columns.iter().cloned());
@@ -155,7 +147,7 @@ impl PostgreSQLDdl {
         &self,
         table_name: &str,
         pk_column: &str,
-        columns: &[(String, UniversalType, bool)],
+        columns: &[(String, Type, bool)],
     ) -> String {
         let column_defs: Vec<String> = columns
             .iter()
@@ -193,11 +185,7 @@ impl PostgreSQLDdl {
     ///
     /// PostgreSQL's UNNEST allows efficient bulk inserts:
     /// INSERT INTO table (col1, col2) SELECT * FROM UNNEST($1::type[], $2::type[])
-    pub fn to_batch_insert_unnest(
-        &self,
-        table_name: &str,
-        columns: &[(String, UniversalType)],
-    ) -> String {
+    pub fn to_batch_insert_unnest(&self, table_name: &str, columns: &[(String, Type)]) -> String {
         let col_names: Vec<String> = columns
             .iter()
             .map(|(name, _)| format!("\"{name}\""))
@@ -241,30 +229,30 @@ mod tests {
     #[test]
     fn test_bool_ddl() {
         let ddl = PostgreSQLDdl;
-        assert_eq!(ddl.to_ddl(&UniversalType::Bool), "BOOLEAN");
+        assert_eq!(ddl.to_ddl(&Type::Bool), "BOOLEAN");
     }
 
     #[test]
     fn test_integer_ddl() {
         let ddl = PostgreSQLDdl;
-        assert_eq!(ddl.to_ddl(&UniversalType::Int8 { width: 4 }), "SMALLINT");
-        assert_eq!(ddl.to_ddl(&UniversalType::Int16), "SMALLINT");
-        assert_eq!(ddl.to_ddl(&UniversalType::Int32), "INTEGER");
-        assert_eq!(ddl.to_ddl(&UniversalType::Int64), "BIGINT");
+        assert_eq!(ddl.to_ddl(&Type::Int8 { width: 4 }), "SMALLINT");
+        assert_eq!(ddl.to_ddl(&Type::Int16), "SMALLINT");
+        assert_eq!(ddl.to_ddl(&Type::Int32), "INTEGER");
+        assert_eq!(ddl.to_ddl(&Type::Int64), "BIGINT");
     }
 
     #[test]
     fn test_float_ddl() {
         let ddl = PostgreSQLDdl;
-        assert_eq!(ddl.to_ddl(&UniversalType::Float32), "REAL");
-        assert_eq!(ddl.to_ddl(&UniversalType::Float64), "DOUBLE PRECISION");
+        assert_eq!(ddl.to_ddl(&Type::Float32), "REAL");
+        assert_eq!(ddl.to_ddl(&Type::Float64), "DOUBLE PRECISION");
     }
 
     #[test]
     fn test_decimal_ddl() {
         let ddl = PostgreSQLDdl;
         assert_eq!(
-            ddl.to_ddl(&UniversalType::Decimal {
+            ddl.to_ddl(&Type::Decimal {
                 precision: 10,
                 scale: 2
             }),
@@ -275,55 +263,52 @@ mod tests {
     #[test]
     fn test_string_ddl() {
         let ddl = PostgreSQLDdl;
-        assert_eq!(ddl.to_ddl(&UniversalType::Char { length: 10 }), "CHAR(10)");
-        assert_eq!(
-            ddl.to_ddl(&UniversalType::VarChar { length: 255 }),
-            "VARCHAR(255)"
-        );
-        assert_eq!(ddl.to_ddl(&UniversalType::Text), "TEXT");
+        assert_eq!(ddl.to_ddl(&Type::Char { length: 10 }), "CHAR(10)");
+        assert_eq!(ddl.to_ddl(&Type::VarChar { length: 255 }), "VARCHAR(255)");
+        assert_eq!(ddl.to_ddl(&Type::Text), "TEXT");
     }
 
     #[test]
     fn test_binary_ddl() {
         let ddl = PostgreSQLDdl;
-        assert_eq!(ddl.to_ddl(&UniversalType::Blob), "BYTEA");
-        assert_eq!(ddl.to_ddl(&UniversalType::Bytes), "BYTEA");
+        assert_eq!(ddl.to_ddl(&Type::Blob), "BYTEA");
+        assert_eq!(ddl.to_ddl(&Type::Bytes), "BYTEA");
     }
 
     #[test]
     fn test_datetime_ddl() {
         let ddl = PostgreSQLDdl;
-        assert_eq!(ddl.to_ddl(&UniversalType::Date), "DATE");
-        assert_eq!(ddl.to_ddl(&UniversalType::Time), "TIME");
-        assert_eq!(ddl.to_ddl(&UniversalType::LocalDateTime), "TIMESTAMP");
-        assert_eq!(ddl.to_ddl(&UniversalType::ZonedDateTime), "TIMESTAMPTZ");
+        assert_eq!(ddl.to_ddl(&Type::Date), "DATE");
+        assert_eq!(ddl.to_ddl(&Type::Time), "TIME");
+        assert_eq!(ddl.to_ddl(&Type::LocalDateTime), "TIMESTAMP");
+        assert_eq!(ddl.to_ddl(&Type::ZonedDateTime), "TIMESTAMPTZ");
     }
 
     #[test]
     fn test_uuid_ddl() {
         let ddl = PostgreSQLDdl;
-        assert_eq!(ddl.to_ddl(&UniversalType::Uuid), "UUID");
+        assert_eq!(ddl.to_ddl(&Type::Uuid), "UUID");
     }
 
     #[test]
     fn test_json_ddl() {
         let ddl = PostgreSQLDdl;
-        assert_eq!(ddl.to_ddl(&UniversalType::Json), "JSON");
-        assert_eq!(ddl.to_ddl(&UniversalType::Jsonb), "JSONB");
+        assert_eq!(ddl.to_ddl(&Type::Json), "JSON");
+        assert_eq!(ddl.to_ddl(&Type::Jsonb), "JSONB");
     }
 
     #[test]
     fn test_array_ddl() {
         let ddl = PostgreSQLDdl;
         assert_eq!(
-            ddl.to_ddl(&UniversalType::Array {
-                element_type: Box::new(UniversalType::Int32)
+            ddl.to_ddl(&Type::Array {
+                element_type: Box::new(Type::Int32)
             }),
             "INTEGER[]"
         );
         assert_eq!(
-            ddl.to_ddl(&UniversalType::Array {
-                element_type: Box::new(UniversalType::Text)
+            ddl.to_ddl(&Type::Array {
+                element_type: Box::new(Type::Text)
             }),
             "TEXT[]"
         );
@@ -333,9 +318,9 @@ mod tests {
     fn test_nested_array_ddl() {
         let ddl = PostgreSQLDdl;
         assert_eq!(
-            ddl.to_ddl(&UniversalType::Array {
-                element_type: Box::new(UniversalType::Array {
-                    element_type: Box::new(UniversalType::Int32)
+            ddl.to_ddl(&Type::Array {
+                element_type: Box::new(Type::Array {
+                    element_type: Box::new(Type::Int32)
                 })
             }),
             "INTEGER[][]"
@@ -346,7 +331,7 @@ mod tests {
     fn test_set_ddl() {
         let ddl = PostgreSQLDdl;
         assert_eq!(
-            ddl.to_ddl(&UniversalType::Set {
+            ddl.to_ddl(&Type::Set {
                 values: vec!["a".to_string(), "b".to_string()]
             }),
             "TEXT[]"
@@ -358,7 +343,7 @@ mod tests {
         let ddl = PostgreSQLDdl;
         // Enums in PostgreSQL need CREATE TYPE, so we store as TEXT
         assert_eq!(
-            ddl.to_ddl(&UniversalType::Enum {
+            ddl.to_ddl(&Type::Enum {
                 values: vec!["active".to_string(), "inactive".to_string()]
             }),
             "TEXT"
@@ -369,13 +354,13 @@ mod tests {
     fn test_geometry_ddl() {
         let ddl = PostgreSQLDdl;
         assert_eq!(
-            ddl.to_ddl(&UniversalType::Geometry {
+            ddl.to_ddl(&Type::Geometry {
                 geometry_type: GeometryType::Point
             }),
             "POINT"
         );
         assert_eq!(
-            ddl.to_ddl(&UniversalType::Geometry {
+            ddl.to_ddl(&Type::Geometry {
                 geometry_type: GeometryType::Polygon
             }),
             "POLYGON"
@@ -386,17 +371,9 @@ mod tests {
     fn test_create_table() {
         let ddl = PostgreSQLDdl;
         let columns = vec![
-            (
-                "name".to_string(),
-                UniversalType::VarChar { length: 100 },
-                false,
-            ),
-            (
-                "email".to_string(),
-                UniversalType::VarChar { length: 255 },
-                false,
-            ),
-            ("age".to_string(), UniversalType::Int32, true),
+            ("name".to_string(), Type::VarChar { length: 100 }, false),
+            ("email".to_string(), Type::VarChar { length: 255 }, false),
+            ("age".to_string(), Type::Int32, true),
         ];
 
         let sql = ddl.to_create_table("users", &columns);
@@ -410,19 +387,11 @@ mod tests {
     fn test_create_table_with_pk() {
         let ddl = PostgreSQLDdl;
         let columns = vec![
-            (
-                "name".to_string(),
-                UniversalType::VarChar { length: 100 },
-                false,
-            ),
-            (
-                "email".to_string(),
-                UniversalType::VarChar { length: 255 },
-                false,
-            ),
+            ("name".to_string(), Type::VarChar { length: 100 }, false),
+            ("email".to_string(), Type::VarChar { length: 255 }, false),
         ];
 
-        let sql = ddl.to_create_table_with_pk("users", "id", &UniversalType::Uuid, &columns);
+        let sql = ddl.to_create_table_with_pk("users", "id", &Type::Uuid, &columns);
         assert!(sql.contains("CREATE TABLE \"users\""));
         assert!(sql.contains("\"id\" UUID NOT NULL"));
         assert!(sql.contains("PRIMARY KEY (\"id\")"));
@@ -432,16 +401,8 @@ mod tests {
     fn test_create_table_with_serial_pk() {
         let ddl = PostgreSQLDdl;
         let columns = vec![
-            (
-                "name".to_string(),
-                UniversalType::VarChar { length: 100 },
-                false,
-            ),
-            (
-                "email".to_string(),
-                UniversalType::VarChar { length: 255 },
-                false,
-            ),
+            ("name".to_string(), Type::VarChar { length: 100 }, false),
+            ("email".to_string(), Type::VarChar { length: 255 }, false),
         ];
 
         let sql = ddl.to_create_table_with_serial_pk("users", "id", &columns);
@@ -466,8 +427,8 @@ mod tests {
     fn test_batch_insert_unnest() {
         let ddl = PostgreSQLDdl;
         let columns = vec![
-            ("name".to_string(), UniversalType::Text),
-            ("age".to_string(), UniversalType::Int32),
+            ("name".to_string(), Type::Text),
+            ("age".to_string(), Type::Int32),
         ];
 
         let sql = ddl.to_batch_insert_unnest("users", &columns);

--- a/crates/postgresql-types/src/forward.rs
+++ b/crates/postgresql-types/src/forward.rs
@@ -1,15 +1,15 @@
-//! Forward conversion: UniversalValue/TypedValue → PostgreSQL value
+//! Forward conversion: Value/TypedValue → PostgreSQL value
 //!
-//! This module implements `From<UniversalValue>` and `From<TypedValue>` for `PostgreSQLValue`,
+//! This module implements `From<Value>` and `From<TypedValue>` for `PostgreSQLValue`,
 //! converting sync-core's values into PostgreSQL-compatible values for INSERT operations.
-//! The TypedValue implementation delegates to UniversalValue for most cases, but keeps
+//! The TypedValue implementation delegates to Value for most cases, but keeps
 //! special handling for typed arrays and JSON text parsing where type info is needed.
 
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use rust_decimal::Decimal;
 use serde_json::json;
 use std::str::FromStr;
-use sync_core::{TypedValue, UniversalType, UniversalValue};
+use sync_core::{Type, TypedValue, Value};
 use uuid::Uuid;
 
 /// PostgreSQL value wrapper for type-safe conversions.
@@ -64,89 +64,89 @@ pub enum PostgreSQLValue {
     Point(f64, f64),
 }
 
-impl From<UniversalValue> for PostgreSQLValue {
-    fn from(value: UniversalValue) -> Self {
+impl From<Value> for PostgreSQLValue {
+    fn from(value: Value) -> Self {
         match value {
             // Null
-            UniversalValue::Null => PostgreSQLValue::Null,
+            Value::Null => PostgreSQLValue::Null,
 
             // Boolean
-            UniversalValue::Bool(b) => PostgreSQLValue::Bool(b),
+            Value::Bool(b) => PostgreSQLValue::Bool(b),
 
             // Integer types
-            UniversalValue::Int8 { value, .. } => PostgreSQLValue::Int16(value as i16),
-            UniversalValue::Int16(i) => PostgreSQLValue::Int16(i),
-            UniversalValue::Int32(i) => PostgreSQLValue::Int32(i),
-            UniversalValue::Int64(i) => PostgreSQLValue::Int64(i),
+            Value::Int8 { value, .. } => PostgreSQLValue::Int16(value as i16),
+            Value::Int16(i) => PostgreSQLValue::Int16(i),
+            Value::Int32(i) => PostgreSQLValue::Int32(i),
+            Value::Int64(i) => PostgreSQLValue::Int64(i),
 
             // Floating point
-            UniversalValue::Float32(f) => PostgreSQLValue::Float32(f),
-            UniversalValue::Float64(f) => PostgreSQLValue::Float64(f),
+            Value::Float32(f) => PostgreSQLValue::Float32(f),
+            Value::Float64(f) => PostgreSQLValue::Float64(f),
 
             // Decimal - try to parse as Decimal, fallback to Text
-            UniversalValue::Decimal { value, .. } => match Decimal::from_str(&value) {
+            Value::Decimal { value, .. } => match Decimal::from_str(&value) {
                 Ok(d) => PostgreSQLValue::Decimal(d),
                 Err(_) => PostgreSQLValue::Text(value),
             },
 
             // String types
-            UniversalValue::Char { value, .. } => PostgreSQLValue::Text(value),
-            UniversalValue::VarChar { value, .. } => PostgreSQLValue::Text(value),
-            UniversalValue::Text(s) => PostgreSQLValue::Text(s),
+            Value::Char { value, .. } => PostgreSQLValue::Text(value),
+            Value::VarChar { value, .. } => PostgreSQLValue::Text(value),
+            Value::Text(s) => PostgreSQLValue::Text(s),
 
             // Binary types
-            UniversalValue::Blob(b) => PostgreSQLValue::Bytes(b),
-            UniversalValue::Bytes(b) => PostgreSQLValue::Bytes(b),
+            Value::Blob(b) => PostgreSQLValue::Bytes(b),
+            Value::Bytes(b) => PostgreSQLValue::Bytes(b),
 
             // UUID
-            UniversalValue::Uuid(u) => PostgreSQLValue::Uuid(u),
+            Value::Uuid(u) => PostgreSQLValue::Uuid(u),
 
             // ULID - convert to text
-            UniversalValue::Ulid(u) => PostgreSQLValue::Text(u.to_string()),
+            Value::Ulid(u) => PostgreSQLValue::Text(u.to_string()),
 
             // Date
-            UniversalValue::Date(dt) => PostgreSQLValue::Date(dt.date_naive()),
+            Value::Date(dt) => PostgreSQLValue::Date(dt.date_naive()),
 
             // Time
-            UniversalValue::Time(dt) => PostgreSQLValue::Time(dt.time()),
+            Value::Time(dt) => PostgreSQLValue::Time(dt.time()),
 
             // DateTime (without timezone)
-            UniversalValue::LocalDateTime(dt) => PostgreSQLValue::Timestamp(dt.naive_utc()),
-            UniversalValue::LocalDateTimeNano(dt) => PostgreSQLValue::Timestamp(dt.naive_utc()),
+            Value::LocalDateTime(dt) => PostgreSQLValue::Timestamp(dt.naive_utc()),
+            Value::LocalDateTimeNano(dt) => PostgreSQLValue::Timestamp(dt.naive_utc()),
 
             // Timestamp with timezone
-            UniversalValue::ZonedDateTime(dt) => PostgreSQLValue::TimestampTz(dt),
+            Value::ZonedDateTime(dt) => PostgreSQLValue::TimestampTz(dt),
 
             // TimeTz - store as text to preserve timezone format
             // Note: We intentionally do NOT use a datetime type because time and datetime
             // are fundamentally different types.
-            UniversalValue::TimeTz(s) => PostgreSQLValue::Text(s),
+            Value::TimeTz(s) => PostgreSQLValue::Text(s),
 
             // JSON
-            UniversalValue::Json(json_val) => PostgreSQLValue::Json((*json_val).clone()),
-            UniversalValue::Jsonb(json_val) => PostgreSQLValue::Json((*json_val).clone()),
+            Value::Json(json_val) => PostgreSQLValue::Json((*json_val).clone()),
+            Value::Jsonb(json_val) => PostgreSQLValue::Json((*json_val).clone()),
 
             // Array - default to text array without element_type info
-            UniversalValue::Array { elements, .. } => {
+            Value::Array { elements, .. } => {
                 let values: Vec<String> = elements.into_iter().map(generated_to_string).collect();
                 PostgreSQLValue::TextArray(values)
             }
 
             // Set - PostgreSQL stores as text[]
-            UniversalValue::Set { elements, .. } => PostgreSQLValue::TextArray(elements),
+            Value::Set { elements, .. } => PostgreSQLValue::TextArray(elements),
 
             // Enum - PostgreSQL stores as text
-            UniversalValue::Enum { value, .. } => PostgreSQLValue::Text(value),
+            Value::Enum { value, .. } => PostgreSQLValue::Text(value),
 
             // Geometry - store as GeoJSON
-            UniversalValue::Geometry { data, .. } => {
+            Value::Geometry { data, .. } => {
                 use sync_core::values::GeometryData;
                 let GeometryData(json_val) = data;
                 PostgreSQLValue::Json(json_val)
             }
 
             // Duration - store as text in ISO 8601 format
-            UniversalValue::Duration(d) => {
+            Value::Duration(d) => {
                 let secs = d.as_secs();
                 let nanos = d.subsec_nanos();
                 if nanos == 0 {
@@ -157,12 +157,12 @@ impl From<UniversalValue> for PostgreSQLValue {
             }
 
             // Thing - record reference as "table:id" format
-            UniversalValue::Thing { table, id } => {
+            Value::Thing { table, id } => {
                 let id_str = match id.as_ref() {
-                    UniversalValue::Text(s) => s.clone(),
-                    UniversalValue::Int32(i) => i.to_string(),
-                    UniversalValue::Int64(i) => i.to_string(),
-                    UniversalValue::Uuid(u) => u.to_string(),
+                    Value::Text(s) => s.clone(),
+                    Value::Int32(i) => i.to_string(),
+                    Value::Int64(i) => i.to_string(),
+                    Value::Uuid(u) => u.to_string(),
                     other => panic!(
                         "Unsupported Thing ID type: {other:?}. \
                          Supported types: Text, Int32, Int64, Uuid"
@@ -172,7 +172,7 @@ impl From<UniversalValue> for PostgreSQLValue {
             }
 
             // Object - nested document as JSONB
-            UniversalValue::Object(map) => {
+            Value::Object(map) => {
                 let obj: serde_json::Map<String, serde_json::Value> = map
                     .into_iter()
                     .map(|(k, v)| (k, universal_value_to_json(v)))
@@ -180,13 +180,12 @@ impl From<UniversalValue> for PostgreSQLValue {
                 PostgreSQLValue::Json(serde_json::Value::Object(obj))
             }
 
-            UniversalValue::ZeroTemporal {
+            Value::ZeroTemporal {
                 intended_type,
                 source,
             } => {
-                let s = source.unwrap_or_else(|| {
-                    UniversalValue::canonical_zero_literal(&intended_type).to_string()
-                });
+                let s = source
+                    .unwrap_or_else(|| Value::canonical_zero_literal(&intended_type).to_string());
                 PostgreSQLValue::Text(s)
             }
         }
@@ -197,52 +196,47 @@ impl From<TypedValue> for PostgreSQLValue {
     fn from(tv: TypedValue) -> Self {
         match (&tv.sync_type, &tv.value) {
             // Special case: UUID type with text value - parse the UUID string
-            (UniversalType::Uuid, UniversalValue::Text(s)) => match Uuid::parse_str(s) {
+            (Type::Uuid, Value::Text(s)) => match Uuid::parse_str(s) {
                 Ok(u) => PostgreSQLValue::Uuid(u),
                 Err(_) => PostgreSQLValue::Text(s.clone()),
             },
 
             // Special case: Decimal type with text value - parse as decimal
-            (UniversalType::Decimal { .. }, UniversalValue::Text(s)) => {
-                match Decimal::from_str(s) {
-                    Ok(d) => PostgreSQLValue::Decimal(d),
-                    Err(_) => PostgreSQLValue::Text(s.clone()),
-                }
-            }
+            (Type::Decimal { .. }, Value::Text(s)) => match Decimal::from_str(s) {
+                Ok(d) => PostgreSQLValue::Decimal(d),
+                Err(_) => PostgreSQLValue::Text(s.clone()),
+            },
 
             // Special case: JSON/Jsonb type with text value - parse JSON string
-            (UniversalType::Json, UniversalValue::Text(s)) => match serde_json::from_str(s) {
+            (Type::Json, Value::Text(s)) => match serde_json::from_str(s) {
                 Ok(v) => PostgreSQLValue::Json(v),
                 Err(_) => PostgreSQLValue::Text(s.clone()),
             },
-            (UniversalType::Jsonb, UniversalValue::Text(s)) => match serde_json::from_str(s) {
+            (Type::Jsonb, Value::Text(s)) => match serde_json::from_str(s) {
                 Ok(v) => PostgreSQLValue::Json(v),
                 Err(_) => PostgreSQLValue::Text(s.clone()),
             },
 
             // Special case: Typed arrays - use element_type for proper array conversion
-            (UniversalType::Array { element_type }, UniversalValue::Array { elements, .. }) => {
+            (Type::Array { element_type }, Value::Array { elements, .. }) => {
                 convert_array_to_postgresql(element_type, elements)
             }
 
-            // All other cases delegate to From<UniversalValue>
+            // All other cases delegate to From<Value>
             _ => PostgreSQLValue::from(tv.value),
         }
     }
 }
 
-/// Convert a UniversalValue array to the appropriate PostgreSQL array type.
-fn convert_array_to_postgresql(
-    element_type: &UniversalType,
-    arr: &[UniversalValue],
-) -> PostgreSQLValue {
+/// Convert a Value array to the appropriate PostgreSQL array type.
+fn convert_array_to_postgresql(element_type: &Type, arr: &[Value]) -> PostgreSQLValue {
     let arr = arr.to_vec();
     match element_type {
-        UniversalType::Bool => {
+        Type::Bool => {
             let values: Vec<bool> = arr
                 .into_iter()
                 .filter_map(|v| {
-                    if let UniversalValue::Bool(b) = v {
+                    if let Value::Bool(b) = v {
                         Some(b)
                     } else {
                         None
@@ -251,33 +245,33 @@ fn convert_array_to_postgresql(
                 .collect();
             PostgreSQLValue::BoolArray(values)
         }
-        UniversalType::Int32 | UniversalType::Int16 | UniversalType::Int8 { .. } => {
+        Type::Int32 | Type::Int16 | Type::Int8 { .. } => {
             let values: Vec<i32> = arr
                 .into_iter()
                 .filter_map(|v| match v {
-                    UniversalValue::Int32(i) => Some(i),
-                    UniversalValue::Int64(i) => Some(i as i32),
+                    Value::Int32(i) => Some(i),
+                    Value::Int64(i) => Some(i as i32),
                     _ => None,
                 })
                 .collect();
             PostgreSQLValue::Int32Array(values)
         }
-        UniversalType::Int64 => {
+        Type::Int64 => {
             let values: Vec<i64> = arr
                 .into_iter()
                 .filter_map(|v| match v {
-                    UniversalValue::Int32(i) => Some(i as i64),
-                    UniversalValue::Int64(i) => Some(i),
+                    Value::Int32(i) => Some(i as i64),
+                    Value::Int64(i) => Some(i),
                     _ => None,
                 })
                 .collect();
             PostgreSQLValue::Int64Array(values)
         }
-        UniversalType::Float32 | UniversalType::Float64 => {
+        Type::Float32 | Type::Float64 => {
             let values: Vec<f64> = arr
                 .into_iter()
                 .filter_map(|v| {
-                    if let UniversalValue::Float64(f) = v {
+                    if let Value::Float64(f) = v {
                         Some(f)
                     } else {
                         None
@@ -294,24 +288,24 @@ fn convert_array_to_postgresql(
     }
 }
 
-/// Convert UniversalValue to string representation.
-fn generated_to_string(gv: UniversalValue) -> String {
+/// Convert Value to string representation.
+fn generated_to_string(gv: Value) -> String {
     match gv {
-        UniversalValue::Null => String::new(),
-        UniversalValue::Bool(b) => b.to_string(),
-        UniversalValue::Int32(i) => i.to_string(),
-        UniversalValue::Int64(i) => i.to_string(),
-        UniversalValue::Float64(f) => f.to_string(),
-        UniversalValue::Text(s) => s,
-        UniversalValue::Bytes(b) => base64_encode(&b),
-        UniversalValue::Uuid(u) => u.to_string(),
-        UniversalValue::LocalDateTime(dt) => dt.to_rfc3339(),
-        UniversalValue::Decimal { value, .. } => value,
-        UniversalValue::Array { elements, .. } => {
+        Value::Null => String::new(),
+        Value::Bool(b) => b.to_string(),
+        Value::Int32(i) => i.to_string(),
+        Value::Int64(i) => i.to_string(),
+        Value::Float64(f) => f.to_string(),
+        Value::Text(s) => s,
+        Value::Bytes(b) => base64_encode(&b),
+        Value::Uuid(u) => u.to_string(),
+        Value::LocalDateTime(dt) => dt.to_rfc3339(),
+        Value::Decimal { value, .. } => value,
+        Value::Array { elements, .. } => {
             let json = generated_array_to_json(elements);
             json.to_string()
         }
-        UniversalValue::Json(json_val) => (*json_val).to_string(),
+        Value::Json(json_val) => (*json_val).to_string(),
         _ => format!("{gv:?}"),
     }
 }
@@ -321,30 +315,30 @@ fn base64_encode(bytes: &[u8]) -> String {
     bytes.iter().map(|b| format!("{b:02x}")).collect()
 }
 
-/// Convert a UniversalValue array to serde_json::Value.
-fn generated_array_to_json(arr: Vec<UniversalValue>) -> serde_json::Value {
+/// Convert a Value array to serde_json::Value.
+fn generated_array_to_json(arr: Vec<Value>) -> serde_json::Value {
     let values: Vec<serde_json::Value> = arr.into_iter().map(generated_to_json).collect();
     serde_json::Value::Array(values)
 }
 
-/// Convert any UniversalValue to serde_json::Value.
-fn generated_to_json(gv: UniversalValue) -> serde_json::Value {
+/// Convert any Value to serde_json::Value.
+fn generated_to_json(gv: Value) -> serde_json::Value {
     match gv {
-        UniversalValue::Null => serde_json::Value::Null,
-        UniversalValue::Bool(b) => serde_json::Value::Bool(b),
-        UniversalValue::Int32(i) => json!(i),
-        UniversalValue::Int64(i) => json!(i),
-        UniversalValue::Float64(f) => serde_json::Number::from_f64(f)
+        Value::Null => serde_json::Value::Null,
+        Value::Bool(b) => serde_json::Value::Bool(b),
+        Value::Int32(i) => json!(i),
+        Value::Int64(i) => json!(i),
+        Value::Float64(f) => serde_json::Number::from_f64(f)
             .map(serde_json::Value::Number)
             .unwrap_or(serde_json::Value::Null),
-        UniversalValue::Text(s) => serde_json::Value::String(s),
-        UniversalValue::Bytes(b) => serde_json::Value::String(base64_encode(&b)),
-        UniversalValue::Uuid(u) => serde_json::Value::String(u.to_string()),
-        UniversalValue::LocalDateTime(dt) => serde_json::Value::String(dt.to_rfc3339()),
-        UniversalValue::Decimal { value, .. } => serde_json::Value::String(value),
-        UniversalValue::Array { elements, .. } => generated_array_to_json(elements),
-        UniversalValue::Json(json_val) => *json_val,
-        UniversalValue::Object(map) => {
+        Value::Text(s) => serde_json::Value::String(s),
+        Value::Bytes(b) => serde_json::Value::String(base64_encode(&b)),
+        Value::Uuid(u) => serde_json::Value::String(u.to_string()),
+        Value::LocalDateTime(dt) => serde_json::Value::String(dt.to_rfc3339()),
+        Value::Decimal { value, .. } => serde_json::Value::String(value),
+        Value::Array { elements, .. } => generated_array_to_json(elements),
+        Value::Json(json_val) => *json_val,
+        Value::Object(map) => {
             let obj: serde_json::Map<String, serde_json::Value> = map
                 .into_iter()
                 .map(|(k, v)| (k, generated_to_json(v)))
@@ -355,8 +349,8 @@ fn generated_to_json(gv: UniversalValue) -> serde_json::Value {
     }
 }
 
-/// Convert UniversalValue by reference to serde_json::Value for Object conversion.
-fn universal_value_to_json(value: UniversalValue) -> serde_json::Value {
+/// Convert Value by reference to serde_json::Value for Object conversion.
+fn universal_value_to_json(value: Value) -> serde_json::Value {
     generated_to_json(value)
 }
 
@@ -453,7 +447,7 @@ mod tests {
 
     #[test]
     fn test_null_conversion() {
-        let tv = TypedValue::null(UniversalType::Text);
+        let tv = TypedValue::null(Type::Text);
         let pg_val: PostgreSQLValue = tv.into();
         assert!(matches!(pg_val, PostgreSQLValue::Null));
     }
@@ -471,12 +465,8 @@ mod tests {
 
     #[test]
     fn test_array_conversion() {
-        let arr = vec![
-            UniversalValue::Int64(1),
-            UniversalValue::Int64(2),
-            UniversalValue::Int64(3),
-        ];
-        let tv = TypedValue::array(arr, UniversalType::Int64);
+        let arr = vec![Value::Int64(1), Value::Int64(2), Value::Int64(3)];
+        let tv = TypedValue::array(arr, Type::Int64);
         let pg_val: PostgreSQLValue = tv.into();
         if let PostgreSQLValue::Int64Array(values) = pg_val {
             assert_eq!(values, vec![1, 2, 3]);

--- a/crates/postgresql-types/src/lib.rs
+++ b/crates/postgresql-types/src/lib.rs
@@ -7,14 +7,14 @@
 //!
 //! - [`forward`] - TypedValue → PostgreSQL value conversion
 //! - [`reverse`] - PostgreSQL value → TypedValue conversion
-//! - [`ddl`] - PostgreSQL DDL generation from UniversalType
-//! - [`schema`] - PostgreSQL column type to UniversalType conversion
+//! - [`ddl`] - PostgreSQL DDL generation from Type
+//! - [`schema`] - PostgreSQL column type to Type conversion
 //!
 //! # Example
 //!
 //! ```ignore
 //! use postgresql_types::{PostgreSQLValue, PostgreSQLDdl, ToDdl, postgresql_column_to_universal_type};
-//! use sync_core::{TypedValue, UniversalType};
+//! use sync_core::{TypedValue, Type};
 //!
 //! // Convert TypedValue to PostgreSQL value
 //! let tv = TypedValue::text("hello");
@@ -22,12 +22,12 @@
 //!
 //! // Generate DDL
 //! let ddl = PostgreSQLDdl;
-//! let type_str = ddl.to_ddl(&UniversalType::Text);
+//! let type_str = ddl.to_ddl(&Type::Text);
 //! assert_eq!(type_str, "TEXT");
 //!
-//! // Convert PostgreSQL column type to UniversalType
+//! // Convert PostgreSQL column type to Type
 //! let ut = postgresql_column_to_universal_type("integer", None, None);
-//! assert_eq!(ut, UniversalType::Int32);
+//! assert_eq!(ut, Type::Int32);
 //! ```
 
 pub mod ddl;

--- a/crates/postgresql-types/src/reverse.rs
+++ b/crates/postgresql-types/src/reverse.rs
@@ -4,9 +4,9 @@
 //! back to sync-core's `TypedValue` format.
 
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
-use postgres_types::Type;
+use postgres_types::Type as PgType;
 use rust_decimal::Decimal;
-use sync_core::{GeometryType, TypedValue, UniversalType, UniversalValue};
+use sync_core::{GeometryType, Type, TypedValue, Value};
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -49,7 +49,7 @@ pub enum ConversionError {
 #[derive(Debug, Clone)]
 pub struct PostgreSQLValueWithSchema {
     /// The PostgreSQL type OID
-    pub pg_type: Type,
+    pub pg_type: PgType,
     /// The raw value (as bytes or parsed)
     pub value: PostgreSQLRawValue,
 }
@@ -105,7 +105,7 @@ pub enum PostgreSQLRawValue {
 
 impl PostgreSQLValueWithSchema {
     /// Create a new PostgreSQLValueWithSchema.
-    pub fn new(pg_type: Type, value: PostgreSQLRawValue) -> Self {
+    pub fn new(pg_type: PgType, value: PostgreSQLRawValue) -> Self {
         Self { pg_type, value }
     }
 
@@ -119,7 +119,7 @@ impl PostgreSQLValueWithSchema {
 
         match &self.pg_type {
             // Boolean
-            t if *t == Type::BOOL => {
+            t if *t == PgType::BOOL => {
                 if let PostgreSQLRawValue::Bool(b) = self.value {
                     Ok(TypedValue::bool(b))
                 } else {
@@ -131,7 +131,7 @@ impl PostgreSQLValueWithSchema {
             }
 
             // Integer types
-            t if *t == Type::INT2 => {
+            t if *t == PgType::INT2 => {
                 if let PostgreSQLRawValue::Int16(i) = self.value {
                     Ok(TypedValue::int16(i))
                 } else {
@@ -142,7 +142,7 @@ impl PostgreSQLValueWithSchema {
                 }
             }
 
-            t if *t == Type::INT4 => {
+            t if *t == PgType::INT4 => {
                 if let PostgreSQLRawValue::Int32(i) = self.value {
                     Ok(TypedValue::int32(i))
                 } else {
@@ -153,7 +153,7 @@ impl PostgreSQLValueWithSchema {
                 }
             }
 
-            t if *t == Type::INT8 => {
+            t if *t == PgType::INT8 => {
                 if let PostgreSQLRawValue::Int64(i) = self.value {
                     Ok(TypedValue::int64(i))
                 } else {
@@ -165,7 +165,7 @@ impl PostgreSQLValueWithSchema {
             }
 
             // Floating point
-            t if *t == Type::FLOAT4 => {
+            t if *t == PgType::FLOAT4 => {
                 if let PostgreSQLRawValue::Float32(f) = self.value {
                     Ok(TypedValue::float32(f))
                 } else {
@@ -176,7 +176,7 @@ impl PostgreSQLValueWithSchema {
                 }
             }
 
-            t if *t == Type::FLOAT8 => {
+            t if *t == PgType::FLOAT8 => {
                 if let PostgreSQLRawValue::Float64(f) = self.value {
                     Ok(TypedValue::float64(f))
                 } else {
@@ -188,7 +188,7 @@ impl PostgreSQLValueWithSchema {
             }
 
             // Numeric/Decimal
-            t if *t == Type::NUMERIC => {
+            t if *t == PgType::NUMERIC => {
                 if let PostgreSQLRawValue::Decimal(d) = &self.value {
                     // Estimate precision and scale from the decimal
                     let s = d.to_string();
@@ -206,7 +206,7 @@ impl PostgreSQLValueWithSchema {
             }
 
             // Text types
-            t if *t == Type::TEXT || *t == Type::VARCHAR || *t == Type::BPCHAR => {
+            t if *t == PgType::TEXT || *t == PgType::VARCHAR || *t == PgType::BPCHAR => {
                 if let PostgreSQLRawValue::Text(s) = &self.value {
                     Ok(TypedValue::text(s.clone()))
                 } else {
@@ -218,7 +218,7 @@ impl PostgreSQLValueWithSchema {
             }
 
             // Binary
-            t if *t == Type::BYTEA => {
+            t if *t == PgType::BYTEA => {
                 if let PostgreSQLRawValue::Bytes(b) = &self.value {
                     Ok(TypedValue::bytes(b.clone()))
                 } else {
@@ -230,7 +230,7 @@ impl PostgreSQLValueWithSchema {
             }
 
             // UUID
-            t if *t == Type::UUID => {
+            t if *t == PgType::UUID => {
                 if let PostgreSQLRawValue::Uuid(u) = &self.value {
                     Ok(TypedValue::uuid(*u))
                 } else {
@@ -242,7 +242,7 @@ impl PostgreSQLValueWithSchema {
             }
 
             // Date
-            t if *t == Type::DATE => {
+            t if *t == PgType::DATE => {
                 if let PostgreSQLRawValue::Date(d) = &self.value {
                     let dt = d.and_hms_opt(0, 0, 0).unwrap().and_utc();
                     Ok(TypedValue::date(dt))
@@ -255,7 +255,7 @@ impl PostgreSQLValueWithSchema {
             }
 
             // Time
-            t if *t == Type::TIME => {
+            t if *t == PgType::TIME => {
                 if let PostgreSQLRawValue::Time(t) = &self.value {
                     let today = chrono::Utc::now().date_naive();
                     let dt = NaiveDateTime::new(today, *t).and_utc();
@@ -269,7 +269,7 @@ impl PostgreSQLValueWithSchema {
             }
 
             // Timestamp
-            t if *t == Type::TIMESTAMP => {
+            t if *t == PgType::TIMESTAMP => {
                 if let PostgreSQLRawValue::Timestamp(ts) = &self.value {
                     Ok(TypedValue::datetime(ts.and_utc()))
                 } else {
@@ -281,7 +281,7 @@ impl PostgreSQLValueWithSchema {
             }
 
             // Timestamp with timezone
-            t if *t == Type::TIMESTAMPTZ => {
+            t if *t == PgType::TIMESTAMPTZ => {
                 if let PostgreSQLRawValue::TimestampTz(ts) = &self.value {
                     Ok(TypedValue::timestamptz(*ts))
                 } else {
@@ -293,9 +293,9 @@ impl PostgreSQLValueWithSchema {
             }
 
             // JSON/JSONB
-            t if *t == Type::JSON || *t == Type::JSONB => {
+            t if *t == PgType::JSON || *t == PgType::JSONB => {
                 if let PostgreSQLRawValue::Json(j) = &self.value {
-                    if *t == Type::JSONB {
+                    if *t == PgType::JSONB {
                         Ok(TypedValue::jsonb(j.clone()))
                     } else {
                         Ok(TypedValue::json(j.clone()))
@@ -309,13 +309,10 @@ impl PostgreSQLValueWithSchema {
             }
 
             // Arrays
-            t if *t == Type::TEXT_ARRAY => {
+            t if *t == PgType::TEXT_ARRAY => {
                 if let PostgreSQLRawValue::TextArray(arr) = &self.value {
-                    let values: Vec<UniversalValue> = arr
-                        .iter()
-                        .map(|s| UniversalValue::Text(s.clone()))
-                        .collect();
-                    Ok(TypedValue::array(values, UniversalType::Text))
+                    let values: Vec<Value> = arr.iter().map(|s| Value::Text(s.clone())).collect();
+                    Ok(TypedValue::array(values, Type::Text))
                 } else {
                     Err(ConversionError::TypeMismatch {
                         expected: "text[]".to_string(),
@@ -324,11 +321,10 @@ impl PostgreSQLValueWithSchema {
                 }
             }
 
-            t if *t == Type::INT4_ARRAY => {
+            t if *t == PgType::INT4_ARRAY => {
                 if let PostgreSQLRawValue::Int32Array(arr) = &self.value {
-                    let values: Vec<UniversalValue> =
-                        arr.iter().map(|i| UniversalValue::Int32(*i)).collect();
-                    Ok(TypedValue::array(values, UniversalType::Int32))
+                    let values: Vec<Value> = arr.iter().map(|i| Value::Int32(*i)).collect();
+                    Ok(TypedValue::array(values, Type::Int32))
                 } else {
                     Err(ConversionError::TypeMismatch {
                         expected: "int4[]".to_string(),
@@ -337,11 +333,10 @@ impl PostgreSQLValueWithSchema {
                 }
             }
 
-            t if *t == Type::INT8_ARRAY => {
+            t if *t == PgType::INT8_ARRAY => {
                 if let PostgreSQLRawValue::Int64Array(arr) = &self.value {
-                    let values: Vec<UniversalValue> =
-                        arr.iter().map(|i| UniversalValue::Int64(*i)).collect();
-                    Ok(TypedValue::array(values, UniversalType::Int64))
+                    let values: Vec<Value> = arr.iter().map(|i| Value::Int64(*i)).collect();
+                    Ok(TypedValue::array(values, Type::Int64))
                 } else {
                     Err(ConversionError::TypeMismatch {
                         expected: "int8[]".to_string(),
@@ -350,11 +345,10 @@ impl PostgreSQLValueWithSchema {
                 }
             }
 
-            t if *t == Type::FLOAT8_ARRAY => {
+            t if *t == PgType::FLOAT8_ARRAY => {
                 if let PostgreSQLRawValue::Float64Array(arr) = &self.value {
-                    let values: Vec<UniversalValue> =
-                        arr.iter().map(|f| UniversalValue::Float64(*f)).collect();
-                    Ok(TypedValue::array(values, UniversalType::Float64))
+                    let values: Vec<Value> = arr.iter().map(|f| Value::Float64(*f)).collect();
+                    Ok(TypedValue::array(values, Type::Float64))
                 } else {
                     Err(ConversionError::TypeMismatch {
                         expected: "float8[]".to_string(),
@@ -363,11 +357,10 @@ impl PostgreSQLValueWithSchema {
                 }
             }
 
-            t if *t == Type::BOOL_ARRAY => {
+            t if *t == PgType::BOOL_ARRAY => {
                 if let PostgreSQLRawValue::BoolArray(arr) = &self.value {
-                    let values: Vec<UniversalValue> =
-                        arr.iter().map(|b| UniversalValue::Bool(*b)).collect();
-                    Ok(TypedValue::array(values, UniversalType::Bool))
+                    let values: Vec<Value> = arr.iter().map(|b| Value::Bool(*b)).collect();
+                    Ok(TypedValue::array(values, Type::Bool))
                 } else {
                     Err(ConversionError::TypeMismatch {
                         expected: "bool[]".to_string(),
@@ -377,7 +370,7 @@ impl PostgreSQLValueWithSchema {
             }
 
             // Point
-            t if *t == Type::POINT => {
+            t if *t == PgType::POINT => {
                 if let PostgreSQLRawValue::Point(x, y) = &self.value {
                     // Store as GeoJSON Point
                     let geojson = serde_json::json!({
@@ -405,79 +398,76 @@ impl PostgreSQLValueWithSchema {
     }
 }
 
-/// Convert PostgreSQL type to UniversalType.
-fn pg_type_to_sync_type(pg_type: &Type) -> UniversalType {
+/// Convert PostgreSQL type to Type.
+fn pg_type_to_sync_type(pg_type: &PgType) -> Type {
     match pg_type {
-        t if *t == Type::BOOL => UniversalType::Bool,
-        t if *t == Type::INT2 => UniversalType::Int16,
-        t if *t == Type::INT4 => UniversalType::Int32,
-        t if *t == Type::INT8 => UniversalType::Int64,
-        t if *t == Type::FLOAT4 => UniversalType::Float32,
-        t if *t == Type::FLOAT8 => UniversalType::Float64,
-        t if *t == Type::NUMERIC => UniversalType::Decimal {
+        t if *t == PgType::BOOL => Type::Bool,
+        t if *t == PgType::INT2 => Type::Int16,
+        t if *t == PgType::INT4 => Type::Int32,
+        t if *t == PgType::INT8 => Type::Int64,
+        t if *t == PgType::FLOAT4 => Type::Float32,
+        t if *t == PgType::FLOAT8 => Type::Float64,
+        t if *t == PgType::NUMERIC => Type::Decimal {
             precision: 38,
             scale: 10,
         },
-        t if *t == Type::TEXT => UniversalType::Text,
-        t if *t == Type::VARCHAR => UniversalType::VarChar { length: 255 },
-        t if *t == Type::BPCHAR => UniversalType::Char { length: 1 },
-        t if *t == Type::BYTEA => UniversalType::Bytes,
-        t if *t == Type::UUID => UniversalType::Uuid,
-        t if *t == Type::DATE => UniversalType::Date,
-        t if *t == Type::TIME => UniversalType::Time,
-        t if *t == Type::TIMESTAMP => UniversalType::LocalDateTime,
-        t if *t == Type::TIMESTAMPTZ => UniversalType::ZonedDateTime,
-        t if *t == Type::JSON => UniversalType::Json,
-        t if *t == Type::JSONB => UniversalType::Jsonb,
-        t if *t == Type::TEXT_ARRAY => UniversalType::Array {
-            element_type: Box::new(UniversalType::Text),
+        t if *t == PgType::TEXT => Type::Text,
+        t if *t == PgType::VARCHAR => Type::VarChar { length: 255 },
+        t if *t == PgType::BPCHAR => Type::Char { length: 1 },
+        t if *t == PgType::BYTEA => Type::Bytes,
+        t if *t == PgType::UUID => Type::Uuid,
+        t if *t == PgType::DATE => Type::Date,
+        t if *t == PgType::TIME => Type::Time,
+        t if *t == PgType::TIMESTAMP => Type::LocalDateTime,
+        t if *t == PgType::TIMESTAMPTZ => Type::ZonedDateTime,
+        t if *t == PgType::JSON => Type::Json,
+        t if *t == PgType::JSONB => Type::Jsonb,
+        t if *t == PgType::TEXT_ARRAY => Type::Array {
+            element_type: Box::new(Type::Text),
         },
-        t if *t == Type::INT4_ARRAY => UniversalType::Array {
-            element_type: Box::new(UniversalType::Int32),
+        t if *t == PgType::INT4_ARRAY => Type::Array {
+            element_type: Box::new(Type::Int32),
         },
-        t if *t == Type::INT8_ARRAY => UniversalType::Array {
-            element_type: Box::new(UniversalType::Int64),
+        t if *t == PgType::INT8_ARRAY => Type::Array {
+            element_type: Box::new(Type::Int64),
         },
-        t if *t == Type::FLOAT8_ARRAY => UniversalType::Array {
-            element_type: Box::new(UniversalType::Float64),
+        t if *t == PgType::FLOAT8_ARRAY => Type::Array {
+            element_type: Box::new(Type::Float64),
         },
-        t if *t == Type::BOOL_ARRAY => UniversalType::Array {
-            element_type: Box::new(UniversalType::Bool),
+        t if *t == PgType::BOOL_ARRAY => Type::Array {
+            element_type: Box::new(Type::Bool),
         },
-        t if *t == Type::POINT => UniversalType::Geometry {
+        t if *t == PgType::POINT => Type::Geometry {
             geometry_type: GeometryType::Point,
         },
-        _ => UniversalType::Text,
+        _ => Type::Text,
     }
 }
 
-/// Convert serde_json::Value to UniversalValue.
+/// Convert serde_json::Value to Value.
 #[allow(dead_code)]
-fn json_to_generated_value(json: serde_json::Value) -> UniversalValue {
+fn json_to_generated_value(json: serde_json::Value) -> Value {
     match json {
-        serde_json::Value::Null => UniversalValue::Null,
-        serde_json::Value::Bool(b) => UniversalValue::Bool(b),
+        serde_json::Value::Null => Value::Null,
+        serde_json::Value::Bool(b) => Value::Bool(b),
         serde_json::Value::Number(n) => {
             if let Some(i) = n.as_i64() {
-                UniversalValue::Int64(i)
+                Value::Int64(i)
             } else if let Some(f) = n.as_f64() {
-                UniversalValue::Float64(f)
+                Value::Float64(f)
             } else {
-                UniversalValue::Text(n.to_string())
+                Value::Text(n.to_string())
             }
         }
-        serde_json::Value::String(s) => UniversalValue::Text(s),
+        serde_json::Value::String(s) => Value::Text(s),
         serde_json::Value::Array(arr) => {
-            let elements: Vec<UniversalValue> =
-                arr.into_iter().map(json_to_generated_value).collect();
-            UniversalValue::Array {
+            let elements: Vec<Value> = arr.into_iter().map(json_to_generated_value).collect();
+            Value::Array {
                 elements,
-                element_type: Box::new(UniversalType::Json),
+                element_type: Box::new(Type::Json),
             }
         }
-        serde_json::Value::Object(obj) => {
-            UniversalValue::Json(Box::new(serde_json::Value::Object(obj)))
-        }
+        serde_json::Value::Object(obj) => Value::Json(Box::new(serde_json::Value::Object(obj))),
     }
 }
 
@@ -488,43 +478,40 @@ mod tests {
 
     #[test]
     fn test_bool_conversion() {
-        let pv = PostgreSQLValueWithSchema::new(Type::BOOL, PostgreSQLRawValue::Bool(true));
+        let pv = PostgreSQLValueWithSchema::new(PgType::BOOL, PostgreSQLRawValue::Bool(true));
         let tv = pv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::Bool));
-        assert!(matches!(tv.value, UniversalValue::Bool(true)));
+        assert!(matches!(tv.sync_type, Type::Bool));
+        assert!(matches!(tv.value, Value::Bool(true)));
     }
 
     #[test]
     fn test_int_conversion() {
-        let pv = PostgreSQLValueWithSchema::new(Type::INT4, PostgreSQLRawValue::Int32(42));
+        let pv = PostgreSQLValueWithSchema::new(PgType::INT4, PostgreSQLRawValue::Int32(42));
         let tv = pv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::Int32));
-        assert!(matches!(tv.value, UniversalValue::Int32(42)));
+        assert!(matches!(tv.sync_type, Type::Int32));
+        assert!(matches!(tv.value, Value::Int32(42)));
     }
 
     #[test]
     fn test_bigint_conversion() {
         let pv = PostgreSQLValueWithSchema::new(
-            Type::INT8,
+            PgType::INT8,
             PostgreSQLRawValue::Int64(9_223_372_036_854_775_807),
         );
         let tv = pv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::Int64));
-        assert!(matches!(
-            tv.value,
-            UniversalValue::Int64(9_223_372_036_854_775_807)
-        ));
+        assert!(matches!(tv.sync_type, Type::Int64));
+        assert!(matches!(tv.value, Value::Int64(9_223_372_036_854_775_807)));
     }
 
     #[test]
     fn test_text_conversion() {
         let pv = PostgreSQLValueWithSchema::new(
-            Type::TEXT,
+            PgType::TEXT,
             PostgreSQLRawValue::Text("hello world".to_string()),
         );
         let tv = pv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::Text));
-        if let UniversalValue::Text(s) = tv.value {
+        assert!(matches!(tv.sync_type, Type::Text));
+        if let Value::Text(s) = tv.value {
             assert_eq!(s, "hello world");
         } else {
             panic!("Expected String value");
@@ -534,10 +521,10 @@ mod tests {
     #[test]
     fn test_uuid_conversion() {
         let uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
-        let pv = PostgreSQLValueWithSchema::new(Type::UUID, PostgreSQLRawValue::Uuid(uuid));
+        let pv = PostgreSQLValueWithSchema::new(PgType::UUID, PostgreSQLRawValue::Uuid(uuid));
         let tv = pv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::Uuid));
-        if let UniversalValue::Uuid(u) = tv.value {
+        assert!(matches!(tv.sync_type, Type::Uuid));
+        if let Value::Uuid(u) = tv.value {
             assert_eq!(u.to_string(), "550e8400-e29b-41d4-a716-446655440000");
         } else {
             panic!("Expected Uuid value");
@@ -547,10 +534,11 @@ mod tests {
     #[test]
     fn test_timestamp_conversion() {
         let ts = NaiveDateTime::parse_from_str("2024-06-15 10:30:45", "%Y-%m-%d %H:%M:%S").unwrap();
-        let pv = PostgreSQLValueWithSchema::new(Type::TIMESTAMP, PostgreSQLRawValue::Timestamp(ts));
+        let pv =
+            PostgreSQLValueWithSchema::new(PgType::TIMESTAMP, PostgreSQLRawValue::Timestamp(ts));
         let tv = pv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::LocalDateTime));
-        if let UniversalValue::LocalDateTime(dt) = tv.value {
+        assert!(matches!(tv.sync_type, Type::LocalDateTime));
+        if let Value::LocalDateTime(dt) = tv.value {
             assert_eq!(dt.year(), 2024);
         } else {
             panic!("Expected DateTime value");
@@ -559,19 +547,19 @@ mod tests {
 
     #[test]
     fn test_null_conversion() {
-        let pv = PostgreSQLValueWithSchema::new(Type::INT4, PostgreSQLRawValue::Null);
+        let pv = PostgreSQLValueWithSchema::new(PgType::INT4, PostgreSQLRawValue::Null);
         let tv = pv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::Int32));
-        assert!(matches!(tv.value, UniversalValue::Null));
+        assert!(matches!(tv.sync_type, Type::Int32));
+        assert!(matches!(tv.value, Value::Null));
     }
 
     #[test]
     fn test_json_conversion() {
         let json = serde_json::json!({"name": "Alice", "age": 30});
-        let pv = PostgreSQLValueWithSchema::new(Type::JSON, PostgreSQLRawValue::Json(json));
+        let pv = PostgreSQLValueWithSchema::new(PgType::JSON, PostgreSQLRawValue::Json(json));
         let tv = pv.to_typed_value().unwrap();
-        assert!(matches!(tv.sync_type, UniversalType::Json));
-        if let UniversalValue::Json(json_val) = tv.value {
+        assert!(matches!(tv.sync_type, Type::Json));
+        if let Value::Json(json_val) = tv.value {
             if let serde_json::Value::Object(obj) = json_val.as_ref() {
                 assert!(obj.contains_key("name"));
                 assert!(obj.contains_key("age"));
@@ -587,14 +575,14 @@ mod tests {
     fn test_decimal_conversion() {
         let decimal = Decimal::from_str_exact("123.456").unwrap();
         let pv =
-            PostgreSQLValueWithSchema::new(Type::NUMERIC, PostgreSQLRawValue::Decimal(decimal));
+            PostgreSQLValueWithSchema::new(PgType::NUMERIC, PostgreSQLRawValue::Decimal(decimal));
         let tv = pv.to_typed_value().unwrap();
-        if let UniversalType::Decimal { scale, .. } = tv.sync_type {
+        if let Type::Decimal { scale, .. } = tv.sync_type {
             assert_eq!(scale, 3);
         } else {
             panic!("Expected Decimal type");
         }
-        if let UniversalValue::Decimal { value, .. } = tv.value {
+        if let Value::Decimal { value, .. } = tv.value {
             assert_eq!(value, "123.456");
         } else {
             panic!("Expected Decimal value");
@@ -605,14 +593,14 @@ mod tests {
     fn test_text_array_conversion() {
         let arr = vec!["a".to_string(), "b".to_string(), "c".to_string()];
         let pv =
-            PostgreSQLValueWithSchema::new(Type::TEXT_ARRAY, PostgreSQLRawValue::TextArray(arr));
+            PostgreSQLValueWithSchema::new(PgType::TEXT_ARRAY, PostgreSQLRawValue::TextArray(arr));
         let tv = pv.to_typed_value().unwrap();
-        if let UniversalType::Array { element_type } = &tv.sync_type {
-            assert!(matches!(**element_type, UniversalType::Text));
+        if let Type::Array { element_type } = &tv.sync_type {
+            assert!(matches!(**element_type, Type::Text));
         } else {
             panic!("Expected Array type");
         }
-        if let UniversalValue::Array { elements, .. } = tv.value {
+        if let Value::Array { elements, .. } = tv.value {
             assert_eq!(elements.len(), 3);
         } else {
             panic!("Expected Array value");
@@ -623,11 +611,11 @@ mod tests {
     fn test_int_array_conversion() {
         let arr = vec![1, 2, 3];
         let pv =
-            PostgreSQLValueWithSchema::new(Type::INT4_ARRAY, PostgreSQLRawValue::Int32Array(arr));
+            PostgreSQLValueWithSchema::new(PgType::INT4_ARRAY, PostgreSQLRawValue::Int32Array(arr));
         let tv = pv.to_typed_value().unwrap();
-        if let UniversalValue::Array { elements, .. } = tv.value {
+        if let Value::Array { elements, .. } = tv.value {
             assert_eq!(elements.len(), 3);
-            assert!(matches!(elements[0], UniversalValue::Int32(1)));
+            assert!(matches!(elements[0], Value::Int32(1)));
         } else {
             panic!("Expected Array value");
         }

--- a/crates/postgresql-types/src/schema.rs
+++ b/crates/postgresql-types/src/schema.rs
@@ -1,14 +1,14 @@
 //! PostgreSQL schema column type conversion.
 //!
 //! This module provides conversion from PostgreSQL INFORMATION_SCHEMA column types
-//! to `UniversalType` for schema introspection during incremental sync.
+//! to `Type` for schema introspection during incremental sync.
 
-use sync_core::UniversalType;
+use sync_core::Type;
 
-/// Convert PostgreSQL INFORMATION_SCHEMA column type to UniversalType.
+/// Convert PostgreSQL INFORMATION_SCHEMA column type to Type.
 ///
 /// This function maps PostgreSQL data types (as returned by `information_schema.columns`)
-/// to the appropriate `UniversalType` for use in schema-aware type conversion.
+/// to the appropriate `Type` for use in schema-aware type conversion.
 ///
 /// # Arguments
 ///
@@ -18,74 +18,74 @@ use sync_core::UniversalType;
 ///
 /// # Returns
 ///
-/// The corresponding `UniversalType` for the PostgreSQL column type.
+/// The corresponding `Type` for the PostgreSQL column type.
 ///
 /// # Example
 ///
 /// ```
 /// use postgresql_types::postgresql_column_to_universal_type;
-/// use sync_core::UniversalType;
+/// use sync_core::Type;
 ///
 /// let ut = postgresql_column_to_universal_type("integer", None, None);
-/// assert_eq!(ut, UniversalType::Int32);
+/// assert_eq!(ut, Type::Int32);
 ///
 /// let ut = postgresql_column_to_universal_type("numeric", Some(10), Some(2));
-/// assert!(matches!(ut, UniversalType::Decimal { precision: 10, scale: 2 }));
+/// assert!(matches!(ut, Type::Decimal { precision: 10, scale: 2 }));
 /// ```
 pub fn postgresql_column_to_universal_type(
     data_type: &str,
     precision: Option<u32>,
     scale: Option<u32>,
-) -> UniversalType {
+) -> Type {
     match data_type.to_lowercase().as_str() {
         // Numeric types
-        "smallint" | "int2" => UniversalType::Int16,
-        "integer" | "int" | "int4" => UniversalType::Int32,
-        "bigint" | "int8" => UniversalType::Int64,
-        "real" | "float4" => UniversalType::Float32,
-        "double precision" | "float8" => UniversalType::Float64,
-        "numeric" | "decimal" => UniversalType::Decimal {
-            // precision/scale are u32 but UniversalType expects u8, cap at 38
+        "smallint" | "int2" => Type::Int16,
+        "integer" | "int" | "int4" => Type::Int32,
+        "bigint" | "int8" => Type::Int64,
+        "real" | "float4" => Type::Float32,
+        "double precision" | "float8" => Type::Float64,
+        "numeric" | "decimal" => Type::Decimal {
+            // precision/scale are u32 but Type expects u8, cap at 38
             precision: precision.map(|p| p.min(38) as u8).unwrap_or(38),
             scale: scale.map(|s| s.min(38) as u8).unwrap_or(10),
         },
 
         // Boolean
-        "boolean" | "bool" => UniversalType::Bool,
+        "boolean" | "bool" => Type::Bool,
 
         // String types
-        "text" => UniversalType::Text,
+        "text" => Type::Text,
         "varchar" | "character varying" => {
             // If no length specified, treat as unlimited (use Text)
             match precision {
-                Some(p) => UniversalType::VarChar { length: p as u16 },
-                None => UniversalType::Text,
+                Some(p) => Type::VarChar { length: p as u16 },
+                None => Type::Text,
             }
         }
-        "char" | "character" => UniversalType::Char {
+        "char" | "character" => Type::Char {
             length: precision.map(|p| p as u16).unwrap_or(1),
         },
 
         // Binary
-        "bytea" => UniversalType::Bytes,
+        "bytea" => Type::Bytes,
 
         // Date/Time types
-        "date" => UniversalType::Date,
-        "time" | "time without time zone" => UniversalType::Time,
-        "timestamp" | "timestamp without time zone" => UniversalType::LocalDateTime,
-        "timestamptz" | "timestamp with time zone" => UniversalType::ZonedDateTime,
-        "interval" => UniversalType::Duration,
+        "date" => Type::Date,
+        "time" | "time without time zone" => Type::Time,
+        "timestamp" | "timestamp without time zone" => Type::LocalDateTime,
+        "timestamptz" | "timestamp with time zone" => Type::ZonedDateTime,
+        "interval" => Type::Duration,
 
         // UUID
-        "uuid" => UniversalType::Uuid,
+        "uuid" => Type::Uuid,
 
         // JSON types
-        "json" => UniversalType::Json,
-        "jsonb" => UniversalType::Jsonb,
+        "json" => Type::Json,
+        "jsonb" => Type::Jsonb,
 
         // Geometry types
         "point" | "line" | "lseg" | "box" | "path" | "polygon" | "circle" => {
-            UniversalType::Geometry {
+            Type::Geometry {
                 geometry_type: sync_core::GeometryType::Point, // Generic fallback
             }
         }
@@ -93,13 +93,13 @@ pub fn postgresql_column_to_universal_type(
         // Array types - PostgreSQL reports arrays as "_type" (e.g., "_int4" for int[])
         s if s.starts_with('_') => {
             let element_type = postgresql_column_to_universal_type(&s[1..], None, None);
-            UniversalType::Array {
+            Type::Array {
                 element_type: Box::new(element_type),
             }
         }
 
         // Fallback to Text for unknown types
-        _ => UniversalType::Text,
+        _ => Type::Text,
     }
 }
 
@@ -111,23 +111,23 @@ mod tests {
     fn test_postgresql_int_types() {
         assert_eq!(
             postgresql_column_to_universal_type("smallint", None, None),
-            UniversalType::Int16
+            Type::Int16
         );
         assert_eq!(
             postgresql_column_to_universal_type("integer", None, None),
-            UniversalType::Int32
+            Type::Int32
         );
         assert_eq!(
             postgresql_column_to_universal_type("int4", None, None),
-            UniversalType::Int32
+            Type::Int32
         );
         assert_eq!(
             postgresql_column_to_universal_type("bigint", None, None),
-            UniversalType::Int64
+            Type::Int64
         );
         assert_eq!(
             postgresql_column_to_universal_type("int8", None, None),
-            UniversalType::Int64
+            Type::Int64
         );
     }
 
@@ -136,7 +136,7 @@ mod tests {
         let ut = postgresql_column_to_universal_type("numeric", Some(10), Some(2));
         assert!(matches!(
             ut,
-            UniversalType::Decimal {
+            Type::Decimal {
                 precision: 10,
                 scale: 2
             }
@@ -145,7 +145,7 @@ mod tests {
         let ut = postgresql_column_to_universal_type("decimal", Some(18), Some(4));
         assert!(matches!(
             ut,
-            UniversalType::Decimal {
+            Type::Decimal {
                 precision: 18,
                 scale: 4
             }
@@ -155,7 +155,7 @@ mod tests {
         let ut = postgresql_column_to_universal_type("numeric", Some(50), Some(10));
         assert!(matches!(
             ut,
-            UniversalType::Decimal {
+            Type::Decimal {
                 precision: 38,
                 scale: 10
             }
@@ -166,20 +166,20 @@ mod tests {
     fn test_postgresql_string_types() {
         assert_eq!(
             postgresql_column_to_universal_type("text", None, None),
-            UniversalType::Text
+            Type::Text
         );
         // VARCHAR without length is treated as Text
         assert_eq!(
             postgresql_column_to_universal_type("varchar", None, None),
-            UniversalType::Text
+            Type::Text
         );
         assert_eq!(
             postgresql_column_to_universal_type("character varying", Some(255), None),
-            UniversalType::VarChar { length: 255 }
+            Type::VarChar { length: 255 }
         );
         assert_eq!(
             postgresql_column_to_universal_type("char", Some(10), None),
-            UniversalType::Char { length: 10 }
+            Type::Char { length: 10 }
         );
     }
 
@@ -187,27 +187,27 @@ mod tests {
     fn test_postgresql_datetime_types() {
         assert_eq!(
             postgresql_column_to_universal_type("timestamp", None, None),
-            UniversalType::LocalDateTime
+            Type::LocalDateTime
         );
         assert_eq!(
             postgresql_column_to_universal_type("timestamp without time zone", None, None),
-            UniversalType::LocalDateTime
+            Type::LocalDateTime
         );
         assert_eq!(
             postgresql_column_to_universal_type("timestamptz", None, None),
-            UniversalType::ZonedDateTime
+            Type::ZonedDateTime
         );
         assert_eq!(
             postgresql_column_to_universal_type("timestamp with time zone", None, None),
-            UniversalType::ZonedDateTime
+            Type::ZonedDateTime
         );
         assert_eq!(
             postgresql_column_to_universal_type("date", None, None),
-            UniversalType::Date
+            Type::Date
         );
         assert_eq!(
             postgresql_column_to_universal_type("time", None, None),
-            UniversalType::Time
+            Type::Time
         );
     }
 
@@ -215,7 +215,7 @@ mod tests {
     fn test_postgresql_uuid_type() {
         assert_eq!(
             postgresql_column_to_universal_type("uuid", None, None),
-            UniversalType::Uuid
+            Type::Uuid
         );
     }
 
@@ -223,11 +223,11 @@ mod tests {
     fn test_postgresql_json_types() {
         assert_eq!(
             postgresql_column_to_universal_type("json", None, None),
-            UniversalType::Json
+            Type::Json
         );
         assert_eq!(
             postgresql_column_to_universal_type("jsonb", None, None),
-            UniversalType::Jsonb
+            Type::Jsonb
         );
     }
 
@@ -235,7 +235,7 @@ mod tests {
     fn test_postgresql_geometry_types() {
         for geom_type in ["point", "line", "polygon", "box", "circle"] {
             let ut = postgresql_column_to_universal_type(geom_type, None, None);
-            assert!(matches!(ut, UniversalType::Geometry { .. }));
+            assert!(matches!(ut, Type::Geometry { .. }));
         }
     }
 
@@ -243,11 +243,11 @@ mod tests {
     fn test_postgresql_bool_type() {
         assert_eq!(
             postgresql_column_to_universal_type("boolean", None, None),
-            UniversalType::Bool
+            Type::Bool
         );
         assert_eq!(
             postgresql_column_to_universal_type("bool", None, None),
-            UniversalType::Bool
+            Type::Bool
         );
     }
 
@@ -255,7 +255,7 @@ mod tests {
     fn test_postgresql_bytes_type() {
         assert_eq!(
             postgresql_column_to_universal_type("bytea", None, None),
-            UniversalType::Bytes
+            Type::Bytes
         );
     }
 
@@ -264,13 +264,13 @@ mod tests {
         let ut = postgresql_column_to_universal_type("_int4", None, None);
         assert!(matches!(
             ut,
-            UniversalType::Array { element_type } if *element_type == UniversalType::Int32
+            Type::Array { element_type } if *element_type == Type::Int32
         ));
 
         let ut = postgresql_column_to_universal_type("_text", None, None);
         assert!(matches!(
             ut,
-            UniversalType::Array { element_type } if *element_type == UniversalType::Text
+            Type::Array { element_type } if *element_type == Type::Text
         ));
     }
 
@@ -278,7 +278,7 @@ mod tests {
     fn test_postgresql_interval_type() {
         assert_eq!(
             postgresql_column_to_universal_type("interval", None, None),
-            UniversalType::Duration
+            Type::Duration
         );
     }
 }

--- a/crates/postgresql-wal2json-source/src/change.rs
+++ b/crates/postgresql-wal2json-source/src/change.rs
@@ -5,15 +5,15 @@ use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
 use std::collections::HashMap;
 use std::fmt;
 use std::time::Duration;
-use sync_core::{UniversalType, UniversalValue};
+use sync_core::{Type, Value};
 
 /// Represents a database row with primary key and column data
 #[derive(Debug, Clone)]
 pub struct Row {
     /// Primary key value(s) - can be composite
-    pub primary_key: UniversalValue,
+    pub primary_key: Value,
     /// Map of column names to their values
-    pub columns: HashMap<String, UniversalValue>,
+    pub columns: HashMap<String, Value>,
     /// Schema name
     pub schema: String,
     /// Table name
@@ -124,7 +124,7 @@ pub fn wal2json_to_psql(wal2json_value: &serde_json::Value) -> Result<Action> {
                 .to_string();
 
             let mut columns = HashMap::new();
-            let mut primary_key_value = UniversalValue::Null;
+            let mut primary_key_value = Value::Null;
 
             // DELETE actions might have different structure
             // They may have "identity" instead of "columns" or just minimal columns
@@ -185,15 +185,15 @@ pub fn wal2json_to_psql(wal2json_value: &serde_json::Value) -> Result<Action> {
                     pk_values.into_iter().next().unwrap()
                 } else if pk_values.len() > 1 {
                     // Composite primary key - store as array
-                    UniversalValue::Array {
+                    Value::Array {
                         elements: pk_values,
-                        element_type: Box::new(UniversalType::Text),
+                        element_type: Box::new(Type::Text),
                     }
                 } else if let Some(id_value) = columns.get("id") {
                     // Fallback to 'id' column if no PK info
                     id_value.clone()
                 } else {
-                    UniversalValue::Null
+                    Value::Null
                 };
             } else if action_str == "D" {
                 // For DELETE with no columns, extract the full PK (including composites).
@@ -214,12 +214,12 @@ pub fn wal2json_to_psql(wal2json_value: &serde_json::Value) -> Result<Action> {
                     primary_key_value = if pk_values.len() == 1 {
                         pk_values.into_iter().next().unwrap()
                     } else if pk_values.len() > 1 {
-                        UniversalValue::Array {
+                        Value::Array {
                             elements: pk_values,
-                            element_type: Box::new(UniversalType::Text),
+                            element_type: Box::new(Type::Text),
                         }
                     } else {
-                        UniversalValue::Null
+                        Value::Null
                     };
                 }
             }
@@ -242,15 +242,15 @@ pub fn wal2json_to_psql(wal2json_value: &serde_json::Value) -> Result<Action> {
     }
 }
 
-/// Converts a PostgreSQL value from wal2json format to UniversalValue
+/// Converts a PostgreSQL value from wal2json format to Value
 fn convert_postgres_wal2json_value(
     value: Option<&serde_json::Value>,
     pg_type: &str,
-) -> Result<UniversalValue> {
+) -> Result<Value> {
     // Handle NULL values
     let value = match value {
         Some(v) if !v.is_null() => v,
-        _ => return Ok(UniversalValue::Null),
+        _ => return Ok(Value::Null),
     };
 
     // Convert based on PostgreSQL type
@@ -258,23 +258,23 @@ fn convert_postgres_wal2json_value(
         // Numeric types
         "smallint" | "int2" => {
             let val = value.as_i64().context("Failed to parse smallint")?;
-            Ok(UniversalValue::Int16(val as i16))
+            Ok(Value::Int16(val as i16))
         }
         "integer" | "int" | "int4" => {
             let val = value.as_i64().context("Failed to parse integer")?;
-            Ok(UniversalValue::Int32(val as i32))
+            Ok(Value::Int32(val as i32))
         }
         "bigint" | "int8" => {
             let val = value.as_i64().context("Failed to parse bigint")?;
-            Ok(UniversalValue::Int64(val))
+            Ok(Value::Int64(val))
         }
         "real" | "float4" => {
             let val = value.as_f64().context("Failed to parse real")?;
-            Ok(UniversalValue::Float32(val as f32))
+            Ok(Value::Float32(val as f32))
         }
         "double precision" | "float8" => {
             let val = value.as_f64().context("Failed to parse double")?;
-            Ok(UniversalValue::Float64(val))
+            Ok(Value::Float64(val))
         }
         "numeric" | "decimal" => {
             // Store as string to preserve precision
@@ -285,7 +285,7 @@ fn convert_postgres_wal2json_value(
             } else {
                 bail!("Failed to parse numeric value")
             };
-            Ok(UniversalValue::Decimal {
+            Ok(Value::Decimal {
                 value: val,
                 precision: 38,
                 scale: 10,
@@ -295,14 +295,14 @@ fn convert_postgres_wal2json_value(
         // String types
         "text" => {
             let val = value.as_str().context("Failed to parse text")?.to_string();
-            Ok(UniversalValue::Text(val))
+            Ok(Value::Text(val))
         }
         s if s.starts_with("character varying") || s.starts_with("varchar") => {
             let val = value
                 .as_str()
                 .context("Failed to parse varchar")?
                 .to_string();
-            Ok(UniversalValue::VarChar {
+            Ok(Value::VarChar {
                 value: val,
                 length: 255,
             })
@@ -310,7 +310,7 @@ fn convert_postgres_wal2json_value(
         s if s.starts_with("character") || s.starts_with("char") => {
             let val = value.as_str().context("Failed to parse char")?.to_string();
             let len = val.len() as u16;
-            Ok(UniversalValue::Char {
+            Ok(Value::Char {
                 value: val,
                 length: len.max(1),
             })
@@ -319,7 +319,7 @@ fn convert_postgres_wal2json_value(
         // Boolean
         "boolean" | "bool" => {
             let val = value.as_bool().context("Failed to parse boolean")?;
-            Ok(UniversalValue::Bool(val))
+            Ok(Value::Bool(val))
         }
 
         // Binary
@@ -327,7 +327,7 @@ fn convert_postgres_wal2json_value(
             let hex_str = value.as_str().context("Failed to parse bytea")?;
             // wal2json returns bytea as hex string without \x prefix
             let bytes = hex::decode(hex_str).context("Failed to decode bytea hex string")?;
-            Ok(UniversalValue::Bytes(bytes))
+            Ok(Value::Bytes(bytes))
         }
 
         // UUID
@@ -335,7 +335,7 @@ fn convert_postgres_wal2json_value(
             let val = value.as_str().context("Failed to parse uuid")?;
             let parsed_uuid = uuid::Uuid::parse_str(val)
                 .map_err(|e| anyhow::anyhow!("Failed to parse UUID '{val}': {e}"))?;
-            Ok(UniversalValue::Uuid(parsed_uuid))
+            Ok(Value::Uuid(parsed_uuid))
         }
 
         // JSON types
@@ -344,14 +344,14 @@ fn convert_postgres_wal2json_value(
             let json_str = value.as_str().context("Failed to get JSON string")?;
             let parsed: serde_json::Value =
                 serde_json::from_str(json_str).context("Failed to parse JSON")?;
-            Ok(UniversalValue::Json(Box::new(parsed)))
+            Ok(Value::Json(Box::new(parsed)))
         }
         "jsonb" => {
             // wal2json returns JSONB as a string, we need to parse it
             let json_str = value.as_str().context("Failed to get JSONB string")?;
             let parsed: serde_json::Value =
                 serde_json::from_str(json_str).context("Failed to parse JSONB")?;
-            Ok(UniversalValue::Jsonb(Box::new(parsed)))
+            Ok(Value::Jsonb(Box::new(parsed)))
         }
 
         // Date/Time types
@@ -359,25 +359,25 @@ fn convert_postgres_wal2json_value(
             let val = value.as_str().context("Failed to parse timestamp")?;
             let dt = parse_timestamp(val)
                 .map_err(|e| anyhow::anyhow!("Failed to parse timestamp '{val}': {e}"))?;
-            Ok(UniversalValue::LocalDateTime(dt))
+            Ok(Value::LocalDateTime(dt))
         }
         "timestamptz" | "timestamp with time zone" => {
             let val = value.as_str().context("Failed to parse timestamptz")?;
             let dt = parse_timestamptz(val)
                 .map_err(|e| anyhow::anyhow!("Failed to parse timestamptz '{val}': {e}"))?;
-            Ok(UniversalValue::ZonedDateTime(dt))
+            Ok(Value::ZonedDateTime(dt))
         }
         "date" => {
             let val = value.as_str().context("Failed to parse date")?;
             let dt = parse_date(val)
                 .map_err(|e| anyhow::anyhow!("Failed to parse date '{val}': {e}"))?;
-            Ok(UniversalValue::Date(dt))
+            Ok(Value::Date(dt))
         }
         "time" | "time without time zone" => {
             let val = value.as_str().context("Failed to parse time")?;
             let dt = parse_time(val)
                 .map_err(|e| anyhow::anyhow!("Failed to parse time '{val}': {e}"))?;
-            Ok(UniversalValue::Time(dt))
+            Ok(Value::Time(dt))
         }
         "timetz" | "time with time zone" => {
             let val = value.as_str().context("Failed to parse timetz")?;
@@ -385,13 +385,13 @@ fn convert_postgres_wal2json_value(
             // Time and datetime are fundamentally different types - datetime implies
             // a specific point in time, while TIMETZ represents a daily recurring time
             // in a specific timezone. Using ZonedDateTime would misrepresent the semantics.
-            Ok(UniversalValue::TimeTz(val.to_string()))
+            Ok(Value::TimeTz(val.to_string()))
         }
         "interval" => {
             let val = value.as_str().context("Failed to parse interval")?;
             let dur = parse_interval(val)
                 .map_err(|e| anyhow::anyhow!("Failed to parse interval '{val}': {e}"))?;
-            Ok(UniversalValue::Duration(dur))
+            Ok(Value::Duration(dur))
         }
 
         // Array types
@@ -401,7 +401,7 @@ fn convert_postgres_wal2json_value(
 
             // Parse PostgreSQL array format
             let (parsed_array, element_type) = parse_postgres_array(array_str, s)?;
-            Ok(UniversalValue::Array {
+            Ok(Value::Array {
                 elements: parsed_array,
                 element_type: Box::new(element_type),
             })
@@ -410,16 +410,13 @@ fn convert_postgres_wal2json_value(
         // Default fallback to text
         _ => {
             let val = value.to_string();
-            Ok(UniversalValue::Text(val))
+            Ok(Value::Text(val))
         }
     }
 }
 
 /// Parses PostgreSQL array format like "{1,2,3}" or "{apple,banana,cherry}"
-fn parse_postgres_array(
-    array_str: &str,
-    array_type: &str,
-) -> Result<(Vec<UniversalValue>, UniversalType)> {
+fn parse_postgres_array(array_str: &str, array_type: &str) -> Result<(Vec<Value>, Type)> {
     // Remove the curly braces
     let trimmed = array_str.trim_start_matches('{').trim_end_matches('}');
 
@@ -446,38 +443,38 @@ fn parse_postgres_array(
                 let val = elem
                     .parse::<i32>()
                     .context("Failed to parse integer array element")?;
-                UniversalValue::Int32(val)
+                Value::Int32(val)
             }
             "bigint" | "int8" => {
                 let val = elem
                     .parse::<i64>()
                     .context("Failed to parse bigint array element")?;
-                UniversalValue::Int64(val)
+                Value::Int64(val)
             }
             "smallint" | "int2" => {
                 let val = elem
                     .parse::<i16>()
                     .context("Failed to parse smallint array element")?;
-                UniversalValue::Int16(val)
+                Value::Int16(val)
             }
             "real" | "float4" => {
                 let val = elem
                     .parse::<f32>()
                     .context("Failed to parse real array element")?;
-                UniversalValue::Float32(val)
+                Value::Float32(val)
             }
             "double precision" | "float8" => {
                 let val = elem
                     .parse::<f64>()
                     .context("Failed to parse double array element")?;
-                UniversalValue::Float64(val)
+                Value::Float64(val)
             }
-            "text" | "varchar" => UniversalValue::Text(elem.to_string()),
+            "text" | "varchar" => Value::Text(elem.to_string()),
             "boolean" | "bool" => {
                 let val = elem
                     .parse::<bool>()
                     .context("Failed to parse boolean array element")?;
-                UniversalValue::Bool(val)
+                Value::Bool(val)
             }
             _ => {
                 return Err(anyhow::anyhow!(
@@ -492,17 +489,17 @@ fn parse_postgres_array(
     Ok((result, element_type))
 }
 
-/// Helper to determine UniversalType from PostgreSQL array type string
-fn array_type_to_universal_type(array_type: &str) -> Result<UniversalType> {
+/// Helper to determine Type from PostgreSQL array type string
+fn array_type_to_universal_type(array_type: &str) -> Result<Type> {
     let element_type_str = array_type.trim_end_matches("[]");
     match element_type_str {
-        "integer" | "int" | "int4" => Ok(UniversalType::Int32),
-        "bigint" | "int8" => Ok(UniversalType::Int64),
-        "smallint" | "int2" => Ok(UniversalType::Int16),
-        "real" | "float4" => Ok(UniversalType::Float32),
-        "double precision" | "float8" => Ok(UniversalType::Float64),
-        "boolean" | "bool" => Ok(UniversalType::Bool),
-        "text" | "varchar" => Ok(UniversalType::Text),
+        "integer" | "int" | "int4" => Ok(Type::Int32),
+        "bigint" | "int8" => Ok(Type::Int64),
+        "smallint" | "int2" => Ok(Type::Int16),
+        "real" | "float4" => Ok(Type::Float32),
+        "double precision" | "float8" => Ok(Type::Float64),
+        "boolean" | "bool" => Ok(Type::Bool),
+        "text" | "varchar" => Ok(Type::Text),
         _ => Err(anyhow::anyhow!(
             "Unsupported array element type: '{element_type_str}'"
         )),
@@ -912,12 +909,12 @@ mod tests {
             Action::Insert(row) => {
                 assert_eq!(row.table, "users");
                 assert_eq!(row.schema, "public");
-                assert_eq!(row.primary_key, UniversalValue::Int32(1));
+                assert_eq!(row.primary_key, Value::Int32(1));
                 assert_eq!(
                     row.columns.get("name"),
-                    Some(&UniversalValue::Text("Alice".to_string()))
+                    Some(&Value::Text("Alice".to_string()))
                 );
-                assert_eq!(row.columns.get("active"), Some(&UniversalValue::Bool(true)));
+                assert_eq!(row.columns.get("active"), Some(&Value::Bool(true)));
             }
             _ => panic!("Expected Insert action"),
         }
@@ -941,19 +938,19 @@ mod tests {
         match action {
             Action::Insert(row) => {
                 // Check integer array
-                if let Some(UniversalValue::Array { elements, .. }) = row.columns.get("numbers") {
+                if let Some(Value::Array { elements, .. }) = row.columns.get("numbers") {
                     assert_eq!(elements.len(), 5);
-                    assert_eq!(elements[0], UniversalValue::Int32(1));
-                    assert_eq!(elements[4], UniversalValue::Int32(5));
+                    assert_eq!(elements[0], Value::Int32(1));
+                    assert_eq!(elements[4], Value::Int32(5));
                 } else {
                     panic!("Expected integer array");
                 }
 
                 // Check text array
-                if let Some(UniversalValue::Array { elements, .. }) = row.columns.get("fruits") {
+                if let Some(Value::Array { elements, .. }) = row.columns.get("fruits") {
                     assert_eq!(elements.len(), 3);
-                    assert_eq!(elements[0], UniversalValue::Text("apple".to_string()));
-                    assert_eq!(elements[2], UniversalValue::Text("cherry".to_string()));
+                    assert_eq!(elements[0], Value::Text("apple".to_string()));
+                    assert_eq!(elements[2], Value::Text("cherry".to_string()));
                 } else {
                     panic!("Expected text array");
                 }
@@ -982,28 +979,25 @@ mod tests {
 
         match action {
             Action::Insert(row) => {
-                assert_eq!(row.columns.get("small"), Some(&UniversalValue::Int16(123)));
-                assert_eq!(
-                    row.columns.get("normal"),
-                    Some(&UniversalValue::Int32(456789))
-                );
+                assert_eq!(row.columns.get("small"), Some(&Value::Int16(123)));
+                assert_eq!(row.columns.get("normal"), Some(&Value::Int32(456789)));
                 assert_eq!(
                     row.columns.get("big"),
-                    Some(&UniversalValue::Int64(9223372036854775807))
+                    Some(&Value::Int64(9223372036854775807))
                 );
-                if let Some(UniversalValue::Float32(v)) = row.columns.get("real_num") {
+                if let Some(Value::Float32(v)) = row.columns.get("real_num") {
                     assert!((v - 3.25).abs() < 0.01);
                 } else {
                     panic!("Expected Float32");
                 }
-                if let Some(UniversalValue::Float64(v)) = row.columns.get("double_num") {
+                if let Some(Value::Float64(v)) = row.columns.get("double_num") {
                     assert!((v - 2.567891234).abs() < 0.0001);
                 } else {
                     panic!("Expected Float64");
                 }
                 assert_eq!(
                     row.columns.get("decimal_num"),
-                    Some(&UniversalValue::Decimal {
+                    Some(&Value::Decimal {
                         value: "123.456".to_string(),
                         precision: 38,
                         scale: 10
@@ -1031,12 +1025,12 @@ mod tests {
 
         match action {
             Action::Insert(row) => {
-                if let Some(UniversalValue::Json(json_val)) = row.columns.get("json_col") {
+                if let Some(Value::Json(json_val)) = row.columns.get("json_col") {
                     assert_eq!(json_val.get("key").and_then(|v| v.as_str()), Some("value"));
                 } else {
                     panic!("Expected Json value");
                 }
-                if let Some(UniversalValue::Jsonb(jsonb_val)) = row.columns.get("jsonb_col") {
+                if let Some(Value::Jsonb(jsonb_val)) = row.columns.get("jsonb_col") {
                     assert_eq!(
                         jsonb_val
                             .get("nested")
@@ -1069,12 +1063,12 @@ mod tests {
 
         match action {
             Action::Insert(row) => {
-                if let Some(UniversalValue::Uuid(uuid_val)) = row.columns.get("uuid_col") {
+                if let Some(Value::Uuid(uuid_val)) = row.columns.get("uuid_col") {
                     assert_eq!(uuid_val.to_string(), "550e8400-e29b-41d4-a716-446655440000");
                 } else {
                     panic!("Expected Uuid value");
                 }
-                if let Some(UniversalValue::Bytes(bytes_val)) = row.columns.get("bytea_col") {
+                if let Some(Value::Bytes(bytes_val)) = row.columns.get("bytea_col") {
                     assert_eq!(bytes_val, &vec![72, 101, 108, 108, 111]); // "Hello" in ASCII
                 } else {
                     panic!("Expected Bytes value");

--- a/crates/postgresql-wal2json-source/src/full_sync.rs
+++ b/crates/postgresql-wal2json-source/src/full_sync.rs
@@ -156,7 +156,7 @@ async fn migrate_one_table_keyset<S: surreal_sink::SurrealSink>(
         get_primary_key_columns, read_offset_relation_chunk, read_offset_table_chunk,
         read_relation_chunk, read_table_chunk,
     };
-    use sync_core::{classify_table, TableKind, UniversalRelation, UniversalRow, UniversalValue};
+    use sync_core::{classify_table, Relation, Row, TableKind, Value};
     use sync_transform::{
         run_source_runtime_with, RelationChunkDriver, RelationChunkSource, RowChunkDriver,
         RowChunkSource, SourceRuntimeOpts,
@@ -189,7 +189,7 @@ async fn migrate_one_table_keyset<S: surreal_sink::SurrealSink>(
                     }
                 }
             } else {
-                let mut after: Option<Vec<UniversalValue>> = None;
+                let mut after: Option<Vec<Value>> = None;
                 let mut base = 0u64;
                 loop {
                     let chunk = read_relation_chunk(
@@ -235,7 +235,7 @@ async fn migrate_one_table_keyset<S: surreal_sink::SurrealSink>(
             }
             #[async_trait]
             impl RelationChunkSource for OffsetRel<'_> {
-                async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<UniversalRelation>>> {
+                async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<Relation>>> {
                     if self.exhausted {
                         return Ok(None);
                     }
@@ -284,7 +284,7 @@ async fn migrate_one_table_keyset<S: surreal_sink::SurrealSink>(
             client: &'a tokio_postgres::Client,
             table_name: &'a str,
             pk_columns: &'a [String],
-            after: Option<Vec<UniversalValue>>,
+            after: Option<Vec<Value>>,
             batch_size: usize,
             in_fk: &'a sync_core::ForeignKeyDefinition,
             out_fk: &'a sync_core::ForeignKeyDefinition,
@@ -293,7 +293,7 @@ async fn migrate_one_table_keyset<S: surreal_sink::SurrealSink>(
         }
         #[async_trait]
         impl RelationChunkSource for KeysetRel<'_> {
-            async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<UniversalRelation>>> {
+            async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<Relation>>> {
                 if self.exhausted {
                     return Ok(None);
                 }
@@ -385,7 +385,7 @@ async fn migrate_one_table_keyset<S: surreal_sink::SurrealSink>(
         }
         #[async_trait]
         impl RowChunkSource for OffsetRows<'_> {
-            async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<UniversalRow>>> {
+            async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<Row>>> {
                 if self.exhausted {
                     return Ok(None);
                 }
@@ -432,7 +432,7 @@ async fn migrate_one_table_keyset<S: surreal_sink::SurrealSink>(
 
     if sync_opts.dry_run {
         let mut total = 0usize;
-        let mut after: Option<Vec<sync_core::UniversalValue>> = None;
+        let mut after: Option<Vec<sync_core::Value>> = None;
         loop {
             let chunk = read_table_chunk(
                 client,
@@ -460,7 +460,7 @@ async fn migrate_one_table_keyset<S: surreal_sink::SurrealSink>(
         client: &'a tokio_postgres::Client,
         table_name: &'a str,
         pk_columns: &'a [String],
-        after: Option<Vec<sync_core::UniversalValue>>,
+        after: Option<Vec<sync_core::Value>>,
         batch_size: usize,
         schema: Option<&'a sync_core::DatabaseSchema>,
         exhausted: bool,
@@ -468,7 +468,7 @@ async fn migrate_one_table_keyset<S: surreal_sink::SurrealSink>(
 
     #[async_trait]
     impl RowChunkSource for PgKeysetChunks<'_> {
-        async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<UniversalRow>>> {
+        async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<Row>>> {
             if self.exhausted {
                 return Ok(None);
             }

--- a/crates/postgresql-wal2json-source/src/incremental_sync.rs
+++ b/crates/postgresql-wal2json-source/src/incremental_sync.rs
@@ -7,10 +7,7 @@ use anyhow::Result;
 use checkpoint::{CheckpointID, CheckpointStore, Surreal2Store};
 use chrono::{DateTime, Utc};
 use surreal_sink::SurrealSink;
-use sync_core::{
-    classify_table, DatabaseSchema, TableKind, UniversalChange, UniversalChangeOp,
-    UniversalRelationChange,
-};
+use sync_core::{classify_table, Change, ChangeOp, DatabaseSchema, RelationChange, TableKind};
 use sync_transform::{
     ApplyOpts, CheckpointPolicy, Pipeline, PositionedEvent, SourceDriver, SourceRuntimeOpts,
     StopReason,
@@ -244,21 +241,21 @@ impl Wal2JsonSourceDriver<'_> {
                         "INSERT: table={}, primary_key={:?}",
                         row.table, row.primary_key
                     );
-                    (row, UniversalChangeOp::Create)
+                    (row, ChangeOp::Create)
                 }
                 crate::Action::Update(row) => {
                     debug!(
                         "UPDATE: table={}, primary_key={:?}",
                         row.table, row.primary_key
                     );
-                    (row, UniversalChangeOp::Update)
+                    (row, ChangeOp::Update)
                 }
                 crate::Action::Delete(row) => {
                     debug!(
                         "DELETE: table={}, primary_key={:?}",
                         row.table, row.primary_key
                     );
-                    (row, UniversalChangeOp::Delete)
+                    (row, ChangeOp::Delete)
                 }
                 crate::Action::Begin { .. } | crate::Action::Commit { .. } => continue,
             };
@@ -441,20 +438,20 @@ impl SourceDriver for Wal2JsonSourceDriver<'_> {
     }
 }
 
-/// Convert a Row to UniversalChange
-fn row_to_universal_change(row: &crate::Row, op: UniversalChangeOp) -> UniversalChange {
-    let data = if op == UniversalChangeOp::Delete {
+/// Convert a Row to Change
+fn row_to_change(row: &crate::Row, op: ChangeOp) -> Change {
+    let data = if op == ChangeOp::Delete {
         None
     } else {
         Some(row.columns.clone())
     };
-    UniversalChange::new(op, row.table.clone(), row.primary_key.clone(), data)
+    Change::new(op, row.table.clone(), row.primary_key.clone(), data)
 }
 
 /// FK enrichment and relation routing before the event enters the apply window.
 fn action_to_positioned_event(
     row: &crate::Row,
-    op: UniversalChangeOp,
+    op: ChangeOp,
     position: Lsn,
     db_schema: &DatabaseSchema,
     relation_table_overrides: &[String],
@@ -467,7 +464,7 @@ fn action_to_positioned_event(
             ref in_fk,
             ref out_fk,
         }) => {
-            let data = if op == UniversalChangeOp::Delete {
+            let data = if op == ChangeOp::Delete {
                 std::collections::HashMap::new()
             } else {
                 row.columns.clone()
@@ -479,12 +476,12 @@ fn action_to_positioned_event(
                 in_fk,
                 out_fk,
             );
-            let rel_change = UniversalRelationChange::new(op, relation);
+            let rel_change = RelationChange::new(op, relation);
             Ok(PositionedEvent::relation_change(rel_change, position))
         }
         _ => {
-            let mut change = row_to_universal_change(row, op);
-            if let (Some(td), Some(ref mut data)) = (table_def, change.data.as_mut()) {
+            let mut change = row_to_change(row, op);
+            if let (Some(td), Some(ref mut data)) = (table_def, change.fields.as_mut()) {
                 surreal_sync_postgresql::fk_transform::transform_fk_values(data, td);
             }
             Ok(PositionedEvent::change(change, position))

--- a/crates/postgresql-wal2json-source/src/watermark_source.rs
+++ b/crates/postgresql-wal2json-source/src/watermark_source.rs
@@ -31,7 +31,7 @@ use surreal_sync_interleaved_snapshot::{
     ReconciliationEvent, SnapshotSignal, SnapshotTransforms, TableSpec, WatermarkKind,
     WatermarkSource,
 };
-use sync_core::{UniversalChange, UniversalChangeOp, UniversalRow, UniversalValue};
+use sync_core::{Change, ChangeOp, Row, Value};
 use tokio::sync::Mutex;
 use tokio_postgres::NoTls;
 use tracing::{debug, info};
@@ -306,21 +306,17 @@ impl Wal2JsonWatermarkSource {
     /// but PostgreSQL's wire protocol rejects an `int8` parameter bound against
     /// an `int4`/`int2` column. This narrows the cursor values back to the
     /// column's actual type so the bound parameter type matches.
-    async fn coerce_after(
-        &self,
-        table: &TableSpec,
-        after: &PkTuple,
-    ) -> Result<Vec<UniversalValue>> {
+    async fn coerce_after(&self, table: &TableSpec, after: &PkTuple) -> Result<Vec<Value>> {
         let types = self.column_type_oids(&table.table).await?;
         let mut out = Vec::with_capacity(after.0.len());
         for (col, value) in table.pk_columns.iter().zip(after.0.iter()) {
             let coerced = match (value, types.get(col).copied()) {
-                (UniversalValue::Int64(n), Some(OID_INT4)) => UniversalValue::Int32(*n as i32),
-                (UniversalValue::Int64(n), Some(OID_INT2)) => UniversalValue::Int16(*n as i16),
-                (UniversalValue::Int32(n), Some(OID_INT8)) => UniversalValue::Int64(*n as i64),
-                (UniversalValue::Int32(n), Some(OID_INT2)) => UniversalValue::Int16(*n as i16),
-                (UniversalValue::Int16(n), Some(OID_INT8)) => UniversalValue::Int64(*n as i64),
-                (UniversalValue::Int16(n), Some(OID_INT4)) => UniversalValue::Int32(*n as i32),
+                (Value::Int64(n), Some(OID_INT4)) => Value::Int32(*n as i32),
+                (Value::Int64(n), Some(OID_INT2)) => Value::Int16(*n as i16),
+                (Value::Int32(n), Some(OID_INT8)) => Value::Int64(*n as i64),
+                (Value::Int32(n), Some(OID_INT2)) => Value::Int16(*n as i16),
+                (Value::Int16(n), Some(OID_INT8)) => Value::Int64(*n as i64),
+                (Value::Int16(n), Some(OID_INT4)) => Value::Int32(*n as i32),
                 (other, _) => other.clone(),
             };
             out.push(coerced);
@@ -345,19 +341,19 @@ impl Wal2JsonWatermarkSource {
 /// wal2json reports them as `Int16`/`Int32`. Widening here keeps both
 /// representations of the same key byte-identical when serialized as the
 /// buffer's dedup key.
-fn normalize_pk_value(value: &UniversalValue) -> UniversalValue {
+fn normalize_pk_value(value: &Value) -> Value {
     match value {
-        UniversalValue::Int16(n) => UniversalValue::Int64(*n as i64),
-        UniversalValue::Int32(n) => UniversalValue::Int64(*n as i64),
+        Value::Int16(n) => Value::Int64(*n as i64),
+        Value::Int32(n) => Value::Int64(*n as i64),
         other => other.clone(),
     }
 }
 
 /// Build a [`PkTuple`] from a change's primary key, matching how the framework
 /// derives the buffer key from a snapshot row.
-fn pk_tuple_from_primary_key(pk: &UniversalValue) -> PkTuple {
+fn pk_tuple_from_primary_key(pk: &Value) -> PkTuple {
     match pk {
-        UniversalValue::Array { elements, .. } => {
+        Value::Array { elements, .. } => {
             PkTuple::new(elements.iter().map(normalize_pk_value).collect())
         }
         single => PkTuple::new(vec![normalize_pk_value(single)]),
@@ -366,20 +362,20 @@ fn pk_tuple_from_primary_key(pk: &UniversalValue) -> PkTuple {
 
 /// Convert a decoded WAL action into a stream event payload, or `None` for
 /// transaction markers.
-fn action_to_event(action: &Action) -> Option<(String, PkTuple, UniversalChange)> {
+fn action_to_event(action: &Action) -> Option<(String, PkTuple, Change)> {
     let (row, op) = match action {
-        Action::Insert(row) => (row, UniversalChangeOp::Create),
-        Action::Update(row) => (row, UniversalChangeOp::Update),
-        Action::Delete(row) => (row, UniversalChangeOp::Delete),
+        Action::Insert(row) => (row, ChangeOp::Create),
+        Action::Update(row) => (row, ChangeOp::Update),
+        Action::Delete(row) => (row, ChangeOp::Delete),
         Action::Begin { .. } | Action::Commit { .. } => return None,
     };
     let pk = pk_tuple_from_primary_key(&row.primary_key);
-    let data = if op == UniversalChangeOp::Delete {
+    let data = if op == ChangeOp::Delete {
         None
     } else {
         Some(row.columns.clone())
     };
-    let change = UniversalChange::new(op, row.table.clone(), row.primary_key.clone(), data);
+    let change = Change::new(op, row.table.clone(), row.primary_key.clone(), data);
     Some((row.table.clone(), pk, change))
 }
 
@@ -420,8 +416,8 @@ impl WatermarkSource for Wal2JsonWatermarkSource {
         table: &TableSpec,
         after: Option<&PkTuple>,
         limit: usize,
-    ) -> Result<Vec<UniversalRow>> {
-        let after_values: Option<Vec<UniversalValue>> = match after {
+    ) -> Result<Vec<Row>> {
+        let after_values: Option<Vec<Value>> = match after {
             Some(pk) => Some(self.coerce_after(table, pk).await?),
             None => None,
         };
@@ -725,8 +721,8 @@ mod tests {
 
     #[test]
     fn pk_tuple_widens_small_integers() {
-        let from_stream = pk_tuple_from_primary_key(&UniversalValue::Int32(42));
-        let from_snapshot = PkTuple::new(vec![UniversalValue::Int64(42)]);
+        let from_stream = pk_tuple_from_primary_key(&Value::Int32(42));
+        let from_snapshot = PkTuple::new(vec![Value::Int64(42)]);
         assert_eq!(from_stream.key(), from_snapshot.key());
     }
 }

--- a/crates/postgresql-wal2json-source/tests/suite/conversion.rs
+++ b/crates/postgresql-wal2json-source/tests/suite/conversion.rs
@@ -2,7 +2,7 @@
 
 use anyhow::{Context, Result};
 use surreal_sync_postgresql_wal2json_source::{Action, Client};
-use sync_core::UniversalValue;
+use sync_core::Value;
 use tokio_postgres::NoTls;
 use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -107,25 +107,25 @@ async fn test_wal2json_to_psql_conversion() -> Result<()> {
 
             // Check primary key (integer 123 becomes Int32)
             assert!(
-                matches!(row.primary_key, UniversalValue::Int32(123)),
+                matches!(row.primary_key, Value::Int32(123)),
                 "Expected Int32(123), got {:?}",
                 row.primary_key
             );
 
             // Check columns
             assert!(
-                matches!(row.columns.get("name"), Some(UniversalValue::Text(s)) if s == "Test Name"),
+                matches!(row.columns.get("name"), Some(Value::Text(s)) if s == "Test Name"),
                 "Expected Text('Test Name'), got {:?}",
                 row.columns.get("name")
             );
             assert!(
-                matches!(row.columns.get("active"), Some(UniversalValue::Bool(true))),
+                matches!(row.columns.get("active"), Some(Value::Bool(true))),
                 "Expected Bool(true), got {:?}",
                 row.columns.get("active")
             );
 
             // Check float (PostgreSQL REAL maps to Float32)
-            if let Some(UniversalValue::Float32(score)) = row.columns.get("score") {
+            if let Some(Value::Float32(score)) = row.columns.get("score") {
                 assert!((score - std::f32::consts::PI).abs() < 0.001);
             } else {
                 panic!(
@@ -135,7 +135,7 @@ async fn test_wal2json_to_psql_conversion() -> Result<()> {
             }
 
             // Check JSON
-            if let Some(UniversalValue::Json(json_val)) = row.columns.get("data") {
+            if let Some(Value::Json(json_val)) = row.columns.get("data") {
                 assert_eq!(json_val.get("key").and_then(|v| v.as_str()), Some("value"));
                 assert_eq!(
                     json_val
@@ -152,20 +152,20 @@ async fn test_wal2json_to_psql_conversion() -> Result<()> {
             }
 
             // Check array
-            if let Some(UniversalValue::Array { elements, .. }) = row.columns.get("tags") {
+            if let Some(Value::Array { elements, .. }) = row.columns.get("tags") {
                 assert_eq!(elements.len(), 3);
                 assert!(
-                    matches!(&elements[0], UniversalValue::Text(s) if s == "tag1"),
+                    matches!(&elements[0], Value::Text(s) if s == "tag1"),
                     "Expected Text('tag1'), got {:?}",
                     elements[0]
                 );
                 assert!(
-                    matches!(&elements[1], UniversalValue::Text(s) if s == "tag2"),
+                    matches!(&elements[1], Value::Text(s) if s == "tag2"),
                     "Expected Text('tag2'), got {:?}",
                     elements[1]
                 );
                 assert!(
-                    matches!(&elements[2], UniversalValue::Text(s) if s == "tag3"),
+                    matches!(&elements[2], Value::Text(s) if s == "tag3"),
                     "Expected Text('tag3'), got {:?}",
                     elements[2]
                 );
@@ -201,17 +201,17 @@ async fn test_wal2json_to_psql_conversion() -> Result<()> {
         Action::Update(row) => {
             info!("Converted to Update action");
             assert!(
-                matches!(row.primary_key, UniversalValue::Int32(123)),
+                matches!(row.primary_key, Value::Int32(123)),
                 "Expected Int32(123), got {:?}",
                 row.primary_key
             );
             assert!(
-                matches!(row.columns.get("name"), Some(UniversalValue::Text(s)) if s == "Updated Name"),
+                matches!(row.columns.get("name"), Some(Value::Text(s)) if s == "Updated Name"),
                 "Expected Text('Updated Name'), got {:?}",
                 row.columns.get("name")
             );
             assert!(
-                matches!(row.columns.get("active"), Some(UniversalValue::Bool(false))),
+                matches!(row.columns.get("active"), Some(Value::Bool(false))),
                 "Expected Bool(false), got {:?}",
                 row.columns.get("active")
             );
@@ -237,7 +237,7 @@ async fn test_wal2json_to_psql_conversion() -> Result<()> {
         Action::Delete(row) => {
             info!("Converted to Delete action");
             assert!(
-                matches!(row.primary_key, UniversalValue::Int32(123)),
+                matches!(row.primary_key, Value::Int32(123)),
                 "Expected Int32(123), got {:?}",
                 row.primary_key
             );

--- a/crates/postgresql-wal2json-source/tests/suite/date.rs
+++ b/crates/postgresql-wal2json-source/tests/suite/date.rs
@@ -3,7 +3,7 @@
 
 use anyhow::{Context, Result};
 use surreal_sync_postgresql_wal2json_source::{Action, Client};
-use sync_core::UniversalValue;
+use sync_core::Value;
 use tokio_postgres::NoTls;
 use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -160,13 +160,13 @@ async fn test_date_replication_formats() -> Result<()> {
 
                 // Verify it's a Date value (date values are converted to DateTime<Utc> at midnight)
                 match event_date {
-                    UniversalValue::Date(dt) => {
+                    Value::Date(dt) => {
                         let date_str = dt.format("%Y-%m-%d").to_string();
                         info!("Date value: {} (DateTime: {})", date_str, dt);
 
                         // Get the ID to verify specific expected values
                         let id = match row.primary_key {
-                            UniversalValue::Int32(i) => i,
+                            Value::Int32(i) => i,
                             _ => panic!("Expected Int32 primary key, got {:?}", row.primary_key),
                         };
 
@@ -237,7 +237,7 @@ async fn test_date_replication_formats() -> Result<()> {
                 .context("Should have event_date column in UPDATE")?;
 
             match event_date {
-                UniversalValue::Date(dt) => {
+                Value::Date(dt) => {
                     let date_str = dt.format("%Y-%m-%d").to_string();
                     info!("UPDATE date value: {} (DateTime: {})", date_str, dt);
                     assert_eq!(date_str, "2025-12-25", "Updated date should be 2025-12-25");

--- a/crates/postgresql-wal2json-source/tests/suite/interleaved_snapshot.rs
+++ b/crates/postgresql-wal2json-source/tests/suite/interleaved_snapshot.rs
@@ -99,7 +99,7 @@ async fn drain_to_catch_up(
             if event.table == signal_table {
                 continue;
             }
-            sink.apply_universal_change(&event.change).await?;
+            sink.apply_change(&event.change).await?;
         }
         let pos = source.current_position().await?;
         source.commit_reconciled(pos).await?;

--- a/crates/postgresql-wal2json-source/tests/suite/interval.rs
+++ b/crates/postgresql-wal2json-source/tests/suite/interval.rs
@@ -4,7 +4,7 @@
 use anyhow::{Context, Result};
 use std::time::Duration;
 use surreal_sync_postgresql_wal2json_source::{Action, Client};
-use sync_core::UniversalValue;
+use sync_core::Value;
 use tokio_postgres::NoTls;
 use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -179,13 +179,13 @@ async fn test_interval_replication_formats() -> Result<()> {
 
                 // Get the ID to verify specific expected values
                 let id = match row.primary_key {
-                    UniversalValue::Int32(i) => i,
+                    Value::Int32(i) => i,
                     _ => panic!("Expected Int32 primary key, got {:?}", row.primary_key),
                 };
 
-                // Verify it's a Duration value (intervals are converted to Duration in UniversalValue)
+                // Verify it's a Duration value (intervals are converted to Duration in Value)
                 let duration = match duration_field {
-                    UniversalValue::Duration(d) => d,
+                    Value::Duration(d) => d,
                     _ => panic!(
                         "Expected Duration value for interval, got {:?}",
                         duration_field
@@ -272,7 +272,7 @@ async fn test_interval_replication_formats() -> Result<()> {
                 .context("Should have duration column in UPDATE")?;
 
             let duration = match duration_field {
-                UniversalValue::Duration(d) => d,
+                Value::Duration(d) => d,
                 _ => panic!(
                     "Expected Duration value in UPDATE, got {:?}",
                     duration_field

--- a/crates/postgresql-wal2json-source/tests/suite/no_pk_offset.rs
+++ b/crates/postgresql-wal2json-source/tests/suite/no_pk_offset.rs
@@ -7,11 +7,11 @@ use anyhow::Result;
 use surreal_sink::SurrealSink;
 use surreal_sync_postgresql::{get_primary_key_columns, read_offset_table_chunk};
 use surreal_sync_postgresql_wal2json_source::{run_full_sync_with_transforms, SourceOpts};
-use sync_core::{UniversalChange, UniversalRow, UniversalValue};
+use sync_core::{Change, Row, Value};
 use sync_transform::{ApplyOpts, Pipeline};
 
 struct CaptureSink {
-    changes: Mutex<Vec<UniversalChange>>,
+    changes: Mutex<Vec<Change>>,
 }
 
 impl CaptureSink {
@@ -24,11 +24,11 @@ impl CaptureSink {
 
 #[async_trait::async_trait]
 impl SurrealSink for CaptureSink {
-    async fn write_universal_rows(&self, rows: &[UniversalRow]) -> anyhow::Result<()> {
-        // Full sync upserts coalesce to write_universal_rows; mirror into `changes`.
+    async fn write_rows(&self, rows: &[Row]) -> anyhow::Result<()> {
+        // Full sync upserts coalesce to write_rows; mirror into `changes`.
         let mut changes = self.changes.lock().expect("lock");
         for row in rows {
-            changes.push(UniversalChange::update(
+            changes.push(Change::update(
                 row.table.clone(),
                 row.id.clone(),
                 row.fields.clone(),
@@ -37,36 +37,33 @@ impl SurrealSink for CaptureSink {
         Ok(())
     }
 
-    async fn write_universal_relations(
-        &self,
-        _relations: &[sync_core::UniversalRelation],
-    ) -> anyhow::Result<()> {
+    async fn write_relations(&self, _relations: &[sync_core::Relation]) -> anyhow::Result<()> {
         Ok(())
     }
 
-    async fn apply_universal_change(&self, change: &UniversalChange) -> anyhow::Result<()> {
+    async fn apply_change(&self, change: &Change) -> anyhow::Result<()> {
         self.changes.lock().expect("lock").push(change.clone());
         Ok(())
     }
 
-    async fn apply_universal_relation_change(
+    async fn apply_relation_change(
         &self,
-        _change: &sync_core::UniversalRelationChange,
+        _change: &sync_core::RelationChange,
     ) -> anyhow::Result<()> {
         Ok(())
     }
 }
 
-fn name_of_row(row: &UniversalRow) -> String {
+fn name_of_row(row: &Row) -> String {
     match row.fields.get("name") {
-        Some(UniversalValue::VarChar { value, .. } | UniversalValue::Text(value)) => value.clone(),
+        Some(Value::VarChar { value, .. } | Value::Text(value)) => value.clone(),
         other => panic!("unexpected name: {other:?}"),
     }
 }
 
-fn name_of_change(change: &UniversalChange) -> String {
-    match change.data.as_ref().and_then(|d| d.get("name")) {
-        Some(UniversalValue::VarChar { value, .. } | UniversalValue::Text(value)) => value.clone(),
+fn name_of_change(change: &Change) -> String {
+    match change.fields.as_ref().and_then(|d| d.get("name")) {
+        Some(Value::VarChar { value, .. } | Value::Text(value)) => value.clone(),
         other => panic!("unexpected name: {other:?}"),
     }
 }
@@ -129,7 +126,7 @@ async fn read_offset_table_chunk_assigns_synthetic_ids_with_ctid_order() -> Resu
             .collect()
     );
     for (i, row) in all.iter().enumerate() {
-        assert_eq!(row.id, UniversalValue::Int64(i as i64));
+        assert_eq!(row.id, Value::Int64(i as i64));
         assert_eq!(row.index, i as u64);
     }
     Ok(())
@@ -184,7 +181,7 @@ async fn full_sync_streams_no_pk_table_via_offset_chunks() -> Result<()> {
     );
     for change in &changes {
         assert!(
-            matches!(change.id, UniversalValue::Int64(_)),
+            matches!(change.id, Value::Int64(_)),
             "no-PK rows should use synthetic Int64 ids, got {:?}",
             change.id
         );

--- a/crates/postgresql-wal2json-source/tests/suite/time.rs
+++ b/crates/postgresql-wal2json-source/tests/suite/time.rs
@@ -3,7 +3,7 @@
 
 use anyhow::{Context, Result};
 use surreal_sync_postgresql_wal2json_source::{Action, Client};
-use sync_core::UniversalValue;
+use sync_core::Value;
 use tokio_postgres::NoTls;
 use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -142,13 +142,13 @@ async fn test_time_replication_formats() -> Result<()> {
 
                 // Verify it's a Time value (time values are converted to DateTime<Utc> with epoch date)
                 match event_time {
-                    UniversalValue::Time(dt) => {
+                    Value::Time(dt) => {
                         let time_str = dt.format("%H:%M:%S%.f").to_string();
                         info!("Time value: {} (DateTime: {})", time_str, dt);
 
                         // Get the ID to verify specific expected values
                         let id = match row.primary_key {
-                            UniversalValue::Int32(i) => i,
+                            Value::Int32(i) => i,
                             _ => panic!("Expected Int32 primary key, got {:?}", row.primary_key),
                         };
 
@@ -238,7 +238,7 @@ async fn test_time_replication_formats() -> Result<()> {
                 .context("Should have event_time column in UPDATE")?;
 
             match event_time {
-                UniversalValue::Time(dt) => {
+                Value::Time(dt) => {
                     // Use %.f format to show fractional seconds if present
                     let time_str = dt.format("%H:%M:%S%.f").to_string();
                     info!("UPDATE time value: {} (DateTime: {})", time_str, dt);

--- a/crates/postgresql-wal2json-source/tests/suite/timestamp.rs
+++ b/crates/postgresql-wal2json-source/tests/suite/timestamp.rs
@@ -4,7 +4,7 @@
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use surreal_sync_postgresql_wal2json_source::{Action, Client};
-use sync_core::UniversalValue;
+use sync_core::Value;
 use tokio_postgres::NoTls;
 use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -144,7 +144,7 @@ async fn test_timestamp_replication_formats() -> Result<()> {
 
                 // Verify it's a LocalDateTime value (TIMESTAMP without timezone)
                 match event_time {
-                    UniversalValue::LocalDateTime(dt) => {
+                    Value::LocalDateTime(dt) => {
                         info!("Successfully got LocalDateTime: {}", dt.to_rfc3339());
 
                         // Verify the timestamp makes sense (not in the future, not before 1990)
@@ -167,7 +167,7 @@ async fn test_timestamp_replication_formats() -> Result<()> {
                         // Note: TIMESTAMP without timezone doesn't preserve timezone info,
                         // so we just verify that parsing succeeded
                         let id = match row.primary_key {
-                            UniversalValue::Int32(i) => i,
+                            Value::Int32(i) => i,
                             _ => panic!("Expected Int32 primary key, got {:?}", row.primary_key),
                         };
 
@@ -216,7 +216,7 @@ async fn test_timestamp_replication_formats() -> Result<()> {
                 .context("Should have event_time column in UPDATE")?;
 
             match event_time {
-                UniversalValue::LocalDateTime(dt) => {
+                Value::LocalDateTime(dt) => {
                     info!(
                         "UPDATE timestamp successfully converted: {}",
                         dt.to_rfc3339()

--- a/crates/postgresql-wal2json-source/tests/suite/timestamptz.rs
+++ b/crates/postgresql-wal2json-source/tests/suite/timestamptz.rs
@@ -4,7 +4,7 @@
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use surreal_sync_postgresql_wal2json_source::{Action, Client};
-use sync_core::UniversalValue;
+use sync_core::Value;
 use tokio_postgres::NoTls;
 use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -145,7 +145,7 @@ async fn test_timestamptz_replication_formats() -> Result<()> {
 
                 // Verify it's a ZonedDateTime value (TIMESTAMPTZ)
                 match event_time {
-                    UniversalValue::ZonedDateTime(dt) => {
+                    Value::ZonedDateTime(dt) => {
                         info!("Successfully got ZonedDateTime: {}", dt.to_rfc3339());
 
                         // Verify the timestamp makes sense (not in the future, not before 1990)
@@ -166,7 +166,7 @@ async fn test_timestamptz_replication_formats() -> Result<()> {
 
                         // For known timestamps (IDs 1-5), verify specific values
                         let id = match row.primary_key {
-                            UniversalValue::Int32(i) => i,
+                            Value::Int32(i) => i,
                             _ => panic!("Expected Int32 primary key, got {:?}", row.primary_key),
                         };
 
@@ -233,7 +233,7 @@ async fn test_timestamptz_replication_formats() -> Result<()> {
                 .context("Should have event_time column in UPDATE")?;
 
             match event_time {
-                UniversalValue::ZonedDateTime(dt) => {
+                Value::ZonedDateTime(dt) => {
                     info!(
                         "UPDATE timestamp successfully converted: {}",
                         dt.to_rfc3339()

--- a/crates/postgresql-wal2json-source/tests/suite/timetz.rs
+++ b/crates/postgresql-wal2json-source/tests/suite/timetz.rs
@@ -3,7 +3,7 @@
 
 use anyhow::{Context, Result};
 use surreal_sync_postgresql_wal2json_source::{Action, Client};
-use sync_core::UniversalValue;
+use sync_core::Value;
 use tokio_postgres::NoTls;
 use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -145,12 +145,12 @@ async fn test_timetz_replication_formats() -> Result<()> {
                 // Time and datetime are fundamentally different types - datetime implies a specific
                 // point in time, while TIMETZ represents a daily recurring time in a specific timezone.
                 match event_time {
-                    UniversalValue::TimeTz(time_str) => {
+                    Value::TimeTz(time_str) => {
                         info!("TimeTz value: {}", time_str);
 
                         // Get the ID to verify specific expected values
                         let id = match row.primary_key {
-                            UniversalValue::Int32(i) => i,
+                            Value::Int32(i) => i,
                             _ => panic!("Expected Int32 primary key, got {:?}", row.primary_key),
                         };
 
@@ -241,7 +241,7 @@ async fn test_timetz_replication_formats() -> Result<()> {
             // Time and datetime are fundamentally different types - datetime implies a specific
             // point in time, while TIMETZ represents a daily recurring time in a specific timezone.
             match event_time {
-                UniversalValue::TimeTz(time_str) => {
+                Value::TimeTz(time_str) => {
                     info!("UPDATE TimeTz value: {}", time_str);
                     // Original format preserved: 18:30:00-05:00
                     assert!(

--- a/crates/postgresql-wal2json-source/tests/suite/transforms.rs
+++ b/crates/postgresql-wal2json-source/tests/suite/transforms.rs
@@ -10,13 +10,13 @@ use surreal_sync_postgresql_wal2json_source::{
     run_full_sync_with_transforms, run_incremental_sync_with_transforms, Client,
     PostgreSQLLogicalCheckpoint, ReplicationTailOptions, SourceOpts,
 };
-use sync_core::{UniversalChange, UniversalRow, UniversalValue};
+use sync_core::{Change, Row, Value};
 use sync_transform::{ApplyOpts, ChildStdioMode, ExternalTransform, FramerKind, Pipeline};
 
 struct CaptureSink {
-    changes: Mutex<Vec<UniversalChange>>,
-    rows: Mutex<Vec<UniversalRow>>,
-    relation_changes: Mutex<Vec<sync_core::UniversalRelationChange>>,
+    changes: Mutex<Vec<Change>>,
+    rows: Mutex<Vec<Row>>,
+    relation_changes: Mutex<Vec<sync_core::RelationChange>>,
 }
 
 impl CaptureSink {
@@ -31,13 +31,13 @@ impl CaptureSink {
 
 #[async_trait::async_trait]
 impl SurrealSink for CaptureSink {
-    async fn write_universal_rows(&self, rows: &[UniversalRow]) -> anyhow::Result<()> {
+    async fn write_rows(&self, rows: &[Row]) -> anyhow::Result<()> {
         // Homogeneous Update upserts coalesce here; mirror into `changes` for
         // incremental assertions (full sync still reads `rows`).
         self.rows.lock().expect("lock").extend(rows.iter().cloned());
         let mut changes = self.changes.lock().expect("lock");
         for row in rows {
-            changes.push(UniversalChange::update(
+            changes.push(Change::update(
                 row.table.clone(),
                 row.id.clone(),
                 row.fields.clone(),
@@ -46,25 +46,22 @@ impl SurrealSink for CaptureSink {
         Ok(())
     }
 
-    async fn write_universal_relations(
-        &self,
-        relations: &[sync_core::UniversalRelation],
-    ) -> anyhow::Result<()> {
+    async fn write_relations(&self, relations: &[sync_core::Relation]) -> anyhow::Result<()> {
         let mut relation_changes = self.relation_changes.lock().expect("lock");
         for relation in relations {
-            relation_changes.push(sync_core::UniversalRelationChange::update(relation.clone()));
+            relation_changes.push(sync_core::RelationChange::update(relation.clone()));
         }
         Ok(())
     }
 
-    async fn apply_universal_change(&self, change: &UniversalChange) -> anyhow::Result<()> {
+    async fn apply_change(&self, change: &Change) -> anyhow::Result<()> {
         self.changes.lock().expect("lock").push(change.clone());
         Ok(())
     }
 
-    async fn apply_universal_relation_change(
+    async fn apply_relation_change(
         &self,
-        change: &sync_core::UniversalRelationChange,
+        change: &sync_core::RelationChange,
     ) -> anyhow::Result<()> {
         self.relation_changes
             .lock()
@@ -116,17 +113,17 @@ fn ensure_fixture_worker() -> PathBuf {
     path
 }
 
-fn name_field(change: &UniversalChange) -> Option<String> {
-    let data = change.data.as_ref()?;
+fn name_field(change: &Change) -> Option<String> {
+    let data = change.fields.as_ref()?;
     match data.get("name")? {
-        UniversalValue::VarChar { value, .. } | UniversalValue::Text(value) => Some(value.clone()),
+        Value::VarChar { value, .. } | Value::Text(value) => Some(value.clone()),
         other => panic!("unexpected name value: {other:?}"),
     }
 }
 
-fn row_name_field(row: &UniversalRow) -> Option<String> {
+fn row_name_field(row: &Row) -> Option<String> {
     match row.fields.get("name")? {
-        UniversalValue::VarChar { value, .. } | UniversalValue::Text(value) => Some(value.clone()),
+        Value::VarChar { value, .. } | Value::Text(value) => Some(value.clone()),
         other => panic!("unexpected name value: {other:?}"),
     }
 }

--- a/crates/postgresql/src/fk_transform.rs
+++ b/crates/postgresql/src/fk_transform.rs
@@ -1,30 +1,25 @@
 //! Foreign key value transformation utilities.
 //!
-//! Converts FK column values to SurrealDB record links (`UniversalValue::Thing`)
-//! and builds `UniversalRelation` instances from join-table rows.
+//! Converts FK column values to SurrealDB record links (`Value::Thing`)
+//! and builds `Relation` instances from join-table rows.
 
 use std::collections::HashMap;
-use sync_core::{
-    ForeignKeyDefinition, TableDefinition, UniversalRelation, UniversalThingRef, UniversalValue,
-};
+use sync_core::{ForeignKeyDefinition, Relation, TableDefinition, ThingRef, Value};
 
 /// Transform FK column values in a field map to record links.
 ///
 /// For each FK on the table, the raw value (e.g. `Int64(1)`) is wrapped
-/// as `UniversalValue::Thing { table: referenced_table, id: raw_value }`.
-/// Null values are left as `UniversalValue::Null`.
-pub fn transform_fk_values(
-    fields: &mut HashMap<String, UniversalValue>,
-    table_def: &TableDefinition,
-) {
+/// as `Value::Thing { table: referenced_table, id: raw_value }`.
+/// Null values are left as `Value::Null`.
+pub fn transform_fk_values(fields: &mut HashMap<String, Value>, table_def: &TableDefinition) {
     for fk in &table_def.foreign_keys {
         // Only handle single-column FKs for record link conversion
         if fk.columns.len() == 1 {
             let col = &fk.columns[0];
             if let Some(value) = fields.remove(col) {
                 let transformed = match value {
-                    UniversalValue::Null => UniversalValue::Null,
-                    other => UniversalValue::Thing {
+                    Value::Null => Value::Null,
+                    other => Value::Thing {
                         table: fk.referenced_table.clone(),
                         id: Box::new(other),
                     },
@@ -35,31 +30,31 @@ pub fn transform_fk_values(
     }
 }
 
-/// Build a `UniversalRelation` from a join-table row.
+/// Build a `Relation` from a join-table row.
 ///
 /// The two FK endpoints become the `input` and `output` of the relation.
 /// FK columns are consumed; remaining fields become the relation's `data`.
 pub fn build_relation_from_row(
     table_name: &str,
-    id: UniversalValue,
-    mut fields: HashMap<String, UniversalValue>,
+    id: Value,
+    mut fields: HashMap<String, Value>,
     in_fk: &ForeignKeyDefinition,
     out_fk: &ForeignKeyDefinition,
-) -> UniversalRelation {
+) -> Relation {
     let in_id = extract_fk_value(&mut fields, in_fk);
     let out_id = extract_fk_value(&mut fields, out_fk);
 
-    let input = UniversalThingRef::new(in_fk.referenced_table.clone(), in_id);
-    let output = UniversalThingRef::new(out_fk.referenced_table.clone(), out_id);
+    let input = ThingRef::new(in_fk.referenced_table.clone(), in_id);
+    let output = ThingRef::new(out_fk.referenced_table.clone(), out_id);
 
     // For composite PK Arrays, flatten into a string ID for the relation.
     // SurrealDB relation IDs must be a simple type, not an array.
     let rel_id = flatten_composite_id(id);
 
-    UniversalRelation::new(table_name, rel_id, input, output, fields)
+    Relation::new(table_name, rel_id, input, output, fields)
 }
 
-/// Build a `UniversalRelation` from an incremental change event.
+/// Build a `Relation` from an incremental change event.
 ///
 /// In incremental sync, FK columns that are also PK columns have already
 /// been stripped from `data` and placed in `id` (as a composite Array).
@@ -67,14 +62,14 @@ pub fn build_relation_from_row(
 /// are missing from the data map.
 pub fn build_relation_from_change(
     table_name: &str,
-    id: UniversalValue,
-    mut data: HashMap<String, UniversalValue>,
+    id: Value,
+    mut data: HashMap<String, Value>,
     in_fk: &ForeignKeyDefinition,
     out_fk: &ForeignKeyDefinition,
-) -> UniversalRelation {
+) -> Relation {
     // If FK columns are missing from data (because they were PK columns),
     // inject them back from the composite ID array.
-    if let UniversalValue::Array { ref elements, .. } = id {
+    if let Value::Array { ref elements, .. } = id {
         inject_missing_fk_from_composite_id(&mut data, in_fk, out_fk, elements);
     }
 
@@ -87,10 +82,10 @@ pub fn build_relation_from_change(
 /// same order as the PK was defined. We match FK column names against
 /// the table's composite PK order.
 fn inject_missing_fk_from_composite_id(
-    data: &mut HashMap<String, UniversalValue>,
+    data: &mut HashMap<String, Value>,
     in_fk: &ForeignKeyDefinition,
     out_fk: &ForeignKeyDefinition,
-    id_elements: &[UniversalValue],
+    id_elements: &[Value],
 ) {
     let all_fk_cols: Vec<&str> = in_fk
         .columns
@@ -111,30 +106,25 @@ fn inject_missing_fk_from_composite_id(
 
 /// Flatten a composite (Array) ID into a string ID.
 /// Simple IDs are returned as-is. Array IDs are joined with `:` separators.
-fn flatten_composite_id(id: UniversalValue) -> UniversalValue {
+fn flatten_composite_id(id: Value) -> Value {
     sync_core::flatten_composite_id(id, ":")
 }
 
 /// Extract and remove the FK value from the fields map.
 /// For single-column FKs, returns the value directly.
 /// For multi-column FKs, returns an array of values.
-fn extract_fk_value(
-    fields: &mut HashMap<String, UniversalValue>,
-    fk: &ForeignKeyDefinition,
-) -> UniversalValue {
+fn extract_fk_value(fields: &mut HashMap<String, Value>, fk: &ForeignKeyDefinition) -> Value {
     if fk.columns.len() == 1 {
-        fields
-            .remove(&fk.columns[0])
-            .unwrap_or(UniversalValue::Null)
+        fields.remove(&fk.columns[0]).unwrap_or(Value::Null)
     } else {
-        let vals: Vec<UniversalValue> = fk
+        let vals: Vec<Value> = fk
             .columns
             .iter()
-            .map(|c| fields.remove(c).unwrap_or(UniversalValue::Null))
+            .map(|c| fields.remove(c).unwrap_or(Value::Null))
             .collect();
-        UniversalValue::Array {
+        Value::Array {
             elements: vals,
-            element_type: Box::new(sync_core::UniversalType::Text),
+            element_type: Box::new(sync_core::Type::Text),
         }
     }
 }
@@ -142,15 +132,15 @@ fn extract_fk_value(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sync_core::{ColumnDefinition, UniversalType};
+    use sync_core::{ColumnDefinition, Type};
 
     fn make_table_with_fks(fks: Vec<ForeignKeyDefinition>) -> TableDefinition {
         let mut td = TableDefinition::new(
             "books",
-            ColumnDefinition::new("id", UniversalType::Int64),
+            ColumnDefinition::new("id", Type::Int64),
             vec![
-                ColumnDefinition::new("title", UniversalType::Text),
-                ColumnDefinition::new("author_id", UniversalType::Int32),
+                ColumnDefinition::new("title", Type::Text),
+                ColumnDefinition::new("author_id", Type::Int32),
             ],
         );
         td.foreign_keys = fks;
@@ -168,22 +158,16 @@ mod tests {
         let table = make_table_with_fks(fks);
 
         let mut fields = HashMap::new();
-        fields.insert(
-            "title".to_string(),
-            UniversalValue::Text("Rust".to_string()),
-        );
-        fields.insert("author_id".to_string(), UniversalValue::Int32(42));
+        fields.insert("title".to_string(), Value::Text("Rust".to_string()));
+        fields.insert("author_id".to_string(), Value::Int32(42));
 
         transform_fk_values(&mut fields, &table);
 
-        assert_eq!(
-            fields.get("title"),
-            Some(&UniversalValue::Text("Rust".to_string()))
-        );
+        assert_eq!(fields.get("title"), Some(&Value::Text("Rust".to_string())));
         match fields.get("author_id") {
-            Some(UniversalValue::Thing { table, id }) => {
+            Some(Value::Thing { table, id }) => {
                 assert_eq!(table, "authors");
-                assert_eq!(**id, UniversalValue::Int32(42));
+                assert_eq!(**id, Value::Int32(42));
             }
             other => panic!("Expected Thing, got {other:?}"),
         }
@@ -200,25 +184,22 @@ mod tests {
         let table = make_table_with_fks(fks);
 
         let mut fields = HashMap::new();
-        fields.insert("author_id".to_string(), UniversalValue::Null);
+        fields.insert("author_id".to_string(), Value::Null);
 
         transform_fk_values(&mut fields, &table);
 
-        assert_eq!(fields.get("author_id"), Some(&UniversalValue::Null));
+        assert_eq!(fields.get("author_id"), Some(&Value::Null));
     }
 
     #[test]
     fn test_transform_fk_values_non_fk_field_unchanged() {
         let table = make_table_with_fks(vec![]);
         let mut fields = HashMap::new();
-        fields.insert("title".to_string(), UniversalValue::Text("Go".to_string()));
+        fields.insert("title".to_string(), Value::Text("Go".to_string()));
 
         transform_fk_values(&mut fields, &table);
 
-        assert_eq!(
-            fields.get("title"),
-            Some(&UniversalValue::Text("Go".to_string()))
-        );
+        assert_eq!(fields.get("title"), Some(&Value::Text("Go".to_string())));
     }
 
     #[test]
@@ -239,26 +220,26 @@ mod tests {
         ];
         let mut td = TableDefinition::new(
             "books",
-            ColumnDefinition::new("id", UniversalType::Int64),
+            ColumnDefinition::new("id", Type::Int64),
             vec![
-                ColumnDefinition::new("author_id", UniversalType::Int32),
-                ColumnDefinition::new("editor_id", UniversalType::Int32),
+                ColumnDefinition::new("author_id", Type::Int32),
+                ColumnDefinition::new("editor_id", Type::Int32),
             ],
         );
         td.foreign_keys = fks;
 
         let mut fields = HashMap::new();
-        fields.insert("author_id".to_string(), UniversalValue::Int32(1));
-        fields.insert("editor_id".to_string(), UniversalValue::Int32(2));
+        fields.insert("author_id".to_string(), Value::Int32(1));
+        fields.insert("editor_id".to_string(), Value::Int32(2));
 
         transform_fk_values(&mut fields, &td);
 
         match fields.get("author_id") {
-            Some(UniversalValue::Thing { table, .. }) => assert_eq!(table, "authors"),
+            Some(Value::Thing { table, .. }) => assert_eq!(table, "authors"),
             other => panic!("Expected Thing for author_id, got {other:?}"),
         }
         match fields.get("editor_id") {
-            Some(UniversalValue::Thing { table, .. }) => assert_eq!(table, "editors"),
+            Some(Value::Thing { table, .. }) => assert_eq!(table, "editors"),
             other => panic!("Expected Thing for editor_id, got {other:?}"),
         }
     }
@@ -279,26 +260,20 @@ mod tests {
         };
 
         let mut fields = HashMap::new();
-        fields.insert("book_id".to_string(), UniversalValue::Int32(10));
-        fields.insert("tag_id".to_string(), UniversalValue::Int32(20));
+        fields.insert("book_id".to_string(), Value::Int32(10));
+        fields.insert("tag_id".to_string(), Value::Int32(20));
         fields.insert(
             "created_at".to_string(),
-            UniversalValue::Text("2024-01-01".to_string()),
+            Value::Text("2024-01-01".to_string()),
         );
 
-        let rel = build_relation_from_row(
-            "book_tags",
-            UniversalValue::Int64(1),
-            fields,
-            &in_fk,
-            &out_fk,
-        );
+        let rel = build_relation_from_row("book_tags", Value::Int64(1), fields, &in_fk, &out_fk);
 
         assert_eq!(rel.relation_type, "book_tags");
         assert_eq!(rel.input.table, "books");
-        assert_eq!(rel.input.id, UniversalValue::Int32(10));
+        assert_eq!(rel.input.id, Value::Int32(10));
         assert_eq!(rel.output.table, "tags");
-        assert_eq!(rel.output.id, UniversalValue::Int32(20));
+        assert_eq!(rel.output.id, Value::Int32(20));
         // FK columns should be removed; only extra data remains
         assert_eq!(rel.data.len(), 1);
         assert!(rel.data.contains_key("created_at"));

--- a/crates/postgresql/src/full_sync.rs
+++ b/crates/postgresql/src/full_sync.rs
@@ -9,11 +9,10 @@ use rust_decimal::Decimal;
 use std::collections::HashMap;
 use surreal_sink::SurrealSink;
 use sync_core::{
-    classify_table, DatabaseSchema, GeometryType, TableKind, UniversalRelation, UniversalRow,
-    UniversalType, UniversalValue,
+    classify_table, DatabaseSchema, GeometryType, Relation, Row, TableKind, Type, Value,
 };
 use tokio_postgres::types::ToSql;
-use tokio_postgres::{Client, Row};
+use tokio_postgres::{Client, Row as PgRow};
 use tracing::{debug, info, warn};
 
 use crate::fk_transform;
@@ -38,7 +37,7 @@ pub async fn convert_table(
     table_name: &str,
     schema: Option<&DatabaseSchema>,
     relation_table_overrides: &[String],
-) -> Result<(Vec<UniversalRow>, Vec<UniversalRelation>)> {
+) -> Result<(Vec<Row>, Vec<Relation>)> {
     let pk_columns = get_primary_key_columns(client, table_name).await?;
 
     let table_kind = schema
@@ -72,7 +71,7 @@ pub async fn convert_table(
             Some(TableKind::Relation { in_fk, out_fk }) => {
                 // Include ALL columns (including PK) so FK extraction can find them.
                 let all_fields = convert_all_columns_to_universal_values(row)?;
-                let rel_id = UniversalValue::Int64(row_index as i64);
+                let rel_id = Value::Int64(row_index as i64);
                 let relation = fk_transform::build_relation_from_row(
                     table_name, rel_id, all_fields, in_fk, out_fk,
                 );
@@ -148,11 +147,11 @@ pub async fn migrate_table<S: SurrealSink>(
 #[derive(Debug, Clone)]
 pub struct TableChunk {
     /// The converted rows, in primary-key order.
-    pub rows: Vec<UniversalRow>,
+    pub rows: Vec<Row>,
     /// Primary-key values of the last row in `rows`, in primary-key column
     /// order. `None` when no rows were returned. Pass this back as `after` to
     /// read the following chunk.
-    pub last_pk: Option<Vec<UniversalValue>>,
+    pub last_pk: Option<Vec<Value>>,
 }
 
 /// Read a single primary-key-ordered chunk of a table using keyset pagination.
@@ -174,7 +173,7 @@ pub async fn read_table_chunk(
     client: &Client,
     table_name: &str,
     pk_columns: &[String],
-    after: Option<&[UniversalValue]>,
+    after: Option<&[Value]>,
     limit: usize,
     schema: Option<&DatabaseSchema>,
 ) -> Result<TableChunk> {
@@ -231,7 +230,7 @@ pub async fn read_table_chunk(
     let table_def = schema.and_then(|s| s.get_table(table_name));
 
     let mut out = Vec::with_capacity(rows.len());
-    let mut last_pk: Option<Vec<UniversalValue>> = None;
+    let mut last_pk: Option<Vec<Value>> = None;
     for (row_index, row) in rows.iter().enumerate() {
         let mut record =
             convert_row_to_universal_row(table_name, row, pk_columns, row_index as u64)?;
@@ -249,9 +248,9 @@ pub async fn read_table_chunk(
 #[derive(Debug, Clone)]
 pub struct RelationChunk {
     /// Converted relations in read order.
-    pub relations: Vec<UniversalRelation>,
+    pub relations: Vec<Relation>,
     /// Primary-key cursor of the last row (for keyset continuation).
-    pub last_pk: Option<Vec<UniversalValue>>,
+    pub last_pk: Option<Vec<Value>>,
 }
 
 /// Keyset-paginated read of a relation (join) table as SurrealDB edges.
@@ -260,7 +259,7 @@ pub async fn read_relation_chunk(
     client: &Client,
     table_name: &str,
     pk_columns: &[String],
-    after: Option<&[UniversalValue]>,
+    after: Option<&[Value]>,
     limit: usize,
     in_fk: &sync_core::ForeignKeyDefinition,
     out_fk: &sync_core::ForeignKeyDefinition,
@@ -312,10 +311,10 @@ pub async fn read_relation_chunk(
 
     let rows = client.query(&query, &params).await?;
     let mut out = Vec::with_capacity(rows.len());
-    let mut last_pk: Option<Vec<UniversalValue>> = None;
+    let mut last_pk: Option<Vec<Value>> = None;
     for (i, row) in rows.iter().enumerate() {
         let all_fields = convert_all_columns_to_universal_values(row)?;
-        let rel_id = UniversalValue::Int64((row_index_base + i as u64) as i64);
+        let rel_id = Value::Int64((row_index_base + i as u64) as i64);
         out.push(fk_transform::build_relation_from_row(
             table_name, rel_id, all_fields, in_fk, out_fk,
         ));
@@ -346,7 +345,7 @@ pub async fn read_offset_table_chunk(
     limit: usize,
     schema: Option<&DatabaseSchema>,
     relation_table_overrides: &[String],
-) -> Result<(Vec<UniversalRow>, Vec<UniversalRelation>)> {
+) -> Result<(Vec<Row>, Vec<Relation>)> {
     let pk_columns = get_primary_key_columns(client, table_name).await?;
     let table_kind = schema
         .and_then(|s| s.get_table(table_name))
@@ -367,7 +366,7 @@ pub async fn read_offset_table_chunk(
         match &table_kind {
             Some(TableKind::Relation { in_fk, out_fk }) => {
                 let all_fields = convert_all_columns_to_universal_values(row)?;
-                let rel_id = UniversalValue::Int64(row_index as i64);
+                let rel_id = Value::Int64(row_index as i64);
                 rel_batch.push(fk_transform::build_relation_from_row(
                     table_name, rel_id, all_fields, in_fk, out_fk,
                 ));
@@ -396,14 +395,14 @@ pub async fn read_offset_relation_chunk(
     limit: usize,
     in_fk: &sync_core::ForeignKeyDefinition,
     out_fk: &sync_core::ForeignKeyDefinition,
-) -> Result<Vec<UniversalRelation>> {
+) -> Result<Vec<Relation>> {
     let query = format!("SELECT * FROM {table_name} ORDER BY ctid OFFSET {offset} LIMIT {limit}");
     debug!("Offset-reading relation table {table_name} with: {query}");
     let rows = client.query(&query, &[]).await?;
     let mut out = Vec::with_capacity(rows.len());
     for (i, row) in rows.iter().enumerate() {
         let all_fields = convert_all_columns_to_universal_values(row)?;
-        let rel_id = UniversalValue::Int64((offset + i) as i64);
+        let rel_id = Value::Int64((offset + i) as i64);
         out.push(fk_transform::build_relation_from_row(
             table_name, rel_id, all_fields, in_fk, out_fk,
         ));
@@ -413,19 +412,19 @@ pub async fn read_offset_relation_chunk(
 
 /// Extract the raw primary-key column values from a row, in primary-key column
 /// order, for use as a keyset-pagination cursor.
-fn extract_pk_cursor_values(row: &Row, pk_columns: &[String]) -> Result<Vec<UniversalValue>> {
+fn extract_pk_cursor_values(row: &PgRow, pk_columns: &[String]) -> Result<Vec<Value>> {
     let mut values = Vec::with_capacity(pk_columns.len());
     for col in pk_columns {
         let value = if let Ok(v) = row.try_get::<_, i32>(col.as_str()) {
-            UniversalValue::Int32(v)
+            Value::Int32(v)
         } else if let Ok(v) = row.try_get::<_, i64>(col.as_str()) {
-            UniversalValue::Int64(v)
+            Value::Int64(v)
         } else if let Ok(v) = row.try_get::<_, i16>(col.as_str()) {
-            UniversalValue::Int16(v)
+            Value::Int16(v)
         } else if let Ok(v) = row.try_get::<_, String>(col.as_str()) {
-            UniversalValue::Text(v)
+            Value::Text(v)
         } else if let Ok(v) = row.try_get::<_, uuid::Uuid>(col.as_str()) {
-            UniversalValue::Uuid(v)
+            Value::Uuid(v)
         } else {
             return Err(anyhow::anyhow!(
                 "Failed to extract primary key value from column '{col}' for keyset pagination - unsupported data type"
@@ -436,18 +435,18 @@ fn extract_pk_cursor_values(row: &Row, pk_columns: &[String]) -> Result<Vec<Univ
     Ok(values)
 }
 
-/// Convert a primary-key `UniversalValue` into a boxed `ToSql` for binding into
+/// Convert a primary-key `Value` into a boxed `ToSql` for binding into
 /// a keyset-pagination query. The bound SQL type mirrors the way the cursor
 /// values were read back out of the row.
-fn pk_value_to_sql(value: &UniversalValue) -> Result<Box<dyn ToSql + Sync + Send>> {
+fn pk_value_to_sql(value: &Value) -> Result<Box<dyn ToSql + Sync + Send>> {
     match value {
-        UniversalValue::Int16(v) => Ok(Box::new(*v)),
-        UniversalValue::Int32(v) => Ok(Box::new(*v)),
-        UniversalValue::Int64(v) => Ok(Box::new(*v)),
-        UniversalValue::Text(v) => Ok(Box::new(v.clone())),
-        UniversalValue::VarChar { value, .. } => Ok(Box::new(value.clone())),
-        UniversalValue::Char { value, .. } => Ok(Box::new(value.clone())),
-        UniversalValue::Uuid(v) => Ok(Box::new(*v)),
+        Value::Int16(v) => Ok(Box::new(*v)),
+        Value::Int32(v) => Ok(Box::new(*v)),
+        Value::Int64(v) => Ok(Box::new(*v)),
+        Value::Text(v) => Ok(Box::new(v.clone())),
+        Value::VarChar { value, .. } => Ok(Box::new(value.clone())),
+        Value::Char { value, .. } => Ok(Box::new(value.clone())),
+        Value::Uuid(v) => Ok(Box::new(*v)),
         other => Err(anyhow::anyhow!(
             "Unsupported primary key value type for keyset pagination: {other:?}"
         )),
@@ -476,12 +475,12 @@ pub async fn get_primary_key_columns(client: &Client, table_name: &str) -> Resul
 
 fn convert_row_to_universal_row(
     table: &str,
-    row: &Row,
+    row: &PgRow,
     pk_columns: &[String],
     row_index: u64,
-) -> anyhow::Result<UniversalRow> {
+) -> anyhow::Result<Row> {
     let (id, data) = convert_row_to_keys_and_universal_values(row, pk_columns, row_index)?;
-    Ok(UniversalRow::new(table.to_string(), row_index, id, data))
+    Ok(Row::new(table.to_string(), row_index, id, data))
 }
 
 /// Convert a PostgreSQL row to a map of universal values.
@@ -489,26 +488,26 @@ fn convert_row_to_universal_row(
 /// When `pk_columns` is empty, the id is a synthetic `Int64(row_index)` (same
 /// convention as MySQL LIMIT/OFFSET full sync).
 fn convert_row_to_keys_and_universal_values(
-    row: &Row,
+    row: &PgRow,
     pk_columns: &[String],
     row_index: u64,
-) -> Result<(UniversalValue, HashMap<String, UniversalValue>)> {
+) -> Result<(Value, HashMap<String, Value>)> {
     let mut record = HashMap::new();
 
     // Generate ID from primary key columns, or a stable synthetic index.
     let id = if pk_columns.is_empty() {
-        UniversalValue::Int64(row_index as i64)
+        Value::Int64(row_index as i64)
     } else if pk_columns.len() == 1 {
         // Single primary key column - extract its value
         let pk_col = &pk_columns[0];
         let id = if let Ok(id) = row.try_get::<_, i32>(pk_col.as_str()) {
-            UniversalValue::Int32(id)
+            Value::Int32(id)
         } else if let Ok(id) = row.try_get::<_, i64>(pk_col.as_str()) {
-            UniversalValue::Int64(id)
+            Value::Int64(id)
         } else if let Ok(id) = row.try_get::<_, String>(pk_col.as_str()) {
-            UniversalValue::Text(id)
+            Value::Text(id)
         } else if let Ok(id) = row.try_get::<_, uuid::Uuid>(pk_col.as_str()) {
-            UniversalValue::Uuid(id)
+            Value::Uuid(id)
         } else {
             return Err(anyhow::anyhow!(
                 "Failed to extract primary key value from column '{pk_col}' - unsupported data type",
@@ -519,13 +518,13 @@ fn convert_row_to_keys_and_universal_values(
         let mut vs = Vec::new();
         for col in pk_columns {
             let v = if let Ok(val) = row.try_get::<_, String>(col.as_str()) {
-                UniversalValue::Text(val)
+                Value::Text(val)
             } else if let Ok(val) = row.try_get::<_, uuid::Uuid>(col.as_str()) {
-                UniversalValue::Uuid(val)
+                Value::Uuid(val)
             } else if let Ok(val) = row.try_get::<_, i32>(col.as_str()) {
-                UniversalValue::Int32(val)
+                Value::Int32(val)
             } else if let Ok(val) = row.try_get::<_, i64>(col.as_str()) {
-                UniversalValue::Int64(val)
+                Value::Int64(val)
             } else {
                 return Err(anyhow::anyhow!(
                     "Failed to extract composite primary key value from column '{col}' - unsupported data type",
@@ -533,9 +532,9 @@ fn convert_row_to_keys_and_universal_values(
             };
             vs.push(v);
         }
-        UniversalValue::Array {
+        Value::Array {
             elements: vs,
-            element_type: Box::new(UniversalType::Text),
+            element_type: Box::new(Type::Text),
         }
     };
 
@@ -555,9 +554,9 @@ fn convert_row_to_keys_and_universal_values(
     Ok((id, record))
 }
 
-/// Convert all columns in a PostgreSQL row to UniversalValues (including PK columns).
+/// Convert all columns in a PostgreSQL row to Values (including PK columns).
 /// Used for relation tables where FK columns may overlap with PK columns.
-fn convert_all_columns_to_universal_values(row: &Row) -> Result<HashMap<String, UniversalValue>> {
+fn convert_all_columns_to_universal_values(row: &PgRow) -> Result<HashMap<String, Value>> {
     let mut record = HashMap::new();
     for (i, column) in row.columns().iter().enumerate() {
         let value = convert_postgres_value_to_universal(row, i)?;
@@ -566,52 +565,52 @@ fn convert_all_columns_to_universal_values(row: &Row) -> Result<HashMap<String, 
     Ok(record)
 }
 
-/// Convert a PostgreSQL value to an UniversalValue
-fn convert_postgres_value_to_universal(row: &Row, index: usize) -> Result<UniversalValue> {
-    use tokio_postgres::types::Type;
+/// Convert a PostgreSQL value to an Value
+fn convert_postgres_value_to_universal(row: &PgRow, index: usize) -> Result<Value> {
+    use tokio_postgres::types::Type as PgType;
 
     let column = &row.columns()[index];
     let pg_type = column.type_();
 
     match *pg_type {
-        Type::BOOL => match row.try_get::<_, Option<bool>>(index)? {
-            Some(b) => Ok(UniversalValue::Bool(b)),
-            None => Ok(UniversalValue::Null),
+        PgType::BOOL => match row.try_get::<_, Option<bool>>(index)? {
+            Some(b) => Ok(Value::Bool(b)),
+            None => Ok(Value::Null),
         },
-        Type::INT2 => match row.try_get::<_, Option<i16>>(index)? {
-            Some(i) => Ok(UniversalValue::Int16(i)),
-            None => Ok(UniversalValue::Null),
+        PgType::INT2 => match row.try_get::<_, Option<i16>>(index)? {
+            Some(i) => Ok(Value::Int16(i)),
+            None => Ok(Value::Null),
         },
-        Type::INT4 => match row.try_get::<_, Option<i32>>(index)? {
-            Some(i) => Ok(UniversalValue::Int32(i)),
-            None => Ok(UniversalValue::Null),
+        PgType::INT4 => match row.try_get::<_, Option<i32>>(index)? {
+            Some(i) => Ok(Value::Int32(i)),
+            None => Ok(Value::Null),
         },
-        Type::INT8 => match row.try_get::<_, Option<i64>>(index)? {
-            Some(i) => Ok(UniversalValue::Int64(i)),
-            None => Ok(UniversalValue::Null),
+        PgType::INT8 => match row.try_get::<_, Option<i64>>(index)? {
+            Some(i) => Ok(Value::Int64(i)),
+            None => Ok(Value::Null),
         },
-        Type::FLOAT4 => match row.try_get::<_, Option<f32>>(index)? {
-            Some(f) => Ok(UniversalValue::Float32(f)),
-            None => Ok(UniversalValue::Null),
+        PgType::FLOAT4 => match row.try_get::<_, Option<f32>>(index)? {
+            Some(f) => Ok(Value::Float32(f)),
+            None => Ok(Value::Null),
         },
-        Type::FLOAT8 => match row.try_get::<_, Option<f64>>(index)? {
-            Some(f) => Ok(UniversalValue::Float64(f)),
-            None => Ok(UniversalValue::Null),
+        PgType::FLOAT8 => match row.try_get::<_, Option<f64>>(index)? {
+            Some(f) => Ok(Value::Float64(f)),
+            None => Ok(Value::Null),
         },
-        Type::NUMERIC => {
+        PgType::NUMERIC => {
             // PostgreSQL NUMERIC type - convert to Decimal
             match row.try_get::<_, Option<Decimal>>(index) {
                 Ok(Some(decimal)) => {
                     // Get precision and scale from the decimal
                     let scale = decimal.scale() as u8;
                     let precision = 38; // Use max precision as default
-                    Ok(UniversalValue::Decimal {
+                    Ok(Value::Decimal {
                         value: decimal.to_string(),
                         precision,
                         scale,
                     })
                 }
-                Ok(None) => Ok(UniversalValue::Null),
+                Ok(None) => Ok(Value::Null),
                 Err(e) => {
                     warn!(
                         "Failed to get PostgreSQL NUMERIC as rust_decimal::Decimal: {}",
@@ -621,112 +620,107 @@ fn convert_postgres_value_to_universal(row: &Row, index: usize) -> Result<Univer
                 }
             }
         }
-        Type::TEXT | Type::VARCHAR | Type::BPCHAR | Type::NAME => {
+        PgType::TEXT | PgType::VARCHAR | PgType::BPCHAR | PgType::NAME => {
             match row.try_get::<_, Option<String>>(index)? {
                 Some(s) => {
                     // Auto-detect ISO 8601 duration strings (PTxxxS format) and convert to Duration
                     if let Some(duration) = try_parse_iso8601_duration(&s) {
-                        Ok(UniversalValue::Duration(duration))
+                        Ok(Value::Duration(duration))
                     } else {
-                        Ok(UniversalValue::Text(s))
+                        Ok(Value::Text(s))
                     }
                 }
-                None => Ok(UniversalValue::Null),
+                None => Ok(Value::Null),
             }
         }
-        Type::TIMESTAMP => match row.try_get::<_, Option<NaiveDateTime>>(index)? {
+        PgType::TIMESTAMP => match row.try_get::<_, Option<NaiveDateTime>>(index)? {
             Some(ts) => {
                 let dt = DateTime::<Utc>::from_naive_utc_and_offset(ts, Utc);
-                Ok(UniversalValue::LocalDateTime(dt))
+                Ok(Value::LocalDateTime(dt))
             }
-            None => Ok(UniversalValue::Null),
+            None => Ok(Value::Null),
         },
-        Type::TIMESTAMPTZ => match row.try_get::<_, Option<DateTime<Utc>>>(index)? {
-            Some(dt) => Ok(UniversalValue::ZonedDateTime(dt)),
-            None => Ok(UniversalValue::Null),
+        PgType::TIMESTAMPTZ => match row.try_get::<_, Option<DateTime<Utc>>>(index)? {
+            Some(dt) => Ok(Value::ZonedDateTime(dt)),
+            None => Ok(Value::Null),
         },
-        Type::DATE => match row.try_get::<_, Option<NaiveDate>>(index)? {
+        PgType::DATE => match row.try_get::<_, Option<NaiveDate>>(index)? {
             Some(date) => {
                 // Convert NaiveDate to DateTime<Utc> at midnight
                 let dt = date
                     .and_hms_opt(0, 0, 0)
                     .ok_or_else(|| anyhow::anyhow!("Invalid date"))?;
                 let dt = DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc);
-                Ok(UniversalValue::Date(dt))
+                Ok(Value::Date(dt))
             }
-            None => Ok(UniversalValue::Null),
+            None => Ok(Value::Null),
         },
-        Type::TIME => match row.try_get::<_, Option<NaiveTime>>(index)? {
+        PgType::TIME => match row.try_get::<_, Option<NaiveTime>>(index)? {
             Some(time) => {
                 // Convert NaiveTime to DateTime<Utc> using epoch date as placeholder
                 let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
                 let dt = epoch.and_time(time);
                 let dt = DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc);
-                Ok(UniversalValue::Time(dt))
+                Ok(Value::Time(dt))
             }
-            None => Ok(UniversalValue::Null),
+            None => Ok(Value::Null),
         },
-        Type::JSON | Type::JSONB => match row.try_get::<_, Option<serde_json::Value>>(index)? {
+        PgType::JSON | PgType::JSONB => match row.try_get::<_, Option<serde_json::Value>>(index)? {
             Some(json) => Ok(json_to_universal_value(json)),
-            None => Ok(UniversalValue::Null),
+            None => Ok(Value::Null),
         },
-        Type::UUID => match row.try_get::<_, Option<uuid::Uuid>>(index)? {
-            Some(uuid) => Ok(UniversalValue::Uuid(uuid)),
-            None => Ok(UniversalValue::Null),
+        PgType::UUID => match row.try_get::<_, Option<uuid::Uuid>>(index)? {
+            Some(uuid) => Ok(Value::Uuid(uuid)),
+            None => Ok(Value::Null),
         },
-        Type::BYTEA => match row.try_get::<_, Option<Vec<u8>>>(index)? {
-            Some(bytes) => Ok(UniversalValue::Bytes(bytes)),
-            None => Ok(UniversalValue::Null),
+        PgType::BYTEA => match row.try_get::<_, Option<Vec<u8>>>(index)? {
+            Some(bytes) => Ok(Value::Bytes(bytes)),
+            None => Ok(Value::Null),
         },
-        Type::TEXT_ARRAY => match row.try_get::<_, Option<Vec<String>>>(index)? {
+        PgType::TEXT_ARRAY => match row.try_get::<_, Option<Vec<String>>>(index)? {
             Some(arr) => {
-                let vals: Vec<UniversalValue> = arr.into_iter().map(UniversalValue::Text).collect();
-                Ok(UniversalValue::Array {
+                let vals: Vec<Value> = arr.into_iter().map(Value::Text).collect();
+                Ok(Value::Array {
                     elements: vals,
-                    element_type: Box::new(UniversalType::Text),
+                    element_type: Box::new(Type::Text),
                 })
             }
-            None => Ok(UniversalValue::Null),
+            None => Ok(Value::Null),
         },
-        Type::INT4_ARRAY => match row.try_get::<_, Option<Vec<i32>>>(index)? {
+        PgType::INT4_ARRAY => match row.try_get::<_, Option<Vec<i32>>>(index)? {
             Some(arr) => {
-                let vals: Vec<UniversalValue> =
-                    arr.into_iter().map(UniversalValue::Int32).collect();
-                Ok(UniversalValue::Array {
+                let vals: Vec<Value> = arr.into_iter().map(Value::Int32).collect();
+                Ok(Value::Array {
                     elements: vals,
-                    element_type: Box::new(UniversalType::Int32),
+                    element_type: Box::new(Type::Int32),
                 })
             }
-            None => Ok(UniversalValue::Null),
+            None => Ok(Value::Null),
         },
-        Type::INT8_ARRAY => match row.try_get::<_, Option<Vec<i64>>>(index)? {
+        PgType::INT8_ARRAY => match row.try_get::<_, Option<Vec<i64>>>(index)? {
             Some(arr) => {
-                let vals: Vec<UniversalValue> =
-                    arr.into_iter().map(UniversalValue::Int64).collect();
-                Ok(UniversalValue::Array {
+                let vals: Vec<Value> = arr.into_iter().map(Value::Int64).collect();
+                Ok(Value::Array {
                     elements: vals,
-                    element_type: Box::new(UniversalType::Int64),
+                    element_type: Box::new(Type::Int64),
                 })
             }
-            None => Ok(UniversalValue::Null),
+            None => Ok(Value::Null),
         },
-        Type::POINT => match row.try_get::<_, Option<geo_types::Point<f64>>>(index)? {
+        PgType::POINT => match row.try_get::<_, Option<geo_types::Point<f64>>>(index)? {
             Some(p) => {
                 let geojson = serde_json::json!({
                     "type": "Point",
                     "coordinates": [p.x(), p.y()]
                 });
-                Ok(UniversalValue::geometry_geojson(
-                    geojson,
-                    GeometryType::Point,
-                ))
+                Ok(Value::geometry_geojson(geojson, GeometryType::Point))
             }
-            None => Ok(UniversalValue::Null),
+            None => Ok(Value::Null),
         },
         _ => {
             // For unknown types, try to get as string
             if let Ok(val) = row.try_get::<_, String>(index) {
-                Ok(UniversalValue::Text(val))
+                Ok(Value::Text(val))
             } else {
                 Err(anyhow::anyhow!("Unsupported PostgreSQL type: {pg_type:?}",))
             }
@@ -734,34 +728,34 @@ fn convert_postgres_value_to_universal(row: &Row, index: usize) -> Result<Univer
     }
 }
 
-/// Convert JSON value to UniversalValue
-fn json_to_universal_value(value: serde_json::Value) -> UniversalValue {
+/// Convert JSON value to Value
+fn json_to_universal_value(value: serde_json::Value) -> Value {
     match value {
-        serde_json::Value::Null => UniversalValue::Null,
-        serde_json::Value::Bool(b) => UniversalValue::Bool(b),
+        serde_json::Value::Null => Value::Null,
+        serde_json::Value::Bool(b) => Value::Bool(b),
         serde_json::Value::Number(n) => {
             if let Some(i) = n.as_i64() {
-                UniversalValue::Int64(i)
+                Value::Int64(i)
             } else if let Some(f) = n.as_f64() {
-                UniversalValue::Float64(f)
+                Value::Float64(f)
             } else {
-                UniversalValue::Text(n.to_string())
+                Value::Text(n.to_string())
             }
         }
-        serde_json::Value::String(s) => UniversalValue::Text(s),
+        serde_json::Value::String(s) => Value::Text(s),
         serde_json::Value::Array(arr) => {
-            let vals: Vec<UniversalValue> = arr.into_iter().map(json_to_universal_value).collect();
-            UniversalValue::Array {
+            let vals: Vec<Value> = arr.into_iter().map(json_to_universal_value).collect();
+            Value::Array {
                 elements: vals,
-                element_type: Box::new(UniversalType::Json),
+                element_type: Box::new(Type::Json),
             }
         }
         serde_json::Value::Object(map) => {
-            let obj: HashMap<String, UniversalValue> = map
+            let obj: HashMap<String, Value> = map
                 .into_iter()
                 .map(|(k, v)| (k, json_to_universal_value(v)))
                 .collect();
-            UniversalValue::Object(obj)
+            Value::Object(obj)
         }
     }
 }

--- a/crates/postgresql/src/schema.rs
+++ b/crates/postgresql/src/schema.rs
@@ -7,9 +7,7 @@
 use anyhow::Result;
 use postgresql_types::postgresql_column_to_universal_type;
 use std::collections::HashMap;
-use sync_core::{
-    ColumnDefinition, DatabaseSchema, ForeignKeyDefinition, TableDefinition, UniversalType,
-};
+use sync_core::{ColumnDefinition, DatabaseSchema, ForeignKeyDefinition, TableDefinition, Type};
 use tokio_postgres::Client;
 
 /// (source_columns, referenced_table, referenced_columns) grouped per constraint.
@@ -47,7 +45,7 @@ pub async fn collect_database_schema(client: &Client) -> Result<DatabaseSchema> 
         pk_columns.entry(table_name).or_default().push(column_name);
     }
 
-    let mut table_columns: HashMap<String, Vec<(String, UniversalType)>> = HashMap::new();
+    let mut table_columns: HashMap<String, Vec<(String, Type)>> = HashMap::new();
     let mut enum_labels: HashMap<String, Vec<String>> = HashMap::new();
     let enum_rows = client
         .query(
@@ -85,7 +83,7 @@ pub async fn collect_database_schema(client: &Client) -> Result<DatabaseSchema> 
 
         let universal_type = if effective_type.eq_ignore_ascii_case("USER-DEFINED") {
             if let Some(labels) = enum_labels.get(&udt_name) {
-                UniversalType::Enum {
+                Type::Enum {
                     values: labels.clone(),
                 }
             } else {
@@ -121,8 +119,7 @@ pub async fn collect_database_schema(client: &Client) -> Result<DatabaseSchema> 
             }
         }
 
-        let pk =
-            primary_key.unwrap_or_else(|| ColumnDefinition::new(pk_col_name, UniversalType::Int64));
+        let pk = primary_key.unwrap_or_else(|| ColumnDefinition::new(pk_col_name, Type::Int64));
 
         let mut table_def = TableDefinition::new(table_name, pk, other_columns);
         if pk_list.len() > 1 {

--- a/crates/snowflake-source/src/client.rs
+++ b/crates/snowflake-source/src/client.rs
@@ -1,7 +1,7 @@
 //! Snowflake SQL REST API v2 client (key-pair JWT auth).
 //!
 //! Handles JWT generation, statement submission, asynchronous (`202`) polling,
-//! and result-partition pagination. Result decoding into `UniversalValue`s is
+//! and result-partition pagination. Result decoding into `Value`s is
 //! the job of the `snowflake-types` crate; this module only produces the raw
 //! `(rowType, data)` pair.
 //!

--- a/crates/snowflake-source/src/full_sync.rs
+++ b/crates/snowflake-source/src/full_sync.rs
@@ -22,7 +22,7 @@ use async_trait::async_trait;
 use serde_json::Value as JsonValue;
 use snowflake_types::{convert_cell, ColumnType};
 use surreal_sink::SurrealSink;
-use sync_core::{UniversalRow, UniversalValue};
+use sync_core::{Row, Value};
 use sync_transform::{
     run_source_runtime_with, ApplyOpts, Pipeline, RowChunkDriver, RowChunkSource, SourceRuntimeOpts,
 };
@@ -182,7 +182,7 @@ pub async fn apply_query_stream_with_transforms<S: SurrealSink>(
 
     #[async_trait]
     impl RowChunkSource for SnowflakePartitionChunks<'_> {
-        async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<UniversalRow>>> {
+        async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<Row>>> {
             let Some(raw_batch) = self.stream.next_batch(self.batch_size).await? else {
                 return Ok(None);
             };
@@ -264,7 +264,7 @@ pub async fn apply_query_result_with_transforms<S: SurrealSink>(
 
     #[async_trait]
     impl RowChunkSource for InMemoryRowChunks<'_> {
-        async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<UniversalRow>>> {
+        async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<Row>>> {
             if self.next_index >= self.rows.len() {
                 return Ok(None);
             }
@@ -308,7 +308,7 @@ fn convert_row(
     columns: &[ColumnType],
     id_indices: &[usize],
     id_index_set: &HashSet<usize>,
-) -> Result<UniversalRow> {
+) -> Result<Row> {
     if row.len() != columns.len() {
         return Err(anyhow!(
             "row {row_index} of table '{table}' has {} cells but {} columns were declared",
@@ -317,7 +317,7 @@ fn convert_row(
         ));
     }
 
-    let mut fields: HashMap<String, UniversalValue> = HashMap::new();
+    let mut fields: HashMap<String, Value> = HashMap::new();
     for (i, col) in columns.iter().enumerate() {
         // When ID columns are explicit, keep them out of the field map so the
         // record ID is not duplicated as a field (matches the PostgreSQL PK behavior).
@@ -329,12 +329,7 @@ fn convert_row(
     }
 
     let id = build_record_id(row, row_index, id_indices);
-    Ok(UniversalRow::new(
-        table.to_string(),
-        row_index as u64,
-        id,
-        fields,
-    ))
+    Ok(Row::new(table.to_string(), row_index as u64, id, fields))
 }
 
 /// Map the configured ID column names to their positions in the result set.
@@ -357,28 +352,27 @@ fn resolve_id_columns(columns: &[ColumnType], id_columns: &[String]) -> Result<V
 /// - No ID columns: sequential per-table index (`Int64`). Deterministic within a
 ///   run, but not stable across re-runs.
 /// - Single ID column: the cell as `Int64` when it parses as an integer, else `Text`.
-/// - Composite ID columns: an [`UniversalValue::Array`] of scalar parts (Surreal
+/// - Composite ID columns: an [`Value::Array`] of scalar parts (Surreal
 ///   array record ID). Use the `flatten_id` transform to restore colon-joined Text.
-fn build_record_id(row: &[JsonValue], row_index: usize, id_indices: &[usize]) -> UniversalValue {
+fn build_record_id(row: &[JsonValue], row_index: usize, id_indices: &[usize]) -> Value {
     match id_indices {
-        [] => UniversalValue::Int64(row_index as i64),
+        [] => Value::Int64(row_index as i64),
         [only] => cell_to_id_scalar(&row[*only]),
         many => {
-            let parts: Vec<UniversalValue> =
-                many.iter().map(|&i| cell_to_id_scalar(&row[i])).collect();
-            UniversalValue::Array {
+            let parts: Vec<Value> = many.iter().map(|&i| cell_to_id_scalar(&row[i])).collect();
+            Value::Array {
                 elements: parts,
-                element_type: Box::new(sync_core::UniversalType::Text),
+                element_type: Box::new(sync_core::Type::Text),
             }
         }
     }
 }
 
-fn cell_to_id_scalar(cell: &JsonValue) -> UniversalValue {
+fn cell_to_id_scalar(cell: &JsonValue) -> Value {
     let s = cell_to_string(cell);
     match s.parse::<i64>() {
-        Ok(n) => UniversalValue::Int64(n),
-        Err(_) => UniversalValue::Text(s),
+        Ok(n) => Value::Int64(n),
+        Err(_) => Value::Text(s),
     }
 }
 
@@ -398,13 +392,13 @@ mod tests {
     #[test]
     fn auto_generated_id_is_row_index() {
         let row = vec![json!("x")];
-        assert_eq!(build_record_id(&row, 7, &[]), UniversalValue::Int64(7));
+        assert_eq!(build_record_id(&row, 7, &[]), Value::Int64(7));
     }
 
     #[test]
     fn single_integer_id_column_is_int64() {
         let row = vec![json!("42"), json!("name")];
-        assert_eq!(build_record_id(&row, 0, &[0]), UniversalValue::Int64(42));
+        assert_eq!(build_record_id(&row, 0, &[0]), Value::Int64(42));
     }
 
     #[test]
@@ -412,7 +406,7 @@ mod tests {
         let row = vec![json!("abc"), json!("name")];
         assert_eq!(
             build_record_id(&row, 0, &[0]),
-            UniversalValue::Text("abc".to_string())
+            Value::Text("abc".to_string())
         );
     }
 
@@ -421,12 +415,9 @@ mod tests {
         let row = vec![json!("a"), json!("b"), json!("c")];
         assert_eq!(
             build_record_id(&row, 0, &[0, 2]),
-            UniversalValue::Array {
-                elements: vec![
-                    UniversalValue::Text("a".to_string()),
-                    UniversalValue::Text("c".to_string()),
-                ],
-                element_type: Box::new(sync_core::UniversalType::Text),
+            Value::Array {
+                elements: vec![Value::Text("a".to_string()), Value::Text("c".to_string()),],
+                element_type: Box::new(sync_core::Type::Text),
             }
         );
     }

--- a/crates/snowflake-source/tests/transforms.rs
+++ b/crates/snowflake-source/tests/transforms.rs
@@ -11,11 +11,11 @@ use surreal_sink::SurrealSink;
 use surreal_sync_snowflake_source::{
     apply_query_result_with_transforms, QueryResult, SourceOpts, SyncOpts,
 };
-use sync_core::{UniversalChange, UniversalRelation, UniversalRow, UniversalValue};
+use sync_core::{Change, Relation, Row, Value};
 use sync_transform::{ApplyOpts, ChildStdioMode, ExternalTransform, FramerKind, Pipeline};
 
 struct CaptureSink {
-    rows: Mutex<Vec<UniversalRow>>,
+    rows: Mutex<Vec<Row>>,
     rows_written: Arc<AtomicUsize>,
 }
 
@@ -28,31 +28,28 @@ impl CaptureSink {
     }
 }
 
-fn change_to_row(change: &UniversalChange, index: u64) -> UniversalRow {
-    UniversalRow::new(
+fn change_to_row(change: &Change, index: u64) -> Row {
+    Row::new(
         change.table.clone(),
         index,
         change.id.clone(),
-        change.data.clone().unwrap_or_default(),
+        change.fields.clone().unwrap_or_default(),
     )
 }
 
 #[async_trait::async_trait]
 impl SurrealSink for CaptureSink {
-    async fn write_universal_rows(&self, rows: &[UniversalRow]) -> anyhow::Result<()> {
+    async fn write_rows(&self, rows: &[Row]) -> anyhow::Result<()> {
         self.rows_written.fetch_add(rows.len(), Ordering::SeqCst);
         self.rows.lock().expect("lock").extend(rows.iter().cloned());
         Ok(())
     }
 
-    async fn write_universal_relations(
-        &self,
-        _relations: &[UniversalRelation],
-    ) -> anyhow::Result<()> {
+    async fn write_relations(&self, _relations: &[Relation]) -> anyhow::Result<()> {
         Ok(())
     }
 
-    async fn apply_universal_change(&self, change: &UniversalChange) -> anyhow::Result<()> {
+    async fn apply_change(&self, change: &Change) -> anyhow::Result<()> {
         let mut rows = self.rows.lock().expect("lock");
         let index = rows.len() as u64;
         rows.push(change_to_row(change, index));
@@ -60,9 +57,9 @@ impl SurrealSink for CaptureSink {
         Ok(())
     }
 
-    async fn apply_universal_relation_change(
+    async fn apply_relation_change(
         &self,
-        _change: &sync_core::UniversalRelationChange,
+        _change: &sync_core::RelationChange,
     ) -> anyhow::Result<()> {
         Ok(())
     }
@@ -134,9 +131,9 @@ fn sample_opts() -> (SourceOpts, SyncOpts) {
     (source, sync)
 }
 
-fn row_name(row: &UniversalRow) -> Option<String> {
+fn row_name(row: &Row) -> Option<String> {
     match row.fields.get("name")? {
-        UniversalValue::Text(value) => Some(value.clone()),
+        Value::Text(value) => Some(value.clone()),
         other => panic!("unexpected name: {other:?}"),
     }
 }

--- a/crates/snowflake-types/src/lib.rs
+++ b/crates/snowflake-types/src/lib.rs
@@ -3,7 +3,7 @@
 //! The Snowflake SQL REST API returns every result cell as a JSON string (or
 //! JSON `null`), together with per-column metadata (`resultSetMetaData.rowType`)
 //! describing the logical Snowflake type. This crate turns a `(cell, column)`
-//! pair into a [`sync_core::UniversalValue`], the intermediate representation the
+//! pair into a [`sync_core::Value`], the intermediate representation the
 //! rest of surreal-sync writes to SurrealDB.
 //!
 //! It is intentionally free of any network or HTTP concerns so the conversion
@@ -32,7 +32,7 @@ use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, NaiveDate, Utc};
 use serde_json::Value as JsonValue;
 use std::collections::HashMap;
-use sync_core::{UniversalType, UniversalValue};
+use sync_core::{Type, Value};
 
 /// Metadata for a single result column, deserialized directly from the Snowflake
 /// SQL API `resultSetMetaData.rowType[]` entries.
@@ -84,16 +84,16 @@ impl ColumnType {
     }
 }
 
-/// Convert a single SQL API result cell into a [`UniversalValue`], using the
+/// Convert a single SQL API result cell into a [`Value`], using the
 /// column's Snowflake type metadata to interpret the stringified value.
 ///
 /// `raw` is the JSON value straight out of the `data` array: a
 /// [`JsonValue::String`] for present scalars, [`JsonValue::Null`] for SQL NULL,
 /// and (defensively) a JSON number/bool if a future server ever emits one.
-pub fn convert_cell(raw: &JsonValue, col: &ColumnType) -> Result<UniversalValue> {
+pub fn convert_cell(raw: &JsonValue, col: &ColumnType) -> Result<Value> {
     // SQL NULL is a genuine JSON null (not the string "null").
     if raw.is_null() {
-        return Ok(UniversalValue::Null);
+        return Ok(Value::Null);
     }
 
     let text = cell_as_string(raw);
@@ -110,12 +110,12 @@ pub fn convert_cell(raw: &JsonValue, col: &ColumnType) -> Result<UniversalValue>
                 .trim()
                 .parse()
                 .with_context(|| format!("column '{}': invalid float '{text}'", col.name))?;
-            UniversalValue::Float64(f)
+            Value::Float64(f)
         }
 
-        "text" | "string" | "varchar" | "char" | "character" => UniversalValue::Text(text),
+        "text" | "string" | "varchar" | "char" | "character" => Value::Text(text),
 
-        "boolean" | "bool" => UniversalValue::Bool(parse_bool(&text)?),
+        "boolean" | "bool" => Value::Bool(parse_bool(&text)?),
 
         "date" => convert_date(&text).with_context(|| format!("column '{}' (date)", col.name))?,
 
@@ -124,13 +124,13 @@ pub fn convert_cell(raw: &JsonValue, col: &ColumnType) -> Result<UniversalValue>
         "timestamp_ntz" | "timestampntz" | "datetime" => {
             let dt = convert_epoch_timestamp(&text)
                 .with_context(|| format!("column '{}' (timestamp_ntz)", col.name))?;
-            UniversalValue::LocalDateTime(dt)
+            Value::LocalDateTime(dt)
         }
 
         "timestamp_ltz" | "timestampltz" | "timestamp_tz" | "timestamptz" | "timestamp" => {
             let dt = convert_epoch_timestamp(&text)
                 .with_context(|| format!("column '{}' (timestamp)", col.name))?;
-            UniversalValue::ZonedDateTime(dt)
+            Value::ZonedDateTime(dt)
         }
 
         "variant" | "object" => {
@@ -143,23 +143,23 @@ pub fn convert_cell(raw: &JsonValue, col: &ColumnType) -> Result<UniversalValue>
             let json: JsonValue = serde_json::from_str(&text)
                 .with_context(|| format!("column '{}': invalid ARRAY JSON", col.name))?;
             match json_to_universal_value(json) {
-                arr @ UniversalValue::Array { .. } => arr,
+                arr @ Value::Array { .. } => arr,
                 // A non-array VARIANT stored in an ARRAY column: wrap defensively.
-                other => UniversalValue::Array {
+                other => Value::Array {
                     elements: vec![other],
-                    element_type: Box::new(UniversalType::Json),
+                    element_type: Box::new(Type::Json),
                 },
             }
         }
 
-        "binary" | "varbinary" => UniversalValue::Bytes(
+        "binary" | "varbinary" => Value::Bytes(
             decode_hex(text.trim())
                 .with_context(|| format!("column '{}': invalid hex BINARY", col.name))?,
         ),
 
         // Unknown/unsupported logical type: preserve the raw text rather than
         // failing the whole sync.
-        _ => UniversalValue::Text(text),
+        _ => Value::Text(text),
     };
 
     Ok(value)
@@ -174,7 +174,7 @@ fn cell_as_string(raw: &JsonValue) -> String {
     }
 }
 
-fn convert_fixed(text: &str, col: &ColumnType) -> Result<UniversalValue> {
+fn convert_fixed(text: &str, col: &ColumnType) -> Result<Value> {
     let scale = col.scale.unwrap_or(0);
     let trimmed = text.trim();
 
@@ -182,14 +182,14 @@ fn convert_fixed(text: &str, col: &ColumnType) -> Result<UniversalValue> {
         // Integer NUMBER. Prefer i64; fall back to Decimal when it does not fit
         // (Snowflake NUMBER supports up to 38 digits of precision).
         if let Ok(n) = trimmed.parse::<i64>() {
-            return Ok(UniversalValue::Int64(n));
+            return Ok(Value::Int64(n));
         }
     }
 
     let precision = col.precision.unwrap_or(38).clamp(0, u8::MAX as i64) as u8;
     let scale_u8 = scale.clamp(0, u8::MAX as i64) as u8;
 
-    Ok(UniversalValue::Decimal {
+    Ok(Value::Decimal {
         value: trimmed.to_string(),
         precision,
         scale: scale_u8,
@@ -205,7 +205,7 @@ fn parse_bool(text: &str) -> Result<bool> {
 }
 
 /// DATE: integer number of days since the Unix epoch.
-fn convert_date(text: &str) -> Result<UniversalValue> {
+fn convert_date(text: &str) -> Result<Value> {
     let days: i64 = text
         .trim()
         .parse()
@@ -218,11 +218,11 @@ fn convert_date(text: &str) -> Result<UniversalValue> {
         Utc,
     );
     let dt = epoch + chrono::Duration::days(days);
-    Ok(UniversalValue::Date(dt))
+    Ok(Value::Date(dt))
 }
 
 /// TIME: seconds since midnight with a fractional part.
-fn convert_time(text: &str) -> Result<UniversalValue> {
+fn convert_time(text: &str) -> Result<Value> {
     let (secs, nanos) = parse_epoch_fraction(text)?;
     let epoch = DateTime::<Utc>::from_naive_utc_and_offset(
         NaiveDate::from_ymd_opt(1970, 1, 1)
@@ -232,7 +232,7 @@ fn convert_time(text: &str) -> Result<UniversalValue> {
         Utc,
     );
     let dt = epoch + chrono::Duration::seconds(secs) + chrono::Duration::nanoseconds(nanos as i64);
-    Ok(UniversalValue::Time(dt))
+    Ok(Value::Time(dt))
 }
 
 /// TIMESTAMP_*: seconds since the Unix epoch with a fractional part, optionally
@@ -288,35 +288,34 @@ fn parse_epoch_fraction(text: &str) -> Result<(i64, u32)> {
 }
 
 /// Recursively convert a decoded JSON document (VARIANT/OBJECT/ARRAY) into a
-/// [`UniversalValue`], mirroring the PostgreSQL source's JSON handling.
-fn json_to_universal_value(value: JsonValue) -> UniversalValue {
+/// [`Value`], mirroring the PostgreSQL source's JSON handling.
+fn json_to_universal_value(value: JsonValue) -> Value {
     match value {
-        JsonValue::Null => UniversalValue::Null,
-        JsonValue::Bool(b) => UniversalValue::Bool(b),
+        JsonValue::Null => Value::Null,
+        JsonValue::Bool(b) => Value::Bool(b),
         JsonValue::Number(n) => {
             if let Some(i) = n.as_i64() {
-                UniversalValue::Int64(i)
+                Value::Int64(i)
             } else if let Some(f) = n.as_f64() {
-                UniversalValue::Float64(f)
+                Value::Float64(f)
             } else {
-                UniversalValue::Text(n.to_string())
+                Value::Text(n.to_string())
             }
         }
-        JsonValue::String(s) => UniversalValue::Text(s),
+        JsonValue::String(s) => Value::Text(s),
         JsonValue::Array(arr) => {
-            let elements: Vec<UniversalValue> =
-                arr.into_iter().map(json_to_universal_value).collect();
-            UniversalValue::Array {
+            let elements: Vec<Value> = arr.into_iter().map(json_to_universal_value).collect();
+            Value::Array {
                 elements,
-                element_type: Box::new(UniversalType::Json),
+                element_type: Box::new(Type::Json),
             }
         }
         JsonValue::Object(map) => {
-            let obj: HashMap<String, UniversalValue> = map
+            let obj: HashMap<String, Value> = map
                 .into_iter()
                 .map(|(k, v)| (k, json_to_universal_value(v)))
                 .collect();
-            UniversalValue::Object(obj)
+            Value::Object(obj)
         }
     }
 }
@@ -358,11 +357,11 @@ mod tests {
     fn null_cell_maps_to_null_regardless_of_type() {
         assert_eq!(
             convert_cell(&JsonValue::Null, &col("fixed")).unwrap(),
-            UniversalValue::Null
+            Value::Null
         );
         assert_eq!(
             convert_cell(&JsonValue::Null, &col("text")).unwrap(),
-            UniversalValue::Null
+            Value::Null
         );
     }
 
@@ -371,21 +370,15 @@ mod tests {
         // The JSON string "null" is real data, not SQL NULL.
         assert_eq!(
             convert_cell(&json!("null"), &col("text")).unwrap(),
-            UniversalValue::Text("null".to_string())
+            Value::Text("null".to_string())
         );
     }
 
     #[test]
     fn fixed_scale_zero_is_int64() {
         let c = col("fixed").with_precision(10).with_scale(0);
-        assert_eq!(
-            convert_cell(&json!("42"), &c).unwrap(),
-            UniversalValue::Int64(42)
-        );
-        assert_eq!(
-            convert_cell(&json!("-7"), &c).unwrap(),
-            UniversalValue::Int64(-7)
-        );
+        assert_eq!(convert_cell(&json!("42"), &c).unwrap(), Value::Int64(42));
+        assert_eq!(convert_cell(&json!("-7"), &c).unwrap(), Value::Int64(-7));
     }
 
     #[test]
@@ -393,7 +386,7 @@ mod tests {
         let c = col("fixed").with_precision(10).with_scale(2);
         assert_eq!(
             convert_cell(&json!("3.14"), &c).unwrap(),
-            UniversalValue::Decimal {
+            Value::Decimal {
                 value: "3.14".to_string(),
                 precision: 10,
                 scale: 2,
@@ -408,7 +401,7 @@ mod tests {
         let big = "123456789012345678901234567890";
         assert_eq!(
             convert_cell(&json!(big), &c).unwrap(),
-            UniversalValue::Decimal {
+            Value::Decimal {
                 value: big.to_string(),
                 precision: 38,
                 scale: 0,
@@ -420,7 +413,7 @@ mod tests {
     fn real_is_float64() {
         assert_eq!(
             convert_cell(&json!("1.5"), &col("real")).unwrap(),
-            UniversalValue::Float64(1.5)
+            Value::Float64(1.5)
         );
     }
 
@@ -428,7 +421,7 @@ mod tests {
     fn text_passthrough() {
         assert_eq!(
             convert_cell(&json!("hello"), &col("text")).unwrap(),
-            UniversalValue::Text("hello".to_string())
+            Value::Text("hello".to_string())
         );
     }
 
@@ -436,31 +429,31 @@ mod tests {
     fn boolean_variants() {
         assert_eq!(
             convert_cell(&json!("true"), &col("boolean")).unwrap(),
-            UniversalValue::Bool(true)
+            Value::Bool(true)
         );
         assert_eq!(
             convert_cell(&json!("false"), &col("boolean")).unwrap(),
-            UniversalValue::Bool(false)
+            Value::Bool(false)
         );
         assert_eq!(
             convert_cell(&json!("1"), &col("boolean")).unwrap(),
-            UniversalValue::Bool(true)
+            Value::Bool(true)
         );
         assert_eq!(
             convert_cell(&json!("0"), &col("boolean")).unwrap(),
-            UniversalValue::Bool(false)
+            Value::Bool(false)
         );
     }
 
     #[test]
     fn date_days_since_epoch() {
         // 0 days => 1970-01-01, 1 day => 1970-01-02.
-        let UniversalValue::Date(dt) = convert_cell(&json!("0"), &col("date")).unwrap() else {
+        let Value::Date(dt) = convert_cell(&json!("0"), &col("date")).unwrap() else {
             panic!("expected Date");
         };
         assert_eq!(dt.format("%Y-%m-%d").to_string(), "1970-01-01");
 
-        let UniversalValue::Date(dt) = convert_cell(&json!("19024"), &col("date")).unwrap() else {
+        let Value::Date(dt) = convert_cell(&json!("19024"), &col("date")).unwrap() else {
             panic!("expected Date");
         };
         assert_eq!(dt.format("%Y-%m-%d").to_string(), "2022-02-01");
@@ -469,9 +462,7 @@ mod tests {
     #[test]
     fn time_seconds_since_midnight() {
         // 3661.5s => 01:01:01.5
-        let UniversalValue::Time(dt) =
-            convert_cell(&json!("3661.500000000"), &col("time")).unwrap()
-        else {
+        let Value::Time(dt) = convert_cell(&json!("3661.500000000"), &col("time")).unwrap() else {
             panic!("expected Time");
         };
         assert_eq!(dt.format("%H:%M:%S").to_string(), "01:01:01");
@@ -480,7 +471,7 @@ mod tests {
 
     #[test]
     fn timestamp_ntz_is_local_datetime() {
-        let UniversalValue::LocalDateTime(dt) =
+        let Value::LocalDateTime(dt) =
             convert_cell(&json!("1640995200.000000000"), &col("timestamp_ntz")).unwrap()
         else {
             panic!("expected LocalDateTime");
@@ -493,7 +484,7 @@ mod tests {
 
     #[test]
     fn timestamp_ltz_is_zoned_datetime() {
-        let UniversalValue::ZonedDateTime(dt) =
+        let Value::ZonedDateTime(dt) =
             convert_cell(&json!("1623456789.123456789"), &col("timestamp_ltz")).unwrap()
         else {
             panic!("expected ZonedDateTime");
@@ -505,7 +496,7 @@ mod tests {
     #[test]
     fn timestamp_tz_ignores_offset_token() {
         // "<epoch> <offset>" — the offset token must not break parsing.
-        let UniversalValue::ZonedDateTime(dt) =
+        let Value::ZonedDateTime(dt) =
             convert_cell(&json!("1623456789.000000000 1440"), &col("timestamp_tz")).unwrap()
         else {
             panic!("expected ZonedDateTime");
@@ -515,29 +506,24 @@ mod tests {
 
     #[test]
     fn variant_object_becomes_object() {
-        let UniversalValue::Object(map) =
+        let Value::Object(map) =
             convert_cell(&json!("{\"a\":1,\"b\":\"x\"}"), &col("object")).unwrap()
         else {
             panic!("expected Object");
         };
-        assert_eq!(map.get("a"), Some(&UniversalValue::Int64(1)));
-        assert_eq!(map.get("b"), Some(&UniversalValue::Text("x".to_string())));
+        assert_eq!(map.get("a"), Some(&Value::Int64(1)));
+        assert_eq!(map.get("b"), Some(&Value::Text("x".to_string())));
     }
 
     #[test]
     fn array_becomes_array() {
-        let UniversalValue::Array { elements, .. } =
-            convert_cell(&json!("[1,2,3]"), &col("array")).unwrap()
+        let Value::Array { elements, .. } = convert_cell(&json!("[1,2,3]"), &col("array")).unwrap()
         else {
             panic!("expected Array");
         };
         assert_eq!(
             elements,
-            vec![
-                UniversalValue::Int64(1),
-                UniversalValue::Int64(2),
-                UniversalValue::Int64(3),
-            ]
+            vec![Value::Int64(1), Value::Int64(2), Value::Int64(3),]
         );
     }
 
@@ -545,7 +531,7 @@ mod tests {
     fn binary_hex_decodes() {
         assert_eq!(
             convert_cell(&json!("DEADBEEF"), &col("binary")).unwrap(),
-            UniversalValue::Bytes(vec![0xDE, 0xAD, 0xBE, 0xEF])
+            Value::Bytes(vec![0xDE, 0xAD, 0xBE, 0xEF])
         );
     }
 
@@ -553,7 +539,7 @@ mod tests {
     fn unknown_type_falls_back_to_text() {
         assert_eq!(
             convert_cell(&json!("geospatial-thing"), &col("geography")).unwrap(),
-            UniversalValue::Text("geospatial-thing".to_string())
+            Value::Text("geospatial-thing".to_string())
         );
     }
 

--- a/crates/surreal-sink/src/lib.rs
+++ b/crates/surreal-sink/src/lib.rs
@@ -4,8 +4,8 @@
 //! version differences. Both `surreal2-sink` and `surreal3-sink` implement this
 //! trait, allowing source crates to write version-independent code.
 //!
-//! The trait uses sync-core universal types (UniversalRow, UniversalRelation,
-//! UniversalChange) to avoid coupling to specific SurrealDB SDK types.
+//! The trait uses sync-core universal types (Row, Relation,
+//! Change) to avoid coupling to specific SurrealDB SDK types.
 
 mod traits;
 mod version;

--- a/crates/surreal-sink/src/traits.rs
+++ b/crates/surreal-sink/src/traits.rs
@@ -5,7 +5,7 @@
 //! with both v2 and v3 servers.
 
 use anyhow::Result;
-use sync_core::{UniversalChange, UniversalRelation, UniversalRelationChange, UniversalRow};
+use sync_core::{Change, Relation, RelationChange, Row};
 
 /// Trait for writing data to SurrealDB.
 ///
@@ -23,7 +23,7 @@ use sync_core::{UniversalChange, UniversalRelation, UniversalRelationChange, Uni
 ///     opts: &SourceOpts,
 /// ) -> Result<()> {
 ///     // All calls here are statically dispatched after monomorphization
-///     surreal.write_universal_rows(&batch).await?;
+///     surreal.write_rows(&batch).await?;
 /// }
 /// ```
 ///
@@ -33,28 +33,27 @@ use sync_core::{UniversalChange, UniversalRelation, UniversalRelationChange, Uni
 pub trait SurrealSink: Send + Sync {
     /// Write a batch of universal rows to SurrealDB.
     ///
-    /// Converts each `UniversalRow` to the appropriate SurrealDB record
+    /// Converts each `Row` to the appropriate SurrealDB record
     /// format and writes it using UPSERT semantics.
-    async fn write_universal_rows(&self, rows: &[UniversalRow]) -> Result<()>;
+    async fn write_rows(&self, rows: &[Row]) -> Result<()>;
 
     /// Write a batch of universal relations to SurrealDB.
     ///
-    /// Converts each `UniversalRelation` to a SurrealDB relation (graph edge)
+    /// Converts each `Relation` to a SurrealDB relation (graph edge)
     /// and writes it using RELATE semantics.
-    async fn write_universal_relations(&self, relations: &[UniversalRelation]) -> Result<()>;
+    async fn write_relations(&self, relations: &[Relation]) -> Result<()>;
 
     /// Apply a single universal change (create/update/delete) to SurrealDB.
     ///
-    /// Converts the `UniversalChange` to the appropriate SurrealDB operation:
+    /// Converts the `Change` to the appropriate SurrealDB operation:
     /// - Create/Update: UPSERT the record
     /// - Delete: DELETE the record
-    async fn apply_universal_change(&self, change: &UniversalChange) -> Result<()>;
+    async fn apply_change(&self, change: &Change) -> Result<()>;
 
     /// Apply a single relation change (create/update/delete) to SurrealDB.
     ///
-    /// Converts the `UniversalRelationChange` to the appropriate SurrealDB operation:
+    /// Converts the `RelationChange` to the appropriate SurrealDB operation:
     /// - Create/Update: RELATE the edge
     /// - Delete: DELETE the relation
-    async fn apply_universal_relation_change(&self, change: &UniversalRelationChange)
-        -> Result<()>;
+    async fn apply_relation_change(&self, change: &RelationChange) -> Result<()>;
 }

--- a/crates/surreal2-sink/src/change.rs
+++ b/crates/surreal2-sink/src/change.rs
@@ -3,51 +3,53 @@ use surreal2_types::SurrealValue;
 use surreal2_types::{RecordWithSurrealValues as Record, Relation};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum ChangeOp {
+pub enum MutationOp {
     Create,
     Update,
     Delete,
 }
 
 #[derive(Debug, Clone)]
-pub enum Change {
+pub enum Mutation {
     UpsertRecord(Record),
     DeleteRecord(surrealdb::sql::Thing),
     UpsertRelation(Relation),
     DeleteRelation(surrealdb::sql::Thing),
 }
 
-impl Change {
+impl Mutation {
     /// Create a record change using native surrealdb::sql::Value types.
     pub fn record(
-        operation: ChangeOp,
+        operation: MutationOp,
         id: surrealdb::sql::Thing,
         data: HashMap<String, surrealdb::sql::Value>,
     ) -> Self {
         match operation {
-            ChangeOp::Create | ChangeOp::Update => Change::UpsertRecord(Record::new(id, data)),
-            ChangeOp::Delete => Change::DeleteRecord(id),
+            MutationOp::Create | MutationOp::Update => {
+                Mutation::UpsertRecord(Record::new(id, data))
+            }
+            MutationOp::Delete => Mutation::DeleteRecord(id),
         }
     }
 
     pub fn relation(
-        operation: ChangeOp,
+        operation: MutationOp,
         id: surrealdb::sql::Thing,
         input: surrealdb::sql::Thing,
         output: surrealdb::sql::Thing,
         data: Option<HashMap<String, SurrealValue>>,
     ) -> Self {
         match operation {
-            ChangeOp::Create | ChangeOp::Update => {
+            MutationOp::Create | MutationOp::Update => {
                 let data = data.expect("Data must be provided for create/update relation");
-                Change::UpsertRelation(Relation {
+                Mutation::UpsertRelation(Relation {
                     id,
                     input,
                     output,
                     data,
                 })
             }
-            ChangeOp::Delete => Change::DeleteRelation(id.clone()),
+            MutationOp::Delete => Mutation::DeleteRelation(id.clone()),
         }
     }
 }

--- a/crates/surreal2-sink/src/lib.rs
+++ b/crates/surreal2-sink/src/lib.rs
@@ -8,17 +8,17 @@ mod rows;
 mod sink_impl;
 mod write;
 
-pub use change::{Change, ChangeOp};
+pub use change::{Mutation, MutationOp};
 pub use connect::{surreal_connect, surreal_connect_with_retries, SurrealOpts};
 pub use rows::{
-    universal_relation_to_surreal_relation, universal_row_to_surreal_record,
-    universal_value_to_surreal_id, write_universal_relations, write_universal_rows,
+    relation_to_surreal_relation, row_to_surreal_record, value_to_surreal_id, write_relations,
+    write_rows,
 };
 pub use sink_impl::Surreal2Sink;
 pub use sync_core::ZeroTemporalPolicy;
 pub use write::{
-    apply_change, apply_universal_change, write_record, write_records, write_relation,
-    write_relations,
+    apply_change, apply_mutation, write_native_relations, write_record, write_records,
+    write_relation,
 };
 
 // Re-export SurrealDB types for use by source crates

--- a/crates/surreal2-sink/src/rows.rs
+++ b/crates/surreal2-sink/src/rows.rs
@@ -1,31 +1,31 @@
-//! Row-level operations for converting and writing UniversalRow to SurrealDB.
+//! Row-level operations for converting and writing Row to SurrealDB.
 
 use crate::write::{write_record, write_relation};
 use anyhow::{bail, Result};
 use std::collections::HashMap;
-use surreal2_types::{RecordWithSurrealValues, Relation, SurrealValue};
-use surrealdb::sql::{Array, Id, Strand, Thing, Value};
+use surreal2_types::{RecordWithSurrealValues, Relation as SurrealRelation, SurrealValue};
+use surrealdb::sql::{Array, Id, Strand, Thing, Value as SqlValue};
 use surrealdb::Surreal;
-use sync_core::{UniversalRelation, UniversalRow, UniversalValue, ZeroTemporalPolicy};
+use sync_core::{Relation, Row, Value, ZeroTemporalPolicy};
 
-/// Convert UniversalValue ID to SurrealDB Id.
+/// Convert Value ID to SurrealDB Id.
 ///
 /// Returns an error for unsupported ID types - never falls back silently.
-/// Composite primary keys arrive as [`UniversalValue::Array`] and become
+/// Composite primary keys arrive as [`Value::Array`] and become
 /// SurrealDB array record IDs (`table:[k1, k2]`).
-pub fn universal_value_to_surreal_id(value: &UniversalValue) -> Result<Id> {
+pub fn value_to_surreal_id(value: &Value) -> Result<Id> {
     match value {
-        UniversalValue::Text(s) => Ok(Id::String(s.clone())),
-        UniversalValue::VarChar { value, .. } => Ok(Id::String(value.clone())),
-        UniversalValue::Char { value, .. } => Ok(Id::String(value.clone())),
-        UniversalValue::Int32(n) => Ok(Id::Number(*n as i64)),
-        UniversalValue::Int64(n) => Ok(Id::Number(*n)),
-        UniversalValue::Uuid(u) => Ok(Id::Uuid(surrealdb::sql::Uuid::from(*u))),
-        UniversalValue::Ulid(u) => {
+        Value::Text(s) => Ok(Id::String(s.clone())),
+        Value::VarChar { value, .. } => Ok(Id::String(value.clone())),
+        Value::Char { value, .. } => Ok(Id::String(value.clone())),
+        Value::Int32(n) => Ok(Id::Number(*n as i64)),
+        Value::Int64(n) => Ok(Id::Number(*n)),
+        Value::Uuid(u) => Ok(Id::Uuid(surrealdb::sql::Uuid::from(*u))),
+        Value::Ulid(u) => {
             // Convert ULID to string since SurrealDB doesn't have native ULID ID type
             Ok(Id::String(u.to_string()))
         }
-        UniversalValue::Array { elements, .. } => {
+        Value::Array { elements, .. } => {
             if elements.is_empty() {
                 bail!("Composite SurrealDB ID Array must not be empty");
             }
@@ -39,28 +39,28 @@ pub fn universal_value_to_surreal_id(value: &UniversalValue) -> Result<Id> {
             Ok(Id::Array(Array::from(vals)))
         }
         other => bail!(
-            "Unsupported UniversalValue type for SurrealDB ID: {other:?}. \
+            "Unsupported Value type for SurrealDB ID: {other:?}. \
              Supported types: Text, VarChar, Char, Int32, Int64, Uuid, Ulid, Array"
         ),
     }
 }
 
-/// Convert one element of a composite (Array) record ID to a SurrealDB [`Value`].
-fn universal_value_to_id_array_element(value: &UniversalValue) -> Result<Value> {
+/// Convert one element of a composite (Array) record ID to a SurrealDB [`SqlValue`].
+fn universal_value_to_id_array_element(value: &Value) -> Result<SqlValue> {
     match value {
-        UniversalValue::Text(s) => Ok(Value::Strand(Strand::from(s.clone()))),
-        UniversalValue::VarChar { value, .. } | UniversalValue::Char { value, .. } => {
-            Ok(Value::Strand(Strand::from(value.clone())))
+        Value::Text(s) => Ok(SqlValue::Strand(Strand::from(s.clone()))),
+        Value::VarChar { value, .. } | Value::Char { value, .. } => {
+            Ok(SqlValue::Strand(Strand::from(value.clone())))
         }
-        UniversalValue::Int8 { value, .. } => Ok(Value::Number((*value as i64).into())),
-        UniversalValue::Int16(n) => Ok(Value::Number((*n as i64).into())),
-        UniversalValue::Int32(n) => Ok(Value::Number((*n as i64).into())),
-        UniversalValue::Int64(n) => Ok(Value::Number((*n).into())),
-        UniversalValue::Bool(b) => Ok(Value::Bool(*b)),
-        UniversalValue::Null => Ok(Value::None),
-        UniversalValue::Uuid(u) => Ok(Value::Uuid(surrealdb::sql::Uuid::from(*u))),
-        UniversalValue::Ulid(u) => Ok(Value::Strand(Strand::from(u.to_string()))),
-        UniversalValue::Array { .. } => {
+        Value::Int8 { value, .. } => Ok(SqlValue::Number((*value as i64).into())),
+        Value::Int16(n) => Ok(SqlValue::Number((*n as i64).into())),
+        Value::Int32(n) => Ok(SqlValue::Number((*n as i64).into())),
+        Value::Int64(n) => Ok(SqlValue::Number((*n).into())),
+        Value::Bool(b) => Ok(SqlValue::Bool(*b)),
+        Value::Null => Ok(SqlValue::None),
+        Value::Uuid(u) => Ok(SqlValue::Uuid(surrealdb::sql::Uuid::from(*u))),
+        Value::Ulid(u) => Ok(SqlValue::Strand(Strand::from(u.to_string()))),
+        Value::Array { .. } => {
             bail!("Nested arrays are not supported in composite SurrealDB IDs")
         }
         other => bail!(
@@ -70,17 +70,17 @@ fn universal_value_to_id_array_element(value: &UniversalValue) -> Result<Value> 
     }
 }
 
-/// Convert UniversalRow to RecordWithSurrealValues.
+/// Convert Row to RecordWithSurrealValues.
 ///
 /// Returns an error if the row's ID type is not supported.
-pub fn universal_row_to_surreal_record(
-    row: &UniversalRow,
+pub fn row_to_surreal_record(
+    row: &Row,
     zero_temporal: ZeroTemporalPolicy,
 ) -> Result<RecordWithSurrealValues> {
-    let id = universal_value_to_surreal_id(&row.id)?;
+    let id = value_to_surreal_id(&row.id)?;
     let thing = Thing::from((row.table.as_str(), id));
 
-    let data: HashMap<String, Value> = row
+    let data: HashMap<String, SqlValue> = row
         .fields
         .iter()
         .map(|(k, v)| {
@@ -93,38 +93,38 @@ pub fn universal_row_to_surreal_record(
     Ok(RecordWithSurrealValues::new(thing, data))
 }
 
-/// Write a batch of UniversalRows to SurrealDB.
+/// Write a batch of Rows to SurrealDB.
 ///
 /// Returns an error if any row has an unsupported ID type.
-pub async fn write_universal_rows(
+pub async fn write_rows(
     surreal: &Surreal<surrealdb::engine::any::Any>,
-    rows: &[UniversalRow],
+    rows: &[Row],
     zero_temporal: ZeroTemporalPolicy,
 ) -> Result<()> {
     for row in rows {
-        let record = universal_row_to_surreal_record(row, zero_temporal)?;
+        let record = row_to_surreal_record(row, zero_temporal)?;
         write_record(surreal, &record).await?;
     }
     Ok(())
 }
 
-/// Convert UniversalRelation to SurrealDB Relation.
+/// Convert Relation to SurrealDB Relation.
 ///
 /// Returns an error if any ID type is not supported.
-pub fn universal_relation_to_surreal_relation(
-    rel: &UniversalRelation,
+pub fn relation_to_surreal_relation(
+    rel: &Relation,
     zero_temporal: ZeroTemporalPolicy,
-) -> Result<Relation> {
+) -> Result<SurrealRelation> {
     // Convert the relation's own ID
-    let id = universal_value_to_surreal_id(&rel.id)?;
+    let id = value_to_surreal_id(&rel.id)?;
     let thing_id = Thing::from((rel.relation_type.as_str(), id));
 
     // Convert input (source) Thing
-    let input_id = universal_value_to_surreal_id(&rel.input.id)?;
+    let input_id = value_to_surreal_id(&rel.input.id)?;
     let input_thing = Thing::from((rel.input.table.as_str(), input_id));
 
     // Convert output (target) Thing
-    let output_id = universal_value_to_surreal_id(&rel.output.id)?;
+    let output_id = value_to_surreal_id(&rel.output.id)?;
     let output_thing = Thing::from((rel.output.table.as_str(), output_id));
 
     // Convert data
@@ -138,7 +138,7 @@ pub fn universal_relation_to_surreal_relation(
         })
         .collect();
 
-    Ok(Relation {
+    Ok(SurrealRelation {
         id: thing_id,
         input: input_thing,
         output: output_thing,
@@ -146,16 +146,16 @@ pub fn universal_relation_to_surreal_relation(
     })
 }
 
-/// Write a batch of UniversalRelations to SurrealDB.
+/// Write a batch of Relations to SurrealDB.
 ///
 /// Returns an error if any relation has an unsupported ID type.
-pub async fn write_universal_relations(
+pub async fn write_relations(
     surreal: &Surreal<surrealdb::engine::any::Any>,
-    relations: &[UniversalRelation],
+    relations: &[Relation],
     zero_temporal: ZeroTemporalPolicy,
 ) -> Result<()> {
     for rel in relations {
-        let surreal_rel = universal_relation_to_surreal_relation(rel, zero_temporal)?;
+        let surreal_rel = relation_to_surreal_relation(rel, zero_temporal)?;
         write_relation(surreal, &surreal_rel).await?;
     }
     Ok(())
@@ -164,113 +164,110 @@ pub async fn write_universal_relations(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sync_core::UniversalValue;
+    use sync_core::Value;
 
     #[test]
-    fn test_universal_value_to_surreal_id_text() {
-        let value = UniversalValue::Text("user123".to_string());
-        let id = universal_value_to_surreal_id(&value).unwrap();
+    fn test_value_to_surreal_id_text() {
+        let value = Value::Text("user123".to_string());
+        let id = value_to_surreal_id(&value).unwrap();
         assert!(matches!(id, Id::String(s) if s == "user123"));
     }
 
     #[test]
-    fn test_universal_value_to_surreal_id_int32() {
-        let value = UniversalValue::Int32(42);
-        let id = universal_value_to_surreal_id(&value).unwrap();
+    fn test_value_to_surreal_id_int32() {
+        let value = Value::Int32(42);
+        let id = value_to_surreal_id(&value).unwrap();
         assert!(matches!(id, Id::Number(n) if n == 42));
     }
 
     #[test]
-    fn test_universal_value_to_surreal_id_int64() {
-        let value = UniversalValue::Int64(9999999999);
-        let id = universal_value_to_surreal_id(&value).unwrap();
+    fn test_value_to_surreal_id_int64() {
+        let value = Value::Int64(9999999999);
+        let id = value_to_surreal_id(&value).unwrap();
         assert!(matches!(id, Id::Number(n) if n == 9999999999));
     }
 
     #[test]
-    fn test_universal_value_to_surreal_id_uuid() {
+    fn test_value_to_surreal_id_uuid() {
         let uuid = uuid::Uuid::new_v4();
-        let value = UniversalValue::Uuid(uuid);
-        let id = universal_value_to_surreal_id(&value).unwrap();
+        let value = Value::Uuid(uuid);
+        let id = value_to_surreal_id(&value).unwrap();
         assert!(matches!(id, Id::Uuid(_)));
     }
 
     #[test]
-    fn test_universal_value_to_surreal_id_ulid() {
+    fn test_value_to_surreal_id_ulid() {
         let ulid = ulid::Ulid::new();
         let ulid_str = ulid.to_string();
-        let value = UniversalValue::Ulid(ulid);
-        let id = universal_value_to_surreal_id(&value).unwrap();
+        let value = Value::Ulid(ulid);
+        let id = value_to_surreal_id(&value).unwrap();
         assert!(matches!(id, Id::String(s) if s == ulid_str));
     }
 
     #[test]
-    fn test_universal_value_to_surreal_id_unsupported() {
-        let value = UniversalValue::Float64(1.23);
-        let result = universal_value_to_surreal_id(&value);
+    fn test_value_to_surreal_id_unsupported() {
+        let value = Value::Float64(1.23);
+        let result = value_to_surreal_id(&value);
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert!(err.to_string().contains("Unsupported UniversalValue type"));
+        assert!(err.to_string().contains("Unsupported Value type"));
     }
 
     #[test]
-    fn test_universal_value_to_surreal_id_bool_unsupported() {
-        let value = UniversalValue::Bool(true);
-        let result = universal_value_to_surreal_id(&value);
+    fn test_value_to_surreal_id_bool_unsupported() {
+        let value = Value::Bool(true);
+        let result = value_to_surreal_id(&value);
         assert!(result.is_err());
     }
 
     #[test]
-    fn test_universal_value_to_surreal_id_array_ints() {
-        let value = UniversalValue::Array {
-            elements: vec![UniversalValue::Int32(4), UniversalValue::Int64(2)],
-            element_type: Box::new(sync_core::UniversalType::Int32),
+    fn test_value_to_surreal_id_array_ints() {
+        let value = Value::Array {
+            elements: vec![Value::Int32(4), Value::Int64(2)],
+            element_type: Box::new(sync_core::Type::Int32),
         };
-        let id = universal_value_to_surreal_id(&value).unwrap();
+        let id = value_to_surreal_id(&value).unwrap();
         match id {
             Id::Array(arr) => {
                 assert_eq!(arr.len(), 2);
-                assert!(matches!(&arr[0], Value::Number(n) if n.to_string() == "4"));
-                assert!(matches!(&arr[1], Value::Number(n) if n.to_string() == "2"));
+                assert!(matches!(&arr[0], SqlValue::Number(n) if n.to_string() == "4"));
+                assert!(matches!(&arr[1], SqlValue::Number(n) if n.to_string() == "2"));
             }
             other => panic!("expected Id::Array, got {other:?}"),
         }
     }
 
     #[test]
-    fn test_universal_value_to_surreal_id_array_mixed() {
+    fn test_value_to_surreal_id_array_mixed() {
         let uuid = uuid::Uuid::new_v4();
-        let value = UniversalValue::Array {
-            elements: vec![
-                UniversalValue::Text("a_b".to_string()),
-                UniversalValue::Uuid(uuid),
-            ],
-            element_type: Box::new(sync_core::UniversalType::Text),
+        let value = Value::Array {
+            elements: vec![Value::Text("a_b".to_string()), Value::Uuid(uuid)],
+            element_type: Box::new(sync_core::Type::Text),
         };
-        let id = universal_value_to_surreal_id(&value).unwrap();
+        let id = value_to_surreal_id(&value).unwrap();
         assert!(matches!(id, Id::Array(arr) if arr.len() == 2));
     }
 
     #[test]
-    fn test_universal_value_to_surreal_id_array_empty_rejected() {
-        let value = UniversalValue::Array {
+    fn test_value_to_surreal_id_array_empty_rejected() {
+        let value = Value::Array {
             elements: vec![],
-            element_type: Box::new(sync_core::UniversalType::Text),
+            element_type: Box::new(sync_core::Type::Text),
         };
-        let err = universal_value_to_surreal_id(&value).unwrap_err();
+        let err = value_to_surreal_id(&value).unwrap_err();
         assert!(err.to_string().contains("must not be empty"));
     }
 
     #[test]
-    fn test_universal_value_to_surreal_id_nested_array_rejected() {
-        let value = UniversalValue::Array {
-            elements: vec![UniversalValue::Array {
-                elements: vec![UniversalValue::Int32(1)],
-                element_type: Box::new(sync_core::UniversalType::Int32),
+    fn test_value_to_surreal_id_nested_array_rejected() {
+        let value = Value::Array {
+            elements: vec![Value::Array {
+                elements: vec![Value::Int32(1)],
+                element_type: Box::new(sync_core::Type::Int32),
             }],
-            element_type: Box::new(sync_core::UniversalType::Text),
+            element_type: Box::new(sync_core::Type::Text),
         };
-        let err = universal_value_to_surreal_id(&value).unwrap_err();
+        let err = value_to_surreal_id(&value).unwrap_err();
         assert!(err.to_string().contains("Nested arrays"));
     }
 }

--- a/crates/surreal2-sink/src/sink_impl.rs
+++ b/crates/surreal2-sink/src/sink_impl.rs
@@ -4,12 +4,10 @@ use anyhow::Result;
 use surreal_sink::SurrealSink;
 use surrealdb::engine::any::Any;
 use surrealdb::Surreal;
-use sync_core::{
-    UniversalChange, UniversalRelation, UniversalRelationChange, UniversalRow, ZeroTemporalPolicy,
-};
+use sync_core::{Change, Relation, RelationChange, Row, ZeroTemporalPolicy};
 
-use crate::rows::{write_universal_relations, write_universal_rows};
-use crate::write::{apply_universal_change, apply_universal_relation_change};
+use crate::rows::{write_relations, write_rows};
+use crate::write::{apply_change, apply_relation_change};
 
 /// Wrapper around Surreal<Any> that implements SurrealSink.
 ///
@@ -61,22 +59,19 @@ impl Surreal2Sink {
 
 #[async_trait::async_trait]
 impl SurrealSink for Surreal2Sink {
-    async fn write_universal_rows(&self, rows: &[UniversalRow]) -> Result<()> {
-        write_universal_rows(&self.client, rows, self.zero_temporal).await
+    async fn write_rows(&self, rows: &[Row]) -> Result<()> {
+        write_rows(&self.client, rows, self.zero_temporal).await
     }
 
-    async fn write_universal_relations(&self, relations: &[UniversalRelation]) -> Result<()> {
-        write_universal_relations(&self.client, relations, self.zero_temporal).await
+    async fn write_relations(&self, relations: &[Relation]) -> Result<()> {
+        write_relations(&self.client, relations, self.zero_temporal).await
     }
 
-    async fn apply_universal_change(&self, change: &UniversalChange) -> Result<()> {
-        apply_universal_change(&self.client, change, self.zero_temporal).await
+    async fn apply_change(&self, change: &Change) -> Result<()> {
+        apply_change(&self.client, change, self.zero_temporal).await
     }
 
-    async fn apply_universal_relation_change(
-        &self,
-        change: &UniversalRelationChange,
-    ) -> Result<()> {
-        apply_universal_relation_change(&self.client, change, self.zero_temporal).await
+    async fn apply_relation_change(&self, change: &RelationChange) -> Result<()> {
+        apply_relation_change(&self.client, change, self.zero_temporal).await
     }
 }

--- a/crates/surreal2-sink/src/write.rs
+++ b/crates/surreal2-sink/src/write.rs
@@ -1,13 +1,13 @@
-use crate::Change;
+use crate::Mutation;
 use std::collections::HashMap;
 use std::time::Duration;
 use surreal2_types::{RecordWithSurrealValues as Record, Relation, SurrealValue};
 use surrealdb::sql;
 use surrealdb::Surreal;
-use sync_core::{UniversalChange, UniversalChangeOp, UniversalRelationChange, ZeroTemporalPolicy};
+use sync_core::{Change, ChangeOp, RelationChange, ZeroTemporalPolicy};
 use tokio::time::sleep;
 
-use crate::rows::{universal_relation_to_surreal_relation, universal_value_to_surreal_id};
+use crate::rows::{relation_to_surreal_relation, value_to_surreal_id};
 
 /// Convert a `surrealdb::sql::Id` to a `surrealdb::sql::Value` suitable for parameter binding.
 ///
@@ -35,17 +35,17 @@ fn is_retriable_transaction_error(error: &surrealdb::Error) -> bool {
 }
 
 // Apply a single change event to SurrealDB
-pub async fn apply_change(
+pub async fn apply_mutation(
     surreal: &Surreal<surrealdb::engine::any::Any>,
-    change: &Change,
+    change: &Mutation,
 ) -> anyhow::Result<()> {
     match change {
-        Change::UpsertRecord(record) => {
+        Mutation::UpsertRecord(record) => {
             write_record(surreal, record).await?;
 
             tracing::trace!("Successfully upserted record: {record:?}");
         }
-        Change::DeleteRecord(thing) => {
+        Mutation::DeleteRecord(thing) => {
             let query = "DELETE type::thing($record_tb, $record_id)".to_string();
             tracing::trace!("Executing SurrealDB query: {}", query);
             log::info!("🔧 migrate_change executing: {query} for record: {thing:?}");
@@ -58,12 +58,12 @@ pub async fn apply_change(
 
             tracing::trace!("Successfully deleted record: {:?}", thing);
         }
-        Change::UpsertRelation(relation) => {
+        Mutation::UpsertRelation(relation) => {
             write_relation(surreal, relation).await?;
 
             tracing::trace!("Successfully upserted relation: {relation:?}");
         }
-        Change::DeleteRelation(thing) => {
+        Mutation::DeleteRelation(thing) => {
             let query = "DELETE type::thing($relation_tb, $relation_id)".to_string();
             tracing::trace!("Executing SurrealDB query: {}", query);
             log::info!("🔧 migrate_change executing: {query} for relation: {thing:?}");
@@ -81,22 +81,22 @@ pub async fn apply_change(
     Ok(())
 }
 
-/// Apply a UniversalChange event to SurrealDB.
+/// Apply a Change event to SurrealDB.
 ///
-/// Converts UniversalChange to the appropriate SurrealDB operation and executes it.
-pub async fn apply_universal_change(
+/// Converts Change to the appropriate SurrealDB operation and executes it.
+pub async fn apply_change(
     surreal: &Surreal<surrealdb::engine::any::Any>,
-    change: &UniversalChange,
+    change: &Change,
     zero_temporal: ZeroTemporalPolicy,
 ) -> anyhow::Result<()> {
-    // Convert ID from UniversalValue to SurrealDB ID
-    let surreal_id = universal_value_to_surreal_id(&change.id)?;
+    // Convert ID from Value to SurrealDB ID
+    let surreal_id = value_to_surreal_id(&change.id)?;
     let thing = surrealdb::sql::Thing::from((change.table.as_str(), surreal_id));
 
     match change.operation {
-        UniversalChangeOp::Create | UniversalChangeOp::Update => {
-            // Convert data from HashMap<String, UniversalValue> to HashMap<String, surrealdb::sql::Value>
-            let data = change.data.as_ref().ok_or_else(|| {
+        ChangeOp::Create | ChangeOp::Update => {
+            // Convert data from HashMap<String, Value> to HashMap<String, surrealdb::sql::Value>
+            let data = change.fields.as_ref().ok_or_else(|| {
                 anyhow::anyhow!(
                     "Create/Update change must have data, but found None for table '{}'",
                     change.table
@@ -116,7 +116,7 @@ pub async fn apply_universal_change(
 
             tracing::trace!("Successfully upserted record: {thing:?}");
         }
-        UniversalChangeOp::Delete => {
+        ChangeOp::Delete => {
             let query = "DELETE type::thing($record_tb, $record_id)".to_string();
             tracing::trace!("Executing SurrealDB query: {}", query);
 
@@ -383,7 +383,7 @@ pub async fn write_relation(
     Err(anyhow::anyhow!(error_msg))
 }
 
-pub async fn write_relations(
+pub async fn write_native_relations(
     surreal: &Surreal<surrealdb::engine::any::Any>,
     table_name: &str,
     batch: &[Relation],
@@ -407,24 +407,23 @@ pub async fn write_relations(
     Ok(())
 }
 
-/// Apply a UniversalRelationChange event to SurrealDB.
-pub async fn apply_universal_relation_change(
+/// Apply a RelationChange event to SurrealDB.
+pub async fn apply_relation_change(
     surreal: &Surreal<surrealdb::engine::any::Any>,
-    change: &UniversalRelationChange,
+    change: &RelationChange,
     zero_temporal: ZeroTemporalPolicy,
 ) -> anyhow::Result<()> {
     match change.operation {
-        UniversalChangeOp::Create | UniversalChangeOp::Update => {
-            let surreal_rel =
-                universal_relation_to_surreal_relation(&change.relation, zero_temporal)?;
+        ChangeOp::Create | ChangeOp::Update => {
+            let surreal_rel = relation_to_surreal_relation(&change.relation, zero_temporal)?;
             write_relation(surreal, &surreal_rel).await?;
             tracing::trace!(
                 "Successfully upserted relation: {:?}",
                 change.relation.relation_type
             );
         }
-        UniversalChangeOp::Delete => {
-            let surreal_id = universal_value_to_surreal_id(&change.relation.id)?;
+        ChangeOp::Delete => {
+            let surreal_id = value_to_surreal_id(&change.relation.id)?;
             let query = "DELETE type::thing($relation_tb, $relation_id)".to_string();
             let mut q = surreal.query(query);
             q = q.bind(("relation_tb", change.relation.relation_type.clone()));

--- a/crates/surreal2-types/src/forward.rs
+++ b/crates/surreal2-types/src/forward.rs
@@ -5,65 +5,62 @@
 use rust_decimal::Decimal;
 use std::collections::BTreeMap;
 use std::str::FromStr;
-use surrealdb::sql::{Array, Datetime, Number, Object, Strand, Thing, Value};
-use sync_core::{TypedValue, UniversalType, UniversalValue};
+use surrealdb::sql::{Array, Datetime, Number, Object, Strand, Thing, Value as SqlValue};
+use sync_core::{Type, TypedValue, Value};
 
 /// Wrapper for SurrealDB values.
 #[derive(Debug, Clone)]
-pub struct SurrealValue(pub Value);
+pub struct SurrealValue(pub SqlValue);
 
 impl SurrealValue {
     /// Get the inner SurrealDB value.
-    pub fn into_inner(self) -> Value {
+    pub fn into_inner(self) -> SqlValue {
         self.0
     }
 
     /// Get a reference to the inner SurrealDB value.
-    pub fn as_inner(&self) -> &Value {
+    pub fn as_inner(&self) -> &SqlValue {
         &self.0
     }
 
     /// Convert a zero-temporal sentinel using the given sink policy.
     pub fn from_zero_temporal(
-        intended_type: &UniversalType,
+        intended_type: &Type,
         source: Option<&str>,
         policy: sync_core::ZeroTemporalPolicy,
     ) -> Self {
         match policy {
-            sync_core::ZeroTemporalPolicy::None => SurrealValue(Value::None),
-            sync_core::ZeroTemporalPolicy::Null => SurrealValue(Value::Null),
+            sync_core::ZeroTemporalPolicy::None => SurrealValue(SqlValue::None),
+            sync_core::ZeroTemporalPolicy::Null => SurrealValue(SqlValue::Null),
             sync_core::ZeroTemporalPolicy::String => {
                 let s = source
-                    .unwrap_or_else(|| UniversalValue::canonical_zero_literal(intended_type))
+                    .unwrap_or_else(|| Value::canonical_zero_literal(intended_type))
                     .to_string();
-                SurrealValue(Value::Strand(Strand::from(s)))
+                SurrealValue(SqlValue::Strand(Strand::from(s)))
             }
         }
     }
 
-    /// Convert a [`UniversalValue`] with an explicit zero-temporal policy.
-    pub fn from_universal_with_policy(
-        value: UniversalValue,
-        policy: sync_core::ZeroTemporalPolicy,
-    ) -> Self {
+    /// Convert a [`Value`] with an explicit zero-temporal policy.
+    pub fn from_universal_with_policy(value: Value, policy: sync_core::ZeroTemporalPolicy) -> Self {
         match value {
-            UniversalValue::ZeroTemporal {
+            Value::ZeroTemporal {
                 intended_type,
                 source,
             } => Self::from_zero_temporal(&intended_type, source.as_deref(), policy),
-            UniversalValue::Array { elements, .. } => {
-                let surreal_arr: Vec<Value> = elements
+            Value::Array { elements, .. } => {
+                let surreal_arr: Vec<SqlValue> = elements
                     .into_iter()
                     .map(|v| Self::from_universal_with_policy(v, policy).into_inner())
                     .collect();
-                SurrealValue(Value::Array(Array::from(surreal_arr)))
+                SurrealValue(SqlValue::Array(Array::from(surreal_arr)))
             }
-            UniversalValue::Object(map) => {
+            Value::Object(map) => {
                 let mut obj = BTreeMap::new();
                 for (k, v) in map {
                     obj.insert(k, Self::from_universal_with_policy(v, policy).into_inner());
                 }
-                SurrealValue(Value::Object(Object::from(obj)))
+                SurrealValue(SqlValue::Object(Object::from(obj)))
             }
             other => SurrealValue::from(other),
         }
@@ -73,33 +70,29 @@ impl SurrealValue {
     pub fn from_typed_with_policy(tv: TypedValue, policy: sync_core::ZeroTemporalPolicy) -> Self {
         match (&tv.sync_type, &tv.value) {
             // JSON can be a string that needs parsing
-            (UniversalType::Json, UniversalValue::Text(s)) => {
-                match serde_json::from_str::<serde_json::Value>(s) {
-                    Ok(v) => SurrealValue(json_to_surreal(&v)),
-                    Err(_) => SurrealValue(Value::Strand(Strand::from(s.clone()))),
-                }
-            }
-            (UniversalType::Jsonb, UniversalValue::Text(s)) => {
-                match serde_json::from_str::<serde_json::Value>(s) {
-                    Ok(v) => SurrealValue(json_to_surreal(&v)),
-                    Err(_) => SurrealValue(Value::Strand(Strand::from(s.clone()))),
-                }
-            }
+            (Type::Json, Value::Text(s)) => match serde_json::from_str::<serde_json::Value>(s) {
+                Ok(v) => SurrealValue(json_to_surreal(&v)),
+                Err(_) => SurrealValue(SqlValue::Strand(Strand::from(s.clone()))),
+            },
+            (Type::Jsonb, Value::Text(s)) => match serde_json::from_str::<serde_json::Value>(s) {
+                Ok(v) => SurrealValue(json_to_surreal(&v)),
+                Err(_) => SurrealValue(SqlValue::Strand(Strand::from(s.clone()))),
+            },
             // JSON can also be an array (e.g., from MySQL SET columns or JSON arrays)
-            (UniversalType::Json, UniversalValue::Array { elements, .. }) => {
-                let surreal_arr: Vec<Value> =
+            (Type::Json, Value::Array { elements, .. }) => {
+                let surreal_arr: Vec<SqlValue> =
                     elements.iter().map(generated_value_to_surreal).collect();
-                SurrealValue(Value::Array(surrealdb::sql::Array::from(surreal_arr)))
+                SurrealValue(SqlValue::Array(surrealdb::sql::Array::from(surreal_arr)))
             }
-            (UniversalType::Jsonb, UniversalValue::Array { elements, .. }) => {
-                let surreal_arr: Vec<Value> =
+            (Type::Jsonb, Value::Array { elements, .. }) => {
+                let surreal_arr: Vec<SqlValue> =
                     elements.iter().map(generated_value_to_surreal).collect();
-                SurrealValue(Value::Array(surrealdb::sql::Array::from(surreal_arr)))
+                SurrealValue(SqlValue::Array(surrealdb::sql::Array::from(surreal_arr)))
             }
 
             // Array types need recursive conversion with element type info
-            (UniversalType::Array { element_type }, UniversalValue::Array { elements, .. }) => {
-                let surreal_arr: Vec<Value> = elements
+            (Type::Array { element_type }, Value::Array { elements, .. }) => {
+                let surreal_arr: Vec<SqlValue> = elements
                     .iter()
                     .map(|v| {
                         let tv = TypedValue {
@@ -109,10 +102,10 @@ impl SurrealValue {
                         Self::from_typed_with_policy(tv, policy).into_inner()
                     })
                     .collect();
-                SurrealValue(Value::Array(Array::from(surreal_arr)))
+                SurrealValue(SqlValue::Array(Array::from(surreal_arr)))
             }
 
-            // For all other cases, delegate to policy-aware UniversalValue conversion
+            // For all other cases, delegate to policy-aware Value conversion
             _ => Self::from_universal_with_policy(tv.value, policy),
         }
     }
@@ -124,162 +117,156 @@ impl From<TypedValue> for SurrealValue {
     }
 }
 
-impl From<UniversalValue> for SurrealValue {
-    fn from(value: UniversalValue) -> Self {
+impl From<Value> for SurrealValue {
+    fn from(value: Value) -> Self {
         match value {
             // Null
-            UniversalValue::Null => SurrealValue(Value::None),
+            Value::Null => SurrealValue(SqlValue::None),
 
             // Boolean
-            UniversalValue::Bool(b) => SurrealValue(Value::Bool(b)),
+            Value::Bool(b) => SurrealValue(SqlValue::Bool(b)),
 
             // Integer types
-            UniversalValue::Int8 { value, .. } => {
-                SurrealValue(Value::Number(Number::Int(value as i64)))
-            }
-            UniversalValue::Int16(i) => SurrealValue(Value::Number(Number::Int(i as i64))),
-            UniversalValue::Int32(i) => SurrealValue(Value::Number(Number::Int(i as i64))),
-            UniversalValue::Int64(i) => SurrealValue(Value::Number(Number::Int(i))),
+            Value::Int8 { value, .. } => SurrealValue(SqlValue::Number(Number::Int(value as i64))),
+            Value::Int16(i) => SurrealValue(SqlValue::Number(Number::Int(i as i64))),
+            Value::Int32(i) => SurrealValue(SqlValue::Number(Number::Int(i as i64))),
+            Value::Int64(i) => SurrealValue(SqlValue::Number(Number::Int(i))),
 
             // Floating point
-            UniversalValue::Float32(f) => SurrealValue(Value::Number(Number::Float(f as f64))),
-            UniversalValue::Float64(f) => SurrealValue(Value::Number(Number::Float(f))),
+            Value::Float32(f) => SurrealValue(SqlValue::Number(Number::Float(f as f64))),
+            Value::Float64(f) => SurrealValue(SqlValue::Number(Number::Float(f))),
 
             // Decimal - try to parse as rust_decimal, fallback to float
-            UniversalValue::Decimal { value, .. } => {
+            Value::Decimal { value, .. } => {
                 match Decimal::from_str(&value) {
-                    Ok(dec) => SurrealValue(Value::Number(Number::Decimal(dec))),
+                    Ok(dec) => SurrealValue(SqlValue::Number(Number::Decimal(dec))),
                     Err(_) => {
                         // Can't fit in rust_decimal - convert to f64
                         // TODO: Add option to store as String if user requests high precision preservation
                         let f: f64 = value.parse().unwrap_or(0.0);
-                        SurrealValue(Value::Number(Number::Float(f)))
+                        SurrealValue(SqlValue::Number(Number::Float(f)))
                     }
                 }
             }
 
             // String types - auto-detect ISO 8601 duration strings
-            UniversalValue::Char { value, .. } => {
+            Value::Char { value, .. } => {
                 if let Some(duration) = try_parse_iso8601_duration(&value) {
-                    SurrealValue(Value::Duration(surrealdb::sql::Duration::from(duration)))
+                    SurrealValue(SqlValue::Duration(surrealdb::sql::Duration::from(duration)))
                 } else {
-                    SurrealValue(Value::Strand(Strand::from(value)))
+                    SurrealValue(SqlValue::Strand(Strand::from(value)))
                 }
             }
-            UniversalValue::VarChar { value, .. } => {
+            Value::VarChar { value, .. } => {
                 if let Some(duration) = try_parse_iso8601_duration(&value) {
-                    SurrealValue(Value::Duration(surrealdb::sql::Duration::from(duration)))
+                    SurrealValue(SqlValue::Duration(surrealdb::sql::Duration::from(duration)))
                 } else {
-                    SurrealValue(Value::Strand(Strand::from(value)))
+                    SurrealValue(SqlValue::Strand(Strand::from(value)))
                 }
             }
-            UniversalValue::Text(s) => {
+            Value::Text(s) => {
                 // Auto-detect ISO 8601 duration strings (PTxxxS format) and convert to Duration
                 if let Some(duration) = try_parse_iso8601_duration(&s) {
-                    SurrealValue(Value::Duration(surrealdb::sql::Duration::from(duration)))
+                    SurrealValue(SqlValue::Duration(surrealdb::sql::Duration::from(duration)))
                 } else {
-                    SurrealValue(Value::Strand(Strand::from(s)))
+                    SurrealValue(SqlValue::Strand(Strand::from(s)))
                 }
             }
 
             // Binary types
-            UniversalValue::Blob(b) => SurrealValue(Value::Bytes(surrealdb::sql::Bytes::from(b))),
-            UniversalValue::Bytes(b) => SurrealValue(Value::Bytes(surrealdb::sql::Bytes::from(b))),
+            Value::Blob(b) => SurrealValue(SqlValue::Bytes(surrealdb::sql::Bytes::from(b))),
+            Value::Bytes(b) => SurrealValue(SqlValue::Bytes(surrealdb::sql::Bytes::from(b))),
 
             // Date/time types
-            UniversalValue::Date(dt) => SurrealValue(Value::Strand(Strand::from(
+            Value::Date(dt) => SurrealValue(SqlValue::Strand(Strand::from(
                 dt.format("%Y-%m-%d").to_string(),
             ))),
             // Note: Using "%H:%M:%S%.f" to preserve fractional seconds from PostgreSQL TIME type.
             // While SurrealDB doesn't have a native TIME type, storing as string with full precision
             // ensures no data loss during sync.
-            UniversalValue::Time(dt) => SurrealValue(Value::Strand(Strand::from(
+            Value::Time(dt) => SurrealValue(SqlValue::Strand(Strand::from(
                 dt.format("%H:%M:%S%.f").to_string(),
             ))),
-            UniversalValue::LocalDateTime(dt) => SurrealValue(Value::Datetime(Datetime::from(dt))),
-            UniversalValue::LocalDateTimeNano(dt) => {
-                SurrealValue(Value::Datetime(Datetime::from(dt)))
-            }
-            UniversalValue::ZonedDateTime(dt) => SurrealValue(Value::Datetime(Datetime::from(dt))),
+            Value::LocalDateTime(dt) => SurrealValue(SqlValue::Datetime(Datetime::from(dt))),
+            Value::LocalDateTimeNano(dt) => SurrealValue(SqlValue::Datetime(Datetime::from(dt))),
+            Value::ZonedDateTime(dt) => SurrealValue(SqlValue::Datetime(Datetime::from(dt))),
             // TIMETZ - stored as string to preserve timezone format.
             // Note: We intentionally do NOT use Datetime here because time and datetime
             // are fundamentally different types. Datetime implies a specific point in time,
             // while TIMETZ represents a daily recurring time in a specific timezone.
             // Misusing Datetime to represent time would lose semantic meaning.
-            UniversalValue::TimeTz(s) => SurrealValue(Value::Strand(Strand::from(s))),
+            Value::TimeTz(s) => SurrealValue(SqlValue::Strand(Strand::from(s))),
 
             // UUID
-            UniversalValue::Uuid(u) => SurrealValue(Value::Uuid(surrealdb::sql::Uuid::from(u))),
+            Value::Uuid(u) => SurrealValue(SqlValue::Uuid(surrealdb::sql::Uuid::from(u))),
 
             // ULID - convert to string since SurrealDB doesn't have native ULID ID type
-            UniversalValue::Ulid(u) => SurrealValue(Value::Strand(Strand::from(u.to_string()))),
+            Value::Ulid(u) => SurrealValue(SqlValue::Strand(Strand::from(u.to_string()))),
 
             // JSON types
-            UniversalValue::Json(json_val) => SurrealValue(json_to_surreal(&json_val)),
-            UniversalValue::Jsonb(json_val) => SurrealValue(json_to_surreal(&json_val)),
+            Value::Json(json_val) => SurrealValue(json_to_surreal(&json_val)),
+            Value::Jsonb(json_val) => SurrealValue(json_to_surreal(&json_val)),
 
             // Array
-            UniversalValue::Array { elements, .. } => {
-                let surreal_arr: Vec<Value> = elements
+            Value::Array { elements, .. } => {
+                let surreal_arr: Vec<SqlValue> = elements
                     .into_iter()
                     .map(|v| SurrealValue::from(v).into_inner())
                     .collect();
-                SurrealValue(Value::Array(Array::from(surreal_arr)))
+                SurrealValue(SqlValue::Array(Array::from(surreal_arr)))
             }
 
             // Set - stored as array of strings
-            UniversalValue::Set { elements, .. } => {
-                let surreal_arr: Vec<Value> = elements
+            Value::Set { elements, .. } => {
+                let surreal_arr: Vec<SqlValue> = elements
                     .into_iter()
-                    .map(|s| Value::Strand(Strand::from(s)))
+                    .map(|s| SqlValue::Strand(Strand::from(s)))
                     .collect();
-                SurrealValue(Value::Array(Array::from(surreal_arr)))
+                SurrealValue(SqlValue::Array(Array::from(surreal_arr)))
             }
 
             // Enum - stored as string
-            UniversalValue::Enum { value, .. } => SurrealValue(Value::Strand(Strand::from(value))),
+            Value::Enum { value, .. } => SurrealValue(SqlValue::Strand(Strand::from(value))),
 
             // Geometry - convert to JSON object
-            UniversalValue::Geometry { data, .. } => {
+            Value::Geometry { data, .. } => {
                 use sync_core::values::GeometryData;
                 let GeometryData(json_val) = data;
                 SurrealValue(json_to_surreal(&json_val))
             }
 
             // Duration - convert to SurrealDB Duration
-            UniversalValue::Duration(d) => {
-                SurrealValue(Value::Duration(surrealdb::sql::Duration::from(d)))
+            Value::Duration(d) => {
+                SurrealValue(SqlValue::Duration(surrealdb::sql::Duration::from(d)))
             }
 
             // Thing - record reference
-            UniversalValue::Thing { table, id } => {
+            Value::Thing { table, id } => {
                 // Convert the ID to a SurrealDB ID type
                 let surreal_id = match id.as_ref() {
-                    UniversalValue::Text(s) => surrealdb::sql::Id::String(s.clone()),
-                    UniversalValue::Int32(i) => surrealdb::sql::Id::Number(*i as i64),
-                    UniversalValue::Int64(i) => surrealdb::sql::Id::Number(*i),
-                    UniversalValue::Uuid(u) => {
-                        surrealdb::sql::Id::Uuid(surrealdb::sql::Uuid::from(*u))
-                    }
-                    UniversalValue::Ulid(u) => surrealdb::sql::Id::String(u.to_string()),
+                    Value::Text(s) => surrealdb::sql::Id::String(s.clone()),
+                    Value::Int32(i) => surrealdb::sql::Id::Number(*i as i64),
+                    Value::Int64(i) => surrealdb::sql::Id::Number(*i),
+                    Value::Uuid(u) => surrealdb::sql::Id::Uuid(surrealdb::sql::Uuid::from(*u)),
+                    Value::Ulid(u) => surrealdb::sql::Id::String(u.to_string()),
                     // For unsupported types, convert to string representation
                     other => surrealdb::sql::Id::String(format!("{other:?}")),
                 };
                 let thing = surrealdb::sql::Thing::from((table.as_str(), surreal_id));
-                SurrealValue(Value::Thing(thing))
+                SurrealValue(SqlValue::Thing(thing))
             }
 
             // Object - nested document
-            UniversalValue::Object(map) => {
+            Value::Object(map) => {
                 let mut obj = BTreeMap::new();
                 for (k, v) in map {
                     obj.insert(k.clone(), generated_value_to_surreal(&v));
                 }
-                SurrealValue(Value::Object(Object::from(obj)))
+                SurrealValue(SqlValue::Object(Object::from(obj)))
             }
 
             // Zero temporal — default sink policy is NONE (see ZeroTemporalPolicy)
-            UniversalValue::ZeroTemporal {
+            Value::ZeroTemporal {
                 intended_type,
                 source,
             } => SurrealValue::from_zero_temporal(
@@ -291,28 +278,28 @@ impl From<UniversalValue> for SurrealValue {
     }
 }
 
-/// Convert a UniversalValue to a SurrealDB Value (without type context).
-/// This is a helper for internal use - prefer using `From<UniversalValue>` trait.
-fn generated_value_to_surreal(value: &UniversalValue) -> Value {
+/// Convert a Value to a SurrealDB SqlValue (without type context).
+/// This is a helper for internal use - prefer using `From<Value>` trait.
+fn generated_value_to_surreal(value: &Value) -> SqlValue {
     SurrealValue::from(value.clone()).into_inner()
 }
 
-/// Convert a serde_json::Value to SurrealDB Value.
-fn json_to_surreal(value: &serde_json::Value) -> Value {
+/// Convert a serde_json::Value to SurrealDB SqlValue.
+fn json_to_surreal(value: &serde_json::Value) -> SqlValue {
     match value {
-        serde_json::Value::Null => Value::None,
-        serde_json::Value::Bool(b) => Value::Bool(*b),
+        serde_json::Value::Null => SqlValue::None,
+        serde_json::Value::Bool(b) => SqlValue::Bool(*b),
         serde_json::Value::Number(n) => {
             if let Some(i) = n.as_i64() {
-                Value::Number(Number::Int(i))
+                SqlValue::Number(Number::Int(i))
             } else if let Some(f) = n.as_f64() {
-                Value::Number(Number::Float(f))
+                SqlValue::Number(Number::Float(f))
             } else {
-                Value::None
+                SqlValue::None
             }
         }
-        serde_json::Value::String(s) => Value::Strand(Strand::from(s.clone())),
-        serde_json::Value::Array(arr) => Value::Array(Array::from(
+        serde_json::Value::String(s) => SqlValue::Strand(Strand::from(s.clone())),
+        serde_json::Value::Array(arr) => SqlValue::Array(Array::from(
             arr.iter().map(json_to_surreal).collect::<Vec<_>>(),
         )),
         serde_json::Value::Object(map) => {
@@ -320,7 +307,7 @@ fn json_to_surreal(value: &serde_json::Value) -> Value {
             for (k, v) in map {
                 obj.insert(k.clone(), json_to_surreal(v));
             }
-            Value::Object(Object::from(obj))
+            SqlValue::Object(Object::from(obj))
         }
     }
 }
@@ -349,15 +336,15 @@ fn try_parse_iso8601_duration(s: &str) -> Option<std::time::Duration> {
 /// Create a SurrealDB Thing (record ID).
 ///
 /// Returns an error for unsupported ID types.
-pub fn create_thing(table: &str, id: &UniversalValue) -> anyhow::Result<Thing> {
+pub fn create_thing(table: &str, id: &Value) -> anyhow::Result<Thing> {
     let id_part = match id {
-        UniversalValue::Text(s) => surrealdb::sql::Id::String(s.clone()),
-        UniversalValue::Int32(i) => surrealdb::sql::Id::Number(*i as i64),
-        UniversalValue::Int64(i) => surrealdb::sql::Id::Number(*i),
-        UniversalValue::Uuid(u) => surrealdb::sql::Id::Uuid(surrealdb::sql::Uuid::from(*u)),
-        UniversalValue::Ulid(u) => surrealdb::sql::Id::String(u.to_string()),
+        Value::Text(s) => surrealdb::sql::Id::String(s.clone()),
+        Value::Int32(i) => surrealdb::sql::Id::Number(*i as i64),
+        Value::Int64(i) => surrealdb::sql::Id::Number(*i),
+        Value::Uuid(u) => surrealdb::sql::Id::Uuid(surrealdb::sql::Uuid::from(*u)),
+        Value::Ulid(u) => surrealdb::sql::Id::String(u.to_string()),
         other => anyhow::bail!(
-            "Unsupported UniversalValue type for SurrealDB ID: {other:?}. \
+            "Unsupported Value type for SurrealDB ID: {other:?}. \
              Supported types: Text, Int32, Int64, Uuid, Ulid"
         ),
     };
@@ -382,7 +369,7 @@ where
 /// before creating SurrealDB records.
 pub fn typed_values_to_surreal_map(
     typed_values: std::collections::HashMap<String, TypedValue>,
-) -> std::collections::HashMap<String, Value> {
+) -> std::collections::HashMap<String, SqlValue> {
     typed_values
         .into_iter()
         .map(|(k, v)| (k, SurrealValue::from(v).into_inner()))
@@ -394,22 +381,22 @@ pub fn typed_values_to_surreal_map(
 #[derive(Debug, Clone)]
 pub struct RecordWithSurrealValues {
     pub id: Thing,
-    pub data: std::collections::HashMap<String, Value>,
+    pub data: std::collections::HashMap<String, SqlValue>,
 }
 
 impl RecordWithSurrealValues {
     /// Create a new record with the given ID and data.
-    pub fn new(id: Thing, data: std::collections::HashMap<String, Value>) -> Self {
+    pub fn new(id: Thing, data: std::collections::HashMap<String, SqlValue>) -> Self {
         Self { id, data }
     }
 
     /// Get the upsert content as a SurrealDB Object.
-    pub fn get_upsert_content(&self) -> Value {
+    pub fn get_upsert_content(&self) -> SqlValue {
         let mut m = BTreeMap::new();
         for (k, v) in &self.data {
             m.insert(k.clone(), v.clone());
         }
-        Value::Object(Object::from(m))
+        SqlValue::Object(Object::from(m))
     }
 }
 
@@ -420,31 +407,31 @@ mod tests {
 
     #[test]
     fn test_null_conversion() {
-        let tv = TypedValue::null(UniversalType::Text);
+        let tv = TypedValue::null(Type::Text);
         let surreal_val: SurrealValue = tv.into();
-        assert!(matches!(surreal_val.0, Value::None));
+        assert!(matches!(surreal_val.0, SqlValue::None));
     }
 
     #[test]
     fn test_zero_temporal_policies() {
-        let zero = UniversalValue::zero_temporal(UniversalType::Date, Some("0000-00-00".into()));
+        let zero = Value::zero_temporal(Type::Date, Some("0000-00-00".into()));
 
         let none = SurrealValue::from_universal_with_policy(
             zero.clone(),
             sync_core::ZeroTemporalPolicy::None,
         );
-        assert!(matches!(none.0, Value::None));
+        assert!(matches!(none.0, SqlValue::None));
 
         let null = SurrealValue::from_universal_with_policy(
             zero.clone(),
             sync_core::ZeroTemporalPolicy::Null,
         );
-        assert!(matches!(null.0, Value::Null));
+        assert!(matches!(null.0, SqlValue::Null));
 
         let strand =
             SurrealValue::from_universal_with_policy(zero, sync_core::ZeroTemporalPolicy::String);
         match strand.0 {
-            Value::Strand(s) => assert_eq!(s.as_str(), "0000-00-00"),
+            SqlValue::Strand(s) => assert_eq!(s.as_str(), "0000-00-00"),
             other => panic!("expected Strand, got {other:?}"),
         }
     }
@@ -453,32 +440,38 @@ mod tests {
     fn test_bool_conversion() {
         let tv = TypedValue::bool(true);
         let surreal_val: SurrealValue = tv.into();
-        assert!(matches!(surreal_val.0, Value::Bool(true)));
+        assert!(matches!(surreal_val.0, SqlValue::Bool(true)));
 
         let tv = TypedValue::bool(false);
         let surreal_val: SurrealValue = tv.into();
-        assert!(matches!(surreal_val.0, Value::Bool(false)));
+        assert!(matches!(surreal_val.0, SqlValue::Bool(false)));
     }
 
     #[test]
     fn test_tinyint_conversion() {
         let tv = TypedValue::int8(127, 4);
         let surreal_val: SurrealValue = tv.into();
-        assert!(matches!(surreal_val.0, Value::Number(Number::Int(127))));
+        assert!(matches!(surreal_val.0, SqlValue::Number(Number::Int(127))));
     }
 
     #[test]
     fn test_smallint_conversion() {
         let tv = TypedValue::int16(32000);
         let surreal_val: SurrealValue = tv.into();
-        assert!(matches!(surreal_val.0, Value::Number(Number::Int(32000))));
+        assert!(matches!(
+            surreal_val.0,
+            SqlValue::Number(Number::Int(32000))
+        ));
     }
 
     #[test]
     fn test_int_conversion() {
         let tv = TypedValue::int32(12345);
         let surreal_val: SurrealValue = tv.into();
-        assert!(matches!(surreal_val.0, Value::Number(Number::Int(12345))));
+        assert!(matches!(
+            surreal_val.0,
+            SqlValue::Number(Number::Int(12345))
+        ));
     }
 
     #[test]
@@ -487,7 +480,7 @@ mod tests {
         let surreal_val: SurrealValue = tv.into();
         assert!(matches!(
             surreal_val.0,
-            Value::Number(Number::Int(9876543210))
+            SqlValue::Number(Number::Int(9876543210))
         ));
     }
 
@@ -495,7 +488,7 @@ mod tests {
     fn test_float_conversion() {
         let tv = TypedValue::float32(1.234);
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Number(Number::Float(f)) = surreal_val.0 {
+        if let SqlValue::Number(Number::Float(f)) = surreal_val.0 {
             assert!((f - 1.234).abs() < 0.0001);
         } else {
             panic!("Expected Float");
@@ -506,7 +499,7 @@ mod tests {
     fn test_double_conversion() {
         let tv = TypedValue::float64(1.23456);
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Number(Number::Float(f)) = surreal_val.0 {
+        if let SqlValue::Number(Number::Float(f)) = surreal_val.0 {
             assert!((f - 1.23456).abs() < 0.00001);
         } else {
             panic!("Expected Float");
@@ -517,7 +510,7 @@ mod tests {
     fn test_decimal_conversion() {
         let tv = TypedValue::decimal("123.45", 10, 2);
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Number(Number::Decimal(d)) = surreal_val.0 {
+        if let SqlValue::Number(Number::Decimal(d)) = surreal_val.0 {
             assert_eq!(d.to_string(), "123.45");
         } else {
             panic!("Expected Decimal");
@@ -526,10 +519,10 @@ mod tests {
 
     #[test]
     fn test_high_precision_decimal_conversion() {
-        // Value exceeding rust_decimal MAX should be stored as float
+        // SqlValue exceeding rust_decimal MAX should be stored as float
         let tv = TypedValue::decimal("12345678901234567890123456789012345678901234567890", 50, 0);
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Number(Number::Float(f)) = surreal_val.0 {
+        if let SqlValue::Number(Number::Float(f)) = surreal_val.0 {
             // Large numbers get converted to f64 (with precision loss)
             assert!(f > 1e49);
         } else {
@@ -544,7 +537,7 @@ mod tests {
     fn test_char_conversion() {
         let tv = TypedValue::char_type("test", 10);
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Strand(s) = surreal_val.0 {
+        if let SqlValue::Strand(s) = surreal_val.0 {
             assert_eq!(s.as_str(), "test");
         } else {
             panic!("Expected Strand");
@@ -555,7 +548,7 @@ mod tests {
     fn test_text_conversion() {
         let tv = TypedValue::text("hello world");
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Strand(s) = surreal_val.0 {
+        if let SqlValue::Strand(s) = surreal_val.0 {
             assert_eq!(s.as_str(), "hello world");
         } else {
             panic!("Expected Strand");
@@ -566,7 +559,7 @@ mod tests {
     fn test_bytes_conversion() {
         let tv = TypedValue::bytes(vec![0xDE, 0xAD, 0xBE, 0xEF]);
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Bytes(b) = surreal_val.0 {
+        if let SqlValue::Bytes(b) = surreal_val.0 {
             assert_eq!(b.as_slice(), &[0xDE, 0xAD, 0xBE, 0xEF]);
         } else {
             panic!("Expected Bytes");
@@ -578,7 +571,7 @@ mod tests {
         let u = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
         let tv = TypedValue::uuid(u);
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Uuid(uuid) = surreal_val.0 {
+        if let SqlValue::Uuid(uuid) = surreal_val.0 {
             assert_eq!(uuid.0.to_string(), "550e8400-e29b-41d4-a716-446655440000");
         } else {
             panic!("Expected Uuid");
@@ -590,7 +583,7 @@ mod tests {
         let dt = Utc.with_ymd_and_hms(2024, 6, 15, 10, 30, 0).unwrap();
         let tv = TypedValue::datetime(dt);
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Datetime(sdt) = surreal_val.0 {
+        if let SqlValue::Datetime(sdt) = surreal_val.0 {
             assert_eq!(sdt.0.year(), 2024);
             assert_eq!(sdt.0.month(), 6);
             assert_eq!(sdt.0.day(), 15);
@@ -604,7 +597,7 @@ mod tests {
         let dt = Utc.with_ymd_and_hms(2024, 6, 15, 0, 0, 0).unwrap();
         let tv = TypedValue::date(dt);
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Strand(s) = surreal_val.0 {
+        if let SqlValue::Strand(s) = surreal_val.0 {
             assert_eq!(s.as_str(), "2024-06-15");
         } else {
             panic!("Expected Strand");
@@ -616,7 +609,7 @@ mod tests {
         let dt = Utc.with_ymd_and_hms(2024, 6, 15, 14, 30, 45).unwrap();
         let tv = TypedValue::time(dt);
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Strand(s) = surreal_val.0 {
+        if let SqlValue::Strand(s) = surreal_val.0 {
             assert_eq!(s.as_str(), "14:30:45");
         } else {
             panic!("Expected Strand");
@@ -631,11 +624,11 @@ mod tests {
         });
 
         let tv = TypedValue {
-            sync_type: UniversalType::Json,
-            value: UniversalValue::Json(Box::new(json)),
+            sync_type: Type::Json,
+            value: Value::Json(Box::new(json)),
         };
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Object(obj) = surreal_val.0 {
+        if let SqlValue::Object(obj) = surreal_val.0 {
             assert!(obj.get("name").is_some());
             assert!(obj.get("count").is_some());
         } else {
@@ -646,11 +639,11 @@ mod tests {
     #[test]
     fn test_json_string_conversion() {
         let tv = TypedValue {
-            sync_type: UniversalType::Json,
-            value: UniversalValue::Text(r#"{"key": "value"}"#.to_string()),
+            sync_type: Type::Json,
+            value: Value::Text(r#"{"key": "value"}"#.to_string()),
         };
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Object(obj) = surreal_val.0 {
+        if let SqlValue::Object(obj) = surreal_val.0 {
             assert!(obj.get("key").is_some());
         } else {
             panic!("Expected Object");
@@ -660,15 +653,11 @@ mod tests {
     #[test]
     fn test_array_int_conversion() {
         let tv = TypedValue::array(
-            vec![
-                UniversalValue::Int32(1),
-                UniversalValue::Int32(2),
-                UniversalValue::Int32(3),
-            ],
-            UniversalType::Int32,
+            vec![Value::Int32(1), Value::Int32(2), Value::Int32(3)],
+            Type::Int32,
         );
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Array(arr) = surreal_val.0 {
+        if let SqlValue::Array(arr) = surreal_val.0 {
             assert_eq!(arr.len(), 3);
         } else {
             panic!("Expected Array");
@@ -678,14 +667,11 @@ mod tests {
     #[test]
     fn test_array_text_conversion() {
         let tv = TypedValue::array(
-            vec![
-                UniversalValue::Text("a".to_string()),
-                UniversalValue::Text("b".to_string()),
-            ],
-            UniversalType::Text,
+            vec![Value::Text("a".to_string()), Value::Text("b".to_string())],
+            Type::Text,
         );
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Array(arr) = surreal_val.0 {
+        if let SqlValue::Array(arr) = surreal_val.0 {
             assert_eq!(arr.len(), 2);
         } else {
             panic!("Expected Array");
@@ -699,7 +685,7 @@ mod tests {
             vec!["a".to_string(), "b".to_string(), "c".to_string()],
         );
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Array(arr) = surreal_val.0 {
+        if let SqlValue::Array(arr) = surreal_val.0 {
             assert_eq!(arr.len(), 2);
         } else {
             panic!("Expected Array");
@@ -711,7 +697,7 @@ mod tests {
         let tv =
             TypedValue::enum_type("active", vec!["active".to_string(), "inactive".to_string()]);
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Strand(s) = surreal_val.0 {
+        if let SqlValue::Strand(s) = surreal_val.0 {
             assert_eq!(s.as_str(), "active");
         } else {
             panic!("Expected Strand");
@@ -727,19 +713,19 @@ mod tests {
         let tv = TypedValue::geometry_geojson(json, sync_core::GeometryType::Point);
         let surreal_val: SurrealValue = tv.into();
         // With the simplified conversion, this will be a JSON object
-        assert!(matches!(surreal_val.0, Value::Object(_)));
+        assert!(matches!(surreal_val.0, SqlValue::Object(_)));
     }
 
     #[test]
     fn test_create_thing_string() {
-        let id = UniversalValue::Text("user123".to_string());
+        let id = Value::Text("user123".to_string());
         let thing = create_thing("users", &id).unwrap();
         assert_eq!(thing.tb, "users");
     }
 
     #[test]
     fn test_create_thing_int() {
-        let id = UniversalValue::Int64(42);
+        let id = Value::Int64(42);
         let thing = create_thing("users", &id).unwrap();
         assert_eq!(thing.tb, "users");
     }
@@ -747,7 +733,7 @@ mod tests {
     #[test]
     fn test_create_thing_uuid() {
         let u = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
-        let id = UniversalValue::Uuid(u);
+        let id = Value::Uuid(u);
         let thing = create_thing("users", &id).unwrap();
         assert_eq!(thing.tb, "users");
     }
@@ -755,14 +741,14 @@ mod tests {
     #[test]
     fn test_create_thing_ulid() {
         let u = ulid::Ulid::new();
-        let id = UniversalValue::Ulid(u);
+        let id = Value::Ulid(u);
         let thing = create_thing("users", &id).unwrap();
         assert_eq!(thing.tb, "users");
     }
 
     #[test]
     fn test_create_thing_unsupported_type() {
-        let id = UniversalValue::Float64(1.23);
+        let id = Value::Float64(1.23);
         let result = create_thing("users", &id);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Unsupported"));
@@ -788,7 +774,7 @@ mod tests {
         // gets auto-detected and converted to a SurrealDB Duration
         let tv = TypedValue::text("PT181S");
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Duration(d) = surreal_val.0 {
+        if let SqlValue::Duration(d) = surreal_val.0 {
             let std_duration: std::time::Duration = d.into();
             assert_eq!(std_duration.as_secs(), 181);
         } else {
@@ -802,7 +788,7 @@ mod tests {
         // gets auto-detected and converted to a SurrealDB Duration
         let tv = TypedValue::varchar("PT181S", 64);
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Duration(d) = surreal_val.0 {
+        if let SqlValue::Duration(d) = surreal_val.0 {
             let std_duration: std::time::Duration = d.into();
             assert_eq!(std_duration.as_secs(), 181);
         } else {
@@ -815,7 +801,7 @@ mod tests {
         // Test duration with nanoseconds: PT60.123456789S
         let tv = TypedValue::text("PT60.123456789S");
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Duration(d) = surreal_val.0 {
+        if let SqlValue::Duration(d) = surreal_val.0 {
             let std_duration: std::time::Duration = d.into();
             assert_eq!(std_duration.as_secs(), 60);
             assert_eq!(std_duration.subsec_nanos(), 123456789);
@@ -829,7 +815,7 @@ mod tests {
         // Regular text should remain as a string
         let tv = TypedValue::text("hello world");
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Strand(s) = surreal_val.0 {
+        if let SqlValue::Strand(s) = surreal_val.0 {
             assert_eq!(s.as_str(), "hello world");
         } else {
             panic!("Expected Strand, got {:?}", surreal_val.0);

--- a/crates/surreal2-types/src/record.rs
+++ b/crates/surreal2-types/src/record.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use sync_core::{TypedValue, UniversalValue};
+use sync_core::{TypedValue, Value};
 
 /// Convert typed values to a SurrealDB record using a specified field as the ID.
 /// The field is removed from the typed values map and used as a part of the record ID.
@@ -10,7 +10,7 @@ pub fn typed_values_to_record_using_field_as_id(
 ) -> anyhow::Result<crate::RecordWithSurrealValues> {
     // Extract ID from typed values
     let surreal_id = if let Some(id_value) = typed_values.remove(id_field) {
-        universal_value_to_surreal_id(&id_value.value)?
+        value_to_surreal_id(&id_value.value)?
     } else {
         anyhow::bail!(format!("Message has no '{id_field}' field"));
     };
@@ -48,13 +48,13 @@ fn typed_values_to_record_with_id(
     Ok(r)
 }
 
-/// Convert a UniversalValue to a SurrealDB ID.
-fn universal_value_to_surreal_id(value: &UniversalValue) -> Result<surrealdb::sql::Id> {
+/// Convert a Value to a SurrealDB ID.
+fn value_to_surreal_id(value: &Value) -> Result<surrealdb::sql::Id> {
     match value {
-        UniversalValue::Int32(i) => Ok(surrealdb::sql::Id::Number(*i as i64)),
-        UniversalValue::Int64(i) => Ok(surrealdb::sql::Id::Number(*i)),
-        UniversalValue::Text(s) => Ok(surrealdb::sql::Id::String(s.clone())),
-        UniversalValue::Uuid(u) => Ok(surrealdb::sql::Id::Uuid(surrealdb::sql::Uuid::from(*u))),
+        Value::Int32(i) => Ok(surrealdb::sql::Id::Number(*i as i64)),
+        Value::Int64(i) => Ok(surrealdb::sql::Id::Number(*i)),
+        Value::Text(s) => Ok(surrealdb::sql::Id::String(s.clone())),
+        Value::Uuid(u) => Ok(surrealdb::sql::Id::Uuid(surrealdb::sql::Uuid::from(*u))),
         other => anyhow::bail!("Cannot convert {other:?} to SurrealDB ID"),
     }
 }

--- a/crates/surreal2-types/src/reverse.rs
+++ b/crates/surreal2-types/src/reverse.rs
@@ -4,21 +4,21 @@
 
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
-use surrealdb::sql::{Number, Object, Value};
-use sync_core::{TypedValue, UniversalType, UniversalValue};
+use surrealdb::sql::{Number, Object, Value as SqlValue};
+use sync_core::{Type, TypedValue, Value};
 
 /// SurrealDB value paired with schema information for type-aware conversion.
 #[derive(Debug, Clone)]
 pub struct SurrealValueWithSchema {
     /// The SurrealDB value.
-    pub value: Value,
+    pub value: SqlValue,
     /// The expected sync type for conversion.
-    pub sync_type: UniversalType,
+    pub sync_type: Type,
 }
 
 impl SurrealValueWithSchema {
     /// Create a new SurrealValueWithSchema.
-    pub fn new(value: Value, sync_type: UniversalType) -> Self {
+    pub fn new(value: SqlValue, sync_type: Type) -> Self {
         Self { value, sync_type }
     }
 
@@ -32,123 +32,121 @@ impl From<SurrealValueWithSchema> for TypedValue {
     fn from(sv: SurrealValueWithSchema) -> Self {
         match (&sv.sync_type, &sv.value) {
             // Null/None
-            (sync_type, Value::None) => TypedValue::null(sync_type.clone()),
+            (sync_type, SqlValue::None) => TypedValue::null(sync_type.clone()),
 
             // Boolean
-            (UniversalType::Bool, Value::Bool(b)) => TypedValue::bool(*b),
+            (Type::Bool, SqlValue::Bool(b)) => TypedValue::bool(*b),
 
             // Integer types
-            (UniversalType::Int8 { width }, Value::Number(Number::Int(i))) => TypedValue {
-                sync_type: UniversalType::Int8 { width: *width },
-                value: UniversalValue::Int32(*i as i32),
+            (Type::Int8 { width }, SqlValue::Number(Number::Int(i))) => TypedValue {
+                sync_type: Type::Int8 { width: *width },
+                value: Value::Int32(*i as i32),
             },
-            (UniversalType::Int16, Value::Number(Number::Int(i))) => TypedValue::int16(*i as i16),
-            (UniversalType::Int32, Value::Number(Number::Int(i))) => TypedValue::int32(*i as i32),
-            (UniversalType::Int64, Value::Number(Number::Int(i))) => TypedValue::int64(*i),
+            (Type::Int16, SqlValue::Number(Number::Int(i))) => TypedValue::int16(*i as i16),
+            (Type::Int32, SqlValue::Number(Number::Int(i))) => TypedValue::int32(*i as i32),
+            (Type::Int64, SqlValue::Number(Number::Int(i))) => TypedValue::int64(*i),
 
             // Floating point
-            (UniversalType::Float32, Value::Number(Number::Float(f))) => {
-                TypedValue::float32(*f as f32)
-            }
-            (UniversalType::Float64, Value::Number(Number::Float(f))) => TypedValue::float64(*f),
+            (Type::Float32, SqlValue::Number(Number::Float(f))) => TypedValue::float32(*f as f32),
+            (Type::Float64, SqlValue::Number(Number::Float(f))) => TypedValue::float64(*f),
 
             // Decimal
-            (UniversalType::Decimal { precision, scale }, Value::Number(Number::Decimal(d))) => {
+            (Type::Decimal { precision, scale }, SqlValue::Number(Number::Decimal(d))) => {
                 TypedValue::decimal(d.to_string(), *precision, *scale)
             }
-            (UniversalType::Decimal { precision, scale }, Value::Strand(s)) => {
+            (Type::Decimal { precision, scale }, SqlValue::Strand(s)) => {
                 TypedValue::decimal(s.as_str(), *precision, *scale)
             }
 
             // String types - use as_str() to get raw string, not to_string() which may add quotes
-            (UniversalType::Char { length }, Value::Strand(s)) => TypedValue {
-                sync_type: UniversalType::Char { length: *length },
-                value: UniversalValue::Text(s.as_str().to_string()),
+            (Type::Char { length }, SqlValue::Strand(s)) => TypedValue {
+                sync_type: Type::Char { length: *length },
+                value: Value::Text(s.as_str().to_string()),
             },
-            (UniversalType::VarChar { length }, Value::Strand(s)) => TypedValue {
-                sync_type: UniversalType::VarChar { length: *length },
-                value: UniversalValue::Text(s.as_str().to_string()),
+            (Type::VarChar { length }, SqlValue::Strand(s)) => TypedValue {
+                sync_type: Type::VarChar { length: *length },
+                value: Value::Text(s.as_str().to_string()),
             },
-            (UniversalType::Text, Value::Strand(s)) => TypedValue::text(s.as_str().to_string()),
+            (Type::Text, SqlValue::Strand(s)) => TypedValue::text(s.as_str().to_string()),
 
             // Binary types
-            (UniversalType::Blob, Value::Bytes(b)) => TypedValue {
-                sync_type: UniversalType::Blob,
-                value: UniversalValue::Bytes(b.clone().into_inner()),
+            (Type::Blob, SqlValue::Bytes(b)) => TypedValue {
+                sync_type: Type::Blob,
+                value: Value::Bytes(b.clone().into_inner()),
             },
-            (UniversalType::Bytes, Value::Bytes(b)) => TypedValue::bytes(b.clone().into_inner()),
+            (Type::Bytes, SqlValue::Bytes(b)) => TypedValue::bytes(b.clone().into_inner()),
 
             // UUID
-            (UniversalType::Uuid, Value::Uuid(u)) => TypedValue::uuid(u.0),
+            (Type::Uuid, SqlValue::Uuid(u)) => TypedValue::uuid(u.0),
             // UUID might also be stored as string
-            (UniversalType::Uuid, Value::Strand(s)) => {
+            (Type::Uuid, SqlValue::Strand(s)) => {
                 if let Ok(uuid) = uuid::Uuid::parse_str(s.as_str()) {
                     TypedValue::uuid(uuid)
                 } else {
-                    TypedValue::null(UniversalType::Uuid)
+                    TypedValue::null(Type::Uuid)
                 }
             }
 
             // Date/time types
-            (UniversalType::LocalDateTime, Value::Datetime(dt)) => TypedValue::datetime(dt.0),
-            (UniversalType::LocalDateTimeNano, Value::Datetime(dt)) => TypedValue {
-                sync_type: UniversalType::LocalDateTimeNano,
-                value: UniversalValue::LocalDateTime(dt.0),
+            (Type::LocalDateTime, SqlValue::Datetime(dt)) => TypedValue::datetime(dt.0),
+            (Type::LocalDateTimeNano, SqlValue::Datetime(dt)) => TypedValue {
+                sync_type: Type::LocalDateTimeNano,
+                value: Value::LocalDateTime(dt.0),
             },
-            (UniversalType::ZonedDateTime, Value::Datetime(dt)) => TypedValue {
-                sync_type: UniversalType::ZonedDateTime,
-                value: UniversalValue::LocalDateTime(dt.0),
+            (Type::ZonedDateTime, SqlValue::Datetime(dt)) => TypedValue {
+                sync_type: Type::ZonedDateTime,
+                value: Value::LocalDateTime(dt.0),
             },
 
             // Date stored as string
-            (UniversalType::Date, Value::Strand(s)) => {
+            (Type::Date, SqlValue::Strand(s)) => {
                 if let Ok(dt) = chrono::NaiveDate::parse_from_str(s.as_str(), "%Y-%m-%d") {
                     let datetime = dt.and_hms_opt(0, 0, 0).unwrap();
                     let utc_dt = DateTime::<Utc>::from_naive_utc_and_offset(datetime, Utc);
                     TypedValue {
-                        sync_type: UniversalType::Date,
-                        value: UniversalValue::LocalDateTime(utc_dt),
+                        sync_type: Type::Date,
+                        value: Value::LocalDateTime(utc_dt),
                     }
                 } else {
-                    TypedValue::null(UniversalType::Date)
+                    TypedValue::null(Type::Date)
                 }
             }
 
             // Time stored as string
-            (UniversalType::Time, Value::Strand(s)) => {
+            (Type::Time, SqlValue::Strand(s)) => {
                 if let Ok(time) = chrono::NaiveTime::parse_from_str(s.as_str(), "%H:%M:%S") {
                     let datetime = chrono::NaiveDate::from_ymd_opt(1970, 1, 1)
                         .unwrap()
                         .and_time(time);
                     let utc_dt = DateTime::<Utc>::from_naive_utc_and_offset(datetime, Utc);
                     TypedValue {
-                        sync_type: UniversalType::Time,
-                        value: UniversalValue::LocalDateTime(utc_dt),
+                        sync_type: Type::Time,
+                        value: Value::LocalDateTime(utc_dt),
                     }
                 } else {
-                    TypedValue::null(UniversalType::Time)
+                    TypedValue::null(Type::Time)
                 }
             }
 
             // JSON types
-            (UniversalType::Json, Value::Object(obj)) => {
+            (Type::Json, SqlValue::Object(obj)) => {
                 let json_val = object_to_serde_json(obj);
                 TypedValue {
-                    sync_type: UniversalType::Json,
-                    value: UniversalValue::Json(Box::new(json_val)),
+                    sync_type: Type::Json,
+                    value: Value::Json(Box::new(json_val)),
                 }
             }
-            (UniversalType::Jsonb, Value::Object(obj)) => {
+            (Type::Jsonb, SqlValue::Object(obj)) => {
                 let json_val = object_to_serde_json(obj);
                 TypedValue {
-                    sync_type: UniversalType::Jsonb,
-                    value: UniversalValue::Json(Box::new(json_val)),
+                    sync_type: Type::Jsonb,
+                    value: Value::Json(Box::new(json_val)),
                 }
             }
 
             // Array types
-            (UniversalType::Array { element_type }, Value::Array(arr)) => {
-                let values: Vec<UniversalValue> = arr
+            (Type::Array { element_type }, SqlValue::Array(arr)) => {
+                let values: Vec<Value> = arr
                     .iter()
                     .map(|v| {
                         let sv = SurrealValueWithSchema::new(v.clone(), (**element_type).clone());
@@ -159,64 +157,64 @@ impl From<SurrealValueWithSchema> for TypedValue {
             }
 
             // Set - stored as array
-            (UniversalType::Set { values: set_values }, Value::Array(arr)) => {
-                let values: Vec<UniversalValue> = arr
+            (Type::Set { values: set_values }, SqlValue::Array(arr)) => {
+                let values: Vec<Value> = arr
                     .iter()
                     .filter_map(|v| {
-                        if let Value::Strand(s) = v {
-                            Some(UniversalValue::Text(s.as_str().to_string()))
+                        if let SqlValue::Strand(s) = v {
+                            Some(Value::Text(s.as_str().to_string()))
                         } else {
                             None
                         }
                     })
                     .collect();
                 TypedValue {
-                    sync_type: UniversalType::Set {
+                    sync_type: Type::Set {
                         values: set_values.clone(),
                     },
-                    value: UniversalValue::Array {
+                    value: Value::Array {
                         elements: values,
-                        element_type: Box::new(UniversalType::Text),
+                        element_type: Box::new(Type::Text),
                     },
                 }
             }
 
             // Enum - stored as string
             (
-                UniversalType::Enum {
+                Type::Enum {
                     values: enum_values,
                 },
-                Value::Strand(s),
+                SqlValue::Strand(s),
             ) => TypedValue {
-                sync_type: UniversalType::Enum {
+                sync_type: Type::Enum {
                     values: enum_values.clone(),
                 },
-                value: UniversalValue::Text(s.as_str().to_string()),
+                value: Value::Text(s.as_str().to_string()),
             },
 
             // Geometry types - stored as SurrealDB Geometry
-            (UniversalType::Geometry { geometry_type }, Value::Geometry(geo)) => {
+            (Type::Geometry { geometry_type }, SqlValue::Geometry(geo)) => {
                 let json_val = geometry_to_serde_json(geo);
                 TypedValue {
-                    sync_type: UniversalType::Geometry {
+                    sync_type: Type::Geometry {
                         geometry_type: geometry_type.clone(),
                     },
-                    value: UniversalValue::Json(Box::new(json_val)),
+                    value: Value::Json(Box::new(json_val)),
                 }
             }
 
             // Thing - record reference
-            (UniversalType::Thing, Value::Thing(thing)) => {
+            (Type::Thing, SqlValue::Thing(thing)) => {
                 let table = thing.tb.to_string();
                 let id = match &thing.id {
-                    surrealdb::sql::Id::String(s) => UniversalValue::Text(s.clone()),
-                    surrealdb::sql::Id::Number(n) => UniversalValue::Int64(*n),
-                    surrealdb::sql::Id::Uuid(u) => UniversalValue::Uuid(u.0),
-                    _ => UniversalValue::Text(thing.id.to_string()),
+                    surrealdb::sql::Id::String(s) => Value::Text(s.clone()),
+                    surrealdb::sql::Id::Number(n) => Value::Int64(*n),
+                    surrealdb::sql::Id::Uuid(u) => Value::Uuid(u.0),
+                    _ => Value::Text(thing.id.to_string()),
                 };
                 TypedValue {
-                    sync_type: UniversalType::Thing,
-                    value: UniversalValue::Thing {
+                    sync_type: Type::Thing,
+                    value: Value::Thing {
                         table,
                         id: Box::new(id),
                     },
@@ -229,9 +227,9 @@ impl From<SurrealValueWithSchema> for TypedValue {
     }
 }
 
-/// Convert a SurrealDB Object to a HashMap of UniversalValue.
+/// Convert a SurrealDB Object to a HashMap of Value.
 #[allow(dead_code)]
-fn object_to_hashmap(obj: &Object) -> HashMap<String, UniversalValue> {
+fn object_to_hashmap(obj: &Object) -> HashMap<String, Value> {
     let mut map = HashMap::new();
     for (key, value) in obj.iter() {
         map.insert(key.clone(), surreal_value_to_generated(value));
@@ -239,62 +237,61 @@ fn object_to_hashmap(obj: &Object) -> HashMap<String, UniversalValue> {
     map
 }
 
-/// Convert a SurrealDB Value to UniversalValue (without type context).
+/// Convert a SurrealDB SqlValue to Value (without type context).
 #[allow(dead_code)]
-fn surreal_value_to_generated(value: &Value) -> UniversalValue {
+fn surreal_value_to_generated(value: &SqlValue) -> Value {
     match value {
-        Value::None => UniversalValue::Null,
-        Value::Bool(b) => UniversalValue::Bool(*b),
-        Value::Number(Number::Int(i)) => UniversalValue::Int64(*i),
-        Value::Number(Number::Float(f)) => UniversalValue::Float64(*f),
-        Value::Number(Number::Decimal(d)) => UniversalValue::Decimal {
+        SqlValue::None => Value::Null,
+        SqlValue::Bool(b) => Value::Bool(*b),
+        SqlValue::Number(Number::Int(i)) => Value::Int64(*i),
+        SqlValue::Number(Number::Float(f)) => Value::Float64(*f),
+        SqlValue::Number(Number::Decimal(d)) => Value::Decimal {
             value: d.to_string(),
             precision: 38,
             scale: 10,
         },
-        Value::Strand(s) => UniversalValue::Text(s.as_str().to_string()),
-        Value::Bytes(b) => UniversalValue::Bytes(b.clone().into_inner()),
-        Value::Uuid(u) => UniversalValue::Uuid(u.0),
-        Value::Datetime(dt) => UniversalValue::LocalDateTime(dt.0),
-        Value::Array(arr) => {
-            let elements: Vec<UniversalValue> =
-                arr.iter().map(surreal_value_to_generated).collect();
-            UniversalValue::Array {
+        SqlValue::Strand(s) => Value::Text(s.as_str().to_string()),
+        SqlValue::Bytes(b) => Value::Bytes(b.clone().into_inner()),
+        SqlValue::Uuid(u) => Value::Uuid(u.0),
+        SqlValue::Datetime(dt) => Value::LocalDateTime(dt.0),
+        SqlValue::Array(arr) => {
+            let elements: Vec<Value> = arr.iter().map(surreal_value_to_generated).collect();
+            Value::Array {
                 elements,
-                element_type: Box::new(UniversalType::Json),
+                element_type: Box::new(Type::Json),
             }
         }
-        Value::Object(obj) => {
-            // Convert SurrealDB Object to UniversalValue::Object
+        SqlValue::Object(obj) => {
+            // Convert SurrealDB Object to Value::Object
             let mut map = std::collections::HashMap::new();
             for (k, v) in obj.iter() {
                 map.insert(k.clone(), surreal_value_to_generated(v));
             }
-            UniversalValue::Object(map)
+            Value::Object(map)
         }
-        // Thing (record ID) - convert to UniversalValue::Thing
-        Value::Thing(thing) => {
+        // Thing (record ID) - convert to Value::Thing
+        SqlValue::Thing(thing) => {
             let table = thing.tb.to_string();
             let id = match &thing.id {
-                surrealdb::sql::Id::String(s) => UniversalValue::Text(s.clone()),
-                surrealdb::sql::Id::Number(n) => UniversalValue::Int64(*n),
-                surrealdb::sql::Id::Uuid(u) => UniversalValue::Uuid(u.0),
-                _ => UniversalValue::Text(thing.id.to_string()),
+                surrealdb::sql::Id::String(s) => Value::Text(s.clone()),
+                surrealdb::sql::Id::Number(n) => Value::Int64(*n),
+                surrealdb::sql::Id::Uuid(u) => Value::Uuid(u.0),
+                _ => Value::Text(thing.id.to_string()),
             };
-            UniversalValue::Thing {
+            Value::Thing {
                 table,
                 id: Box::new(id),
             }
         }
         // Duration - convert to string
-        Value::Duration(dur) => UniversalValue::Text(dur.to_string()),
+        SqlValue::Duration(dur) => Value::Text(dur.to_string()),
         // Geometry - convert to object
-        Value::Geometry(geo) => {
+        SqlValue::Geometry(geo) => {
             let json_val = geometry_to_serde_json(geo);
-            UniversalValue::Json(Box::new(json_val))
+            Value::Json(Box::new(json_val))
         }
         // Other types - convert to null
-        _ => UniversalValue::Null,
+        _ => Value::Null,
     }
 }
 
@@ -350,32 +347,32 @@ fn object_to_serde_json(obj: &Object) -> serde_json::Value {
     serde_json::Value::Object(map)
 }
 
-/// Convert a SurrealDB Value to serde_json::Value.
-fn surreal_value_to_json(value: &Value) -> serde_json::Value {
+/// Convert a SurrealDB SqlValue to serde_json::Value.
+fn surreal_value_to_json(value: &SqlValue) -> serde_json::Value {
     match value {
-        Value::None | Value::Null => serde_json::Value::Null,
-        Value::Bool(b) => serde_json::Value::Bool(*b),
-        Value::Number(n) => match n {
+        SqlValue::None | SqlValue::Null => serde_json::Value::Null,
+        SqlValue::Bool(b) => serde_json::Value::Bool(*b),
+        SqlValue::Number(n) => match n {
             Number::Int(i) => serde_json::json!(i),
             Number::Float(f) => serde_json::json!(f),
             Number::Decimal(d) => serde_json::json!(d.to_string()),
             _ => serde_json::Value::Null,
         },
-        Value::Strand(s) => serde_json::Value::String(s.as_str().to_string()),
-        Value::Datetime(dt) => serde_json::Value::String(dt.0.to_rfc3339()),
-        Value::Uuid(u) => serde_json::Value::String(u.0.to_string()),
-        Value::Array(arr) => {
+        SqlValue::Strand(s) => serde_json::Value::String(s.as_str().to_string()),
+        SqlValue::Datetime(dt) => serde_json::Value::String(dt.0.to_rfc3339()),
+        SqlValue::Uuid(u) => serde_json::Value::String(u.0.to_string()),
+        SqlValue::Array(arr) => {
             let values: Vec<serde_json::Value> = arr.iter().map(surreal_value_to_json).collect();
             serde_json::Value::Array(values)
         }
-        Value::Object(obj) => object_to_serde_json(obj),
-        Value::Geometry(geo) => geometry_to_serde_json(geo),
+        SqlValue::Object(obj) => object_to_serde_json(obj),
+        SqlValue::Geometry(geo) => geometry_to_serde_json(geo),
         _ => serde_json::Value::Null,
     }
 }
 
 /// Extract a typed value from a SurrealDB Object field.
-pub fn extract_field(obj: &Object, field: &str, sync_type: &UniversalType) -> TypedValue {
+pub fn extract_field(obj: &Object, field: &str, sync_type: &Type) -> TypedValue {
     match obj.get(field) {
         Some(value) => {
             SurrealValueWithSchema::new(value.clone(), sync_type.clone()).to_typed_value()
@@ -387,7 +384,7 @@ pub fn extract_field(obj: &Object, field: &str, sync_type: &UniversalType) -> Ty
 /// Convert a complete SurrealDB Object to a map of TypedValues using schema.
 pub fn object_to_typed_values(
     obj: &Object,
-    schema: &[(String, UniversalType)],
+    schema: &[(String, Type)],
 ) -> HashMap<String, TypedValue> {
     let mut result = HashMap::new();
     for (field_name, sync_type) in schema {
@@ -406,43 +403,39 @@ mod tests {
 
     #[test]
     fn test_null_conversion() {
-        let sv = SurrealValueWithSchema::new(Value::None, UniversalType::Text);
+        let sv = SurrealValueWithSchema::new(SqlValue::None, Type::Text);
         let tv = TypedValue::from(sv);
-        assert!(matches!(tv.value, UniversalValue::Null));
+        assert!(matches!(tv.value, Value::Null));
     }
 
     #[test]
     fn test_bool_conversion() {
-        let sv = SurrealValueWithSchema::new(Value::Bool(true), UniversalType::Bool);
+        let sv = SurrealValueWithSchema::new(SqlValue::Bool(true), Type::Bool);
         let tv = TypedValue::from(sv);
-        assert!(matches!(tv.value, UniversalValue::Bool(true)));
+        assert!(matches!(tv.value, Value::Bool(true)));
     }
 
     #[test]
     fn test_int_conversion() {
-        let sv = SurrealValueWithSchema::new(Value::Number(Number::Int(42)), UniversalType::Int32);
+        let sv = SurrealValueWithSchema::new(SqlValue::Number(Number::Int(42)), Type::Int32);
         let tv = TypedValue::from(sv);
-        assert!(matches!(tv.value, UniversalValue::Int32(42)));
+        assert!(matches!(tv.value, Value::Int32(42)));
     }
 
     #[test]
     fn test_bigint_conversion() {
-        let sv = SurrealValueWithSchema::new(
-            Value::Number(Number::Int(9876543210)),
-            UniversalType::Int64,
-        );
+        let sv =
+            SurrealValueWithSchema::new(SqlValue::Number(Number::Int(9876543210)), Type::Int64);
         let tv = TypedValue::from(sv);
-        assert!(matches!(tv.value, UniversalValue::Int64(9876543210)));
+        assert!(matches!(tv.value, Value::Int64(9876543210)));
     }
 
     #[test]
     fn test_float_conversion() {
-        let sv = SurrealValueWithSchema::new(
-            Value::Number(Number::Float(1.23456)),
-            UniversalType::Float64,
-        );
+        let sv =
+            SurrealValueWithSchema::new(SqlValue::Number(Number::Float(1.23456)), Type::Float64);
         let tv = TypedValue::from(sv);
-        if let UniversalValue::Float64(f) = tv.value {
+        if let Value::Float64(f) = tv.value {
             assert!((f - 1.23456).abs() < 0.00001);
         } else {
             panic!("Expected Float64");
@@ -453,14 +446,14 @@ mod tests {
     fn test_decimal_conversion() {
         let dec = rust_decimal::Decimal::from_str_exact("123.456").unwrap();
         let sv = SurrealValueWithSchema::new(
-            Value::Number(Number::Decimal(dec)),
-            UniversalType::Decimal {
+            SqlValue::Number(Number::Decimal(dec)),
+            Type::Decimal {
                 precision: 10,
                 scale: 3,
             },
         );
         let tv = TypedValue::from(sv);
-        if let UniversalValue::Decimal {
+        if let Value::Decimal {
             value,
             precision,
             scale,
@@ -476,45 +469,40 @@ mod tests {
 
     #[test]
     fn test_string_conversion() {
-        let sv = SurrealValueWithSchema::new(
-            Value::Strand(Strand::from("hello world")),
-            UniversalType::Text,
-        );
+        let sv =
+            SurrealValueWithSchema::new(SqlValue::Strand(Strand::from("hello world")), Type::Text);
         let tv = TypedValue::from(sv);
-        assert!(matches!(tv.value, UniversalValue::Text(ref s) if s == "hello world"));
+        assert!(matches!(tv.value, Value::Text(ref s) if s == "hello world"));
     }
 
     #[test]
     fn test_varchar_conversion() {
         let sv = SurrealValueWithSchema::new(
-            Value::Strand(Strand::from("test")),
-            UniversalType::VarChar { length: 100 },
+            SqlValue::Strand(Strand::from("test")),
+            Type::VarChar { length: 100 },
         );
         let tv = TypedValue::from(sv);
-        assert!(matches!(
-            tv.sync_type,
-            UniversalType::VarChar { length: 100 }
-        ));
-        assert!(matches!(tv.value, UniversalValue::Text(ref s) if s == "test"));
+        assert!(matches!(tv.sync_type, Type::VarChar { length: 100 }));
+        assert!(matches!(tv.value, Value::Text(ref s) if s == "test"));
     }
 
     #[test]
     fn test_bytes_conversion() {
         let bytes = surrealdb::sql::Bytes::from(vec![0x01, 0x02, 0x03]);
-        let sv = SurrealValueWithSchema::new(Value::Bytes(bytes), UniversalType::Bytes);
+        let sv = SurrealValueWithSchema::new(SqlValue::Bytes(bytes), Type::Bytes);
         let tv = TypedValue::from(sv);
-        assert!(matches!(tv.value, UniversalValue::Bytes(ref b) if *b == vec![0x01, 0x02, 0x03]));
+        assert!(matches!(tv.value, Value::Bytes(ref b) if *b == vec![0x01, 0x02, 0x03]));
     }
 
     #[test]
     fn test_uuid_conversion() {
         let uuid = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
         let sv = SurrealValueWithSchema::new(
-            Value::Uuid(surrealdb::sql::Uuid::from(uuid)),
-            UniversalType::Uuid,
+            SqlValue::Uuid(surrealdb::sql::Uuid::from(uuid)),
+            Type::Uuid,
         );
         let tv = TypedValue::from(sv);
-        if let UniversalValue::Uuid(u) = tv.value {
+        if let Value::Uuid(u) = tv.value {
             assert_eq!(u, uuid);
         } else {
             panic!("Expected Uuid");
@@ -524,11 +512,11 @@ mod tests {
     #[test]
     fn test_uuid_from_string() {
         let sv = SurrealValueWithSchema::new(
-            Value::Strand(Strand::from("550e8400-e29b-41d4-a716-446655440000")),
-            UniversalType::Uuid,
+            SqlValue::Strand(Strand::from("550e8400-e29b-41d4-a716-446655440000")),
+            Type::Uuid,
         );
         let tv = TypedValue::from(sv);
-        if let UniversalValue::Uuid(u) = tv.value {
+        if let Value::Uuid(u) = tv.value {
             assert_eq!(u.to_string(), "550e8400-e29b-41d4-a716-446655440000");
         } else {
             panic!("Expected Uuid");
@@ -539,11 +527,11 @@ mod tests {
     fn test_datetime_conversion() {
         let dt = Utc.with_ymd_and_hms(2024, 6, 15, 10, 30, 0).unwrap();
         let sv = SurrealValueWithSchema::new(
-            Value::Datetime(Datetime::from(dt)),
-            UniversalType::LocalDateTime,
+            SqlValue::Datetime(Datetime::from(dt)),
+            Type::LocalDateTime,
         );
         let tv = TypedValue::from(sv);
-        if let UniversalValue::LocalDateTime(result_dt) = tv.value {
+        if let Value::LocalDateTime(result_dt) = tv.value {
             assert_eq!(result_dt.year(), 2024);
             assert_eq!(result_dt.month(), 6);
             assert_eq!(result_dt.day(), 15);
@@ -554,12 +542,10 @@ mod tests {
 
     #[test]
     fn test_date_from_string() {
-        let sv = SurrealValueWithSchema::new(
-            Value::Strand(Strand::from("2024-06-15")),
-            UniversalType::Date,
-        );
+        let sv =
+            SurrealValueWithSchema::new(SqlValue::Strand(Strand::from("2024-06-15")), Type::Date);
         let tv = TypedValue::from(sv);
-        if let UniversalValue::LocalDateTime(dt) = tv.value {
+        if let Value::LocalDateTime(dt) = tv.value {
             assert_eq!(dt.format("%Y-%m-%d").to_string(), "2024-06-15");
         } else {
             panic!("Expected DateTime");
@@ -568,12 +554,10 @@ mod tests {
 
     #[test]
     fn test_time_from_string() {
-        let sv = SurrealValueWithSchema::new(
-            Value::Strand(Strand::from("14:30:45")),
-            UniversalType::Time,
-        );
+        let sv =
+            SurrealValueWithSchema::new(SqlValue::Strand(Strand::from("14:30:45")), Type::Time);
         let tv = TypedValue::from(sv);
-        if let UniversalValue::LocalDateTime(dt) = tv.value {
+        if let Value::LocalDateTime(dt) = tv.value {
             assert_eq!(dt.format("%H:%M:%S").to_string(), "14:30:45");
         } else {
             panic!("Expected DateTime");
@@ -583,13 +567,13 @@ mod tests {
     #[test]
     fn test_object_to_json() {
         let mut obj_map = BTreeMap::new();
-        obj_map.insert("name".to_string(), Value::Strand(Strand::from("test")));
-        obj_map.insert("count".to_string(), Value::Number(Number::Int(42)));
+        obj_map.insert("name".to_string(), SqlValue::Strand(Strand::from("test")));
+        obj_map.insert("count".to_string(), SqlValue::Number(Number::Int(42)));
         let obj = Object::from(obj_map);
 
-        let sv = SurrealValueWithSchema::new(Value::Object(obj), UniversalType::Json);
+        let sv = SurrealValueWithSchema::new(SqlValue::Object(obj), Type::Json);
         let tv = TypedValue::from(sv);
-        if let UniversalValue::Json(json_val) = tv.value {
+        if let Value::Json(json_val) = tv.value {
             if let serde_json::Value::Object(map) = json_val.as_ref() {
                 assert!(
                     matches!(map.get("name"), Some(serde_json::Value::String(s)) if s == "test")
@@ -608,21 +592,21 @@ mod tests {
     #[test]
     fn test_array_int_conversion() {
         let arr = Array::from(vec![
-            Value::Number(Number::Int(1)),
-            Value::Number(Number::Int(2)),
-            Value::Number(Number::Int(3)),
+            SqlValue::Number(Number::Int(1)),
+            SqlValue::Number(Number::Int(2)),
+            SqlValue::Number(Number::Int(3)),
         ]);
         let sv = SurrealValueWithSchema::new(
-            Value::Array(arr),
-            UniversalType::Array {
-                element_type: Box::new(UniversalType::Int32),
+            SqlValue::Array(arr),
+            Type::Array {
+                element_type: Box::new(Type::Int32),
             },
         );
         let tv = TypedValue::from(sv);
-        if let UniversalValue::Array { elements, .. } = tv.value {
+        if let Value::Array { elements, .. } = tv.value {
             assert_eq!(elements.len(), 3);
             // Values are converted as Int32
-            assert!(matches!(elements[0], UniversalValue::Int32(1)));
+            assert!(matches!(elements[0], Value::Int32(1)));
         } else {
             panic!("Expected Array");
         }
@@ -631,17 +615,17 @@ mod tests {
     #[test]
     fn test_set_conversion() {
         let arr = Array::from(vec![
-            Value::Strand(Strand::from("a")),
-            Value::Strand(Strand::from("b")),
+            SqlValue::Strand(Strand::from("a")),
+            SqlValue::Strand(Strand::from("b")),
         ]);
         let sv = SurrealValueWithSchema::new(
-            Value::Array(arr),
-            UniversalType::Set {
+            SqlValue::Array(arr),
+            Type::Set {
                 values: vec!["a".to_string(), "b".to_string(), "c".to_string()],
             },
         );
         let tv = TypedValue::from(sv);
-        if let UniversalValue::Array { elements, .. } = tv.value {
+        if let Value::Array { elements, .. } = tv.value {
             assert_eq!(elements.len(), 2);
         } else {
             panic!("Expected Array");
@@ -651,56 +635,56 @@ mod tests {
     #[test]
     fn test_enum_conversion() {
         let sv = SurrealValueWithSchema::new(
-            Value::Strand(Strand::from("active")),
-            UniversalType::Enum {
+            SqlValue::Strand(Strand::from("active")),
+            Type::Enum {
                 values: vec!["active".to_string(), "inactive".to_string()],
             },
         );
         let tv = TypedValue::from(sv);
-        assert!(matches!(tv.value, UniversalValue::Text(ref s) if s == "active"));
+        assert!(matches!(tv.value, Value::Text(ref s) if s == "active"));
     }
 
     #[test]
     fn test_extract_field() {
         let mut obj_map = BTreeMap::new();
-        obj_map.insert("name".to_string(), Value::Strand(Strand::from("Alice")));
-        obj_map.insert("age".to_string(), Value::Number(Number::Int(30)));
+        obj_map.insert("name".to_string(), SqlValue::Strand(Strand::from("Alice")));
+        obj_map.insert("age".to_string(), SqlValue::Number(Number::Int(30)));
         let obj = Object::from(obj_map);
 
-        let name = extract_field(&obj, "name", &UniversalType::Text);
-        assert!(matches!(name.value, UniversalValue::Text(ref s) if s == "Alice"));
+        let name = extract_field(&obj, "name", &Type::Text);
+        assert!(matches!(name.value, Value::Text(ref s) if s == "Alice"));
 
-        let age = extract_field(&obj, "age", &UniversalType::Int32);
-        assert!(matches!(age.value, UniversalValue::Int32(30)));
+        let age = extract_field(&obj, "age", &Type::Int32);
+        assert!(matches!(age.value, Value::Int32(30)));
 
-        let missing = extract_field(&obj, "missing", &UniversalType::Text);
-        assert!(matches!(missing.value, UniversalValue::Null));
+        let missing = extract_field(&obj, "missing", &Type::Text);
+        assert!(matches!(missing.value, Value::Null));
     }
 
     #[test]
     fn test_object_to_typed_values() {
         let mut obj_map = BTreeMap::new();
-        obj_map.insert("name".to_string(), Value::Strand(Strand::from("Bob")));
-        obj_map.insert("active".to_string(), Value::Bool(true));
-        obj_map.insert("score".to_string(), Value::Number(Number::Float(95.5)));
+        obj_map.insert("name".to_string(), SqlValue::Strand(Strand::from("Bob")));
+        obj_map.insert("active".to_string(), SqlValue::Bool(true));
+        obj_map.insert("score".to_string(), SqlValue::Number(Number::Float(95.5)));
         let obj = Object::from(obj_map);
 
         let schema = vec![
-            ("name".to_string(), UniversalType::Text),
-            ("active".to_string(), UniversalType::Bool),
-            ("score".to_string(), UniversalType::Float64),
+            ("name".to_string(), Type::Text),
+            ("active".to_string(), Type::Bool),
+            ("score".to_string(), Type::Float64),
         ];
 
         let values = object_to_typed_values(&obj, &schema);
         assert!(matches!(
             values.get("name").unwrap().value,
-            UniversalValue::Text(ref s) if s == "Bob"
+            Value::Text(ref s) if s == "Bob"
         ));
         assert!(matches!(
             values.get("active").unwrap().value,
-            UniversalValue::Bool(true)
+            Value::Bool(true)
         ));
-        if let UniversalValue::Float64(f) = values.get("score").unwrap().value {
+        if let Value::Float64(f) = values.get("score").unwrap().value {
             assert!((f - 95.5).abs() < 0.001);
         } else {
             panic!("Expected Float64");

--- a/crates/surreal2-types/src/schema.rs
+++ b/crates/surreal2-types/src/schema.rs
@@ -5,11 +5,11 @@
 //!
 //! ## Type System
 //!
-//! This module uses `UniversalType` from sync-core directly for schema representation,
+//! This module uses `Type` from sync-core directly for schema representation,
 //! along with `TableDefinition` and `DatabaseSchema` for schema structures.
 
 use surrealdb::sql::{Number, Strand, Value};
-use sync_core::{DatabaseSchema, TableDefinition, UniversalType};
+use sync_core::{DatabaseSchema, TableDefinition, Type};
 
 /// Convert JSON value to surrealdb::sql::Value using schema information for type precision.
 ///
@@ -35,16 +35,16 @@ pub fn json_to_surreal_with_table_schema(
     json_to_surreal_with_universal_type(value, column_type)
 }
 
-/// Convert JSON value to surrealdb::sql::Value using UniversalType for type precision.
+/// Convert JSON value to surrealdb::sql::Value using Type for type precision.
 ///
 /// This is the core conversion function that handles all type-specific conversions.
 pub fn json_to_surreal_with_universal_type(
     value: serde_json::Value,
-    column_type: Option<&UniversalType>,
+    column_type: Option<&Type>,
 ) -> anyhow::Result<Value> {
     match (value, column_type) {
         // High-precision decimal conversion
-        (serde_json::Value::Number(n), Some(UniversalType::Decimal { .. })) => {
+        (serde_json::Value::Number(n), Some(Type::Decimal { .. })) => {
             let decimal_str = n.to_string();
             match Number::try_from(decimal_str.as_str()) {
                 Ok(surreal_num) => Ok(Value::Number(surreal_num)),
@@ -60,7 +60,7 @@ pub fn json_to_surreal_with_universal_type(
         }
 
         // Timestamp conversion (LocalDateTime - without timezone)
-        (serde_json::Value::String(s), Some(UniversalType::LocalDateTime)) => {
+        (serde_json::Value::String(s), Some(Type::LocalDateTime)) => {
             use chrono::NaiveDateTime;
             // Try common timestamp formats
             if let Ok(ndt) = NaiveDateTime::parse_from_str(&s, "%Y-%m-%d %H:%M:%S") {
@@ -89,7 +89,7 @@ pub fn json_to_surreal_with_universal_type(
         }
 
         // Timestamp with timezone (ZonedDateTime)
-        (serde_json::Value::String(s), Some(UniversalType::ZonedDateTime)) => {
+        (serde_json::Value::String(s), Some(Type::ZonedDateTime)) => {
             if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(&s) {
                 Ok(Value::Datetime(surrealdb::sql::Datetime::from(
                     dt.with_timezone(&chrono::Utc),
@@ -100,12 +100,10 @@ pub fn json_to_surreal_with_universal_type(
         }
 
         // UUID validation and preservation
-        (serde_json::Value::String(s), Some(UniversalType::Uuid)) => {
-            Ok(Value::Strand(Strand::from(s)))
-        }
+        (serde_json::Value::String(s), Some(Type::Uuid)) => Ok(Value::Strand(Strand::from(s))),
 
         // JSON type - parse if it's a string representation
-        (serde_json::Value::String(s), Some(UniversalType::Json | UniversalType::Jsonb)) => {
+        (serde_json::Value::String(s), Some(Type::Json | Type::Jsonb)) => {
             match serde_json::from_str::<serde_json::Value>(&s) {
                 Ok(parsed_json) => Ok(json_to_surreal_without_schema(parsed_json)),
                 Err(_) => Ok(Value::Strand(Strand::from(s))),
@@ -113,7 +111,7 @@ pub fn json_to_surreal_with_universal_type(
         }
 
         // Date conversion
-        (serde_json::Value::String(s), Some(UniversalType::Date)) => {
+        (serde_json::Value::String(s), Some(Type::Date)) => {
             if let Ok(date) = chrono::NaiveDate::parse_from_str(&s, "%Y-%m-%d") {
                 let dt = date
                     .and_hms_opt(0, 0, 0)
@@ -127,12 +125,10 @@ pub fn json_to_surreal_with_universal_type(
         }
 
         // Time conversion
-        (serde_json::Value::String(s), Some(UniversalType::Time)) => {
-            Ok(Value::Strand(Strand::from(s)))
-        }
+        (serde_json::Value::String(s), Some(Type::Time)) => Ok(Value::Strand(Strand::from(s))),
 
         // Boolean conversion - handle MySQL TINYINT(1) which comes as 0/1 integers
-        (serde_json::Value::Number(n), Some(UniversalType::Bool)) => {
+        (serde_json::Value::Number(n), Some(Type::Bool)) => {
             if let Some(i) = n.as_i64() {
                 Ok(Value::Bool(i != 0))
             } else {
@@ -143,7 +139,7 @@ pub fn json_to_surreal_with_universal_type(
         }
 
         // SET column conversion - handle MySQL SET columns encoded as comma-separated strings
-        (serde_json::Value::String(s), Some(UniversalType::Set { .. })) => {
+        (serde_json::Value::String(s), Some(Type::Set { .. })) => {
             if s.is_empty() {
                 Ok(Value::Array(surrealdb::sql::Array::from(
                     Vec::<Value>::new(),
@@ -158,11 +154,11 @@ pub fn json_to_surreal_with_universal_type(
         }
 
         // Handle NULL SET columns
-        (serde_json::Value::Null, Some(UniversalType::Set { .. })) => Ok(Value::Null),
+        (serde_json::Value::Null, Some(Type::Set { .. })) => Ok(Value::Null),
 
         // Array type conversion
-        (serde_json::Value::String(s), Some(UniversalType::Array { element_type }))
-            if matches!(element_type.as_ref(), UniversalType::Text) =>
+        (serde_json::Value::String(s), Some(Type::Array { element_type }))
+            if matches!(element_type.as_ref(), Type::Text) =>
         {
             if s.is_empty() {
                 Ok(Value::Array(surrealdb::sql::Array::from(
@@ -178,7 +174,7 @@ pub fn json_to_surreal_with_universal_type(
         }
 
         // Handle NULL Arrays
-        (serde_json::Value::Null, Some(UniversalType::Array { .. })) => Ok(Value::Null),
+        (serde_json::Value::Null, Some(Type::Array { .. })) => Ok(Value::Null),
 
         // For all other cases, use the generic JSON conversion
         (value, _) => Ok(json_to_surreal_without_schema(value)),
@@ -214,17 +210,14 @@ pub fn convert_id_with_database_schema(
     convert_id_with_universal_type(id_str, table_name, id_type)
 }
 
-/// Convert a string ID value to the proper SurrealDB ID type using UniversalType.
+/// Convert a string ID value to the proper SurrealDB ID type using Type.
 fn convert_id_with_universal_type(
     id_str: &str,
     table_name: &str,
-    id_type: &UniversalType,
+    id_type: &Type,
 ) -> anyhow::Result<surrealdb::sql::Id> {
     match id_type {
-        UniversalType::Int8 { .. }
-        | UniversalType::Int16
-        | UniversalType::Int32
-        | UniversalType::Int64 => {
+        Type::Int8 { .. } | Type::Int16 | Type::Int32 | Type::Int64 => {
             let id_int: i64 = id_str.parse().map_err(|e| {
                 anyhow::anyhow!(
                     "Failed to parse ID '{id_str}' as integer for table '{table_name}': {e}"
@@ -232,7 +225,7 @@ fn convert_id_with_universal_type(
             })?;
             Ok(surrealdb::sql::Id::Number(id_int))
         }
-        UniversalType::Uuid => {
+        Type::Uuid => {
             let uuid = uuid::Uuid::parse_str(id_str).map_err(|e| {
                 anyhow::anyhow!(
                     "Failed to parse ID '{id_str}' as UUID for table '{table_name}': {e}"
@@ -240,7 +233,7 @@ fn convert_id_with_universal_type(
             })?;
             Ok(surrealdb::sql::Id::Uuid(surrealdb::sql::Uuid::from(uuid)))
         }
-        UniversalType::Text | UniversalType::VarChar { .. } | UniversalType::Char { .. } => {
+        Type::Text | Type::VarChar { .. } | Type::Char { .. } => {
             Ok(surrealdb::sql::Id::String(id_str.to_string()))
         }
         other => {
@@ -327,10 +320,10 @@ mod tests {
     fn test_new_schema_aware_decimal_conversion() {
         let schema = TableDefinition::new(
             "products",
-            ColumnDefinition::new("id", UniversalType::Int64),
+            ColumnDefinition::new("id", Type::Int64),
             vec![ColumnDefinition::new(
                 "price",
-                UniversalType::Decimal {
+                Type::Decimal {
                     precision: 10,
                     scale: 2,
                 },
@@ -351,11 +344,8 @@ mod tests {
     fn test_new_schema_aware_timestamp_conversion() {
         let schema = TableDefinition::new(
             "events",
-            ColumnDefinition::new("id", UniversalType::Int64),
-            vec![ColumnDefinition::new(
-                "created_at",
-                UniversalType::LocalDateTime,
-            )],
+            ColumnDefinition::new("id", Type::Int64),
+            vec![ColumnDefinition::new("created_at", Type::LocalDateTime)],
         );
 
         // Test timestamp conversion
@@ -372,7 +362,7 @@ mod tests {
     fn test_new_schema_aware_fallback() {
         let schema = TableDefinition::new(
             "test",
-            ColumnDefinition::new("id", UniversalType::Int64),
+            ColumnDefinition::new("id", Type::Int64),
             vec![], // Empty columns
         );
 
@@ -391,7 +381,7 @@ mod tests {
     fn test_new_convert_id_integer() {
         let schema = DatabaseSchema::new(vec![TableDefinition::new(
             "users",
-            ColumnDefinition::new("id", UniversalType::Int64),
+            ColumnDefinition::new("id", Type::Int64),
             vec![],
         )]);
 
@@ -407,7 +397,7 @@ mod tests {
     fn test_new_convert_id_uuid() {
         let schema = DatabaseSchema::new(vec![TableDefinition::new(
             "products",
-            ColumnDefinition::new("id", UniversalType::Uuid),
+            ColumnDefinition::new("id", Type::Uuid),
             vec![],
         )]);
 
@@ -427,7 +417,7 @@ mod tests {
     fn test_new_convert_id_string() {
         let schema = DatabaseSchema::new(vec![TableDefinition::new(
             "documents",
-            ColumnDefinition::new("id", UniversalType::Text),
+            ColumnDefinition::new("id", Type::Text),
             vec![],
         )]);
 
@@ -457,10 +447,10 @@ mod tests {
     fn test_new_set_column_conversion() {
         let schema = TableDefinition::new(
             "users",
-            ColumnDefinition::new("id", UniversalType::Int64),
+            ColumnDefinition::new("id", Type::Int64),
             vec![ColumnDefinition::new(
                 "roles",
-                UniversalType::Set {
+                Type::Set {
                     values: vec!["admin".to_string(), "user".to_string()],
                 },
             )],

--- a/crates/surreal3-sink/src/change.rs
+++ b/crates/surreal3-sink/src/change.rs
@@ -4,51 +4,53 @@ use surreal3_types::{RecordWithSurrealValues as Record, Relation};
 use surrealdb::types::RecordId;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum ChangeOp {
+pub enum MutationOp {
     Create,
     Update,
     Delete,
 }
 
 #[derive(Debug, Clone)]
-pub enum Change {
+pub enum Mutation {
     UpsertRecord(Record),
     DeleteRecord(RecordId),
     UpsertRelation(Relation),
     DeleteRelation(RecordId),
 }
 
-impl Change {
+impl Mutation {
     /// Create a record change using native surrealdb::types::Value types.
     pub fn record(
-        operation: ChangeOp,
+        operation: MutationOp,
         id: RecordId,
         data: HashMap<String, surrealdb::types::Value>,
     ) -> Self {
         match operation {
-            ChangeOp::Create | ChangeOp::Update => Change::UpsertRecord(Record::new(id, data)),
-            ChangeOp::Delete => Change::DeleteRecord(id),
+            MutationOp::Create | MutationOp::Update => {
+                Mutation::UpsertRecord(Record::new(id, data))
+            }
+            MutationOp::Delete => Mutation::DeleteRecord(id),
         }
     }
 
     pub fn relation(
-        operation: ChangeOp,
+        operation: MutationOp,
         id: RecordId,
         input: RecordId,
         output: RecordId,
         data: Option<HashMap<String, SurrealValue>>,
     ) -> Self {
         match operation {
-            ChangeOp::Create | ChangeOp::Update => {
+            MutationOp::Create | MutationOp::Update => {
                 let data = data.expect("Data must be provided for create/update relation");
-                Change::UpsertRelation(Relation {
+                Mutation::UpsertRelation(Relation {
                     id,
                     input,
                     output,
                     data,
                 })
             }
-            ChangeOp::Delete => Change::DeleteRelation(id.clone()),
+            MutationOp::Delete => Mutation::DeleteRelation(id.clone()),
         }
     }
 }

--- a/crates/surreal3-sink/src/lib.rs
+++ b/crates/surreal3-sink/src/lib.rs
@@ -8,17 +8,17 @@ mod rows;
 mod sink_impl;
 mod write;
 
-pub use change::{Change, ChangeOp};
+pub use change::{Mutation, MutationOp};
 pub use connect::{surreal_connect, surreal_connect_with_retries, SurrealOpts};
 pub use rows::{
-    universal_relation_to_surreal_relation, universal_row_to_surreal_record,
-    universal_value_to_surreal_id, write_universal_relations, write_universal_rows,
+    relation_to_surreal_relation, row_to_surreal_record, value_to_surreal_id, write_relations,
+    write_rows,
 };
 pub use sink_impl::Surreal3Sink;
 pub use sync_core::ZeroTemporalPolicy;
 pub use write::{
-    apply_change, apply_universal_change, write_record, write_records, write_relation,
-    write_relations,
+    apply_change, apply_mutation, write_native_relations, write_record, write_records,
+    write_relation,
 };
 
 // Re-export SurrealDB types for use by source crates

--- a/crates/surreal3-sink/src/rows.rs
+++ b/crates/surreal3-sink/src/rows.rs
@@ -1,31 +1,31 @@
-//! Row-level operations for converting and writing UniversalRow to SurrealDB v3.
+//! Row-level operations for converting and writing Row to SurrealDB v3.
 
 use crate::write::{write_record, write_relation};
 use anyhow::{bail, Result};
 use std::collections::HashMap;
-use surreal3_types::{RecordWithSurrealValues, Relation, SurrealValue};
-use surrealdb::types::{Array, Number, RecordId, RecordIdKey, Value};
+use surreal3_types::{RecordWithSurrealValues, Relation as SurrealRelation, SurrealValue};
+use surrealdb::types::{Array, Number, RecordId, RecordIdKey, Value as DbValue};
 use surrealdb::Surreal;
-use sync_core::{UniversalRelation, UniversalRow, UniversalValue, ZeroTemporalPolicy};
+use sync_core::{Relation, Row, Value, ZeroTemporalPolicy};
 
-/// Convert UniversalValue ID to SurrealDB RecordIdKey.
+/// Convert Value ID to SurrealDB RecordIdKey.
 ///
 /// Returns an error for unsupported ID types - never falls back silently.
-/// Composite primary keys arrive as [`UniversalValue::Array`] and become
+/// Composite primary keys arrive as [`Value::Array`] and become
 /// SurrealDB array record IDs (`table:[k1, k2]`).
-pub fn universal_value_to_surreal_id(value: &UniversalValue) -> Result<RecordIdKey> {
+pub fn value_to_surreal_id(value: &Value) -> Result<RecordIdKey> {
     match value {
-        UniversalValue::Text(s) => Ok(RecordIdKey::String(s.clone())),
-        UniversalValue::VarChar { value, .. } => Ok(RecordIdKey::String(value.clone())),
-        UniversalValue::Char { value, .. } => Ok(RecordIdKey::String(value.clone())),
-        UniversalValue::Int32(n) => Ok(RecordIdKey::Number(*n as i64)),
-        UniversalValue::Int64(n) => Ok(RecordIdKey::Number(*n)),
-        UniversalValue::Uuid(u) => Ok(RecordIdKey::Uuid(surrealdb::types::Uuid::from(*u))),
-        UniversalValue::Ulid(u) => {
+        Value::Text(s) => Ok(RecordIdKey::String(s.clone())),
+        Value::VarChar { value, .. } => Ok(RecordIdKey::String(value.clone())),
+        Value::Char { value, .. } => Ok(RecordIdKey::String(value.clone())),
+        Value::Int32(n) => Ok(RecordIdKey::Number(*n as i64)),
+        Value::Int64(n) => Ok(RecordIdKey::Number(*n)),
+        Value::Uuid(u) => Ok(RecordIdKey::Uuid(surrealdb::types::Uuid::from(*u))),
+        Value::Ulid(u) => {
             // Convert ULID to string since SurrealDB doesn't have native ULID ID type
             Ok(RecordIdKey::String(u.to_string()))
         }
-        UniversalValue::Array { elements, .. } => {
+        Value::Array { elements, .. } => {
             if elements.is_empty() {
                 bail!("Composite SurrealDB ID Array must not be empty");
             }
@@ -39,28 +39,28 @@ pub fn universal_value_to_surreal_id(value: &UniversalValue) -> Result<RecordIdK
             Ok(RecordIdKey::Array(Array::from(vals)))
         }
         other => bail!(
-            "Unsupported UniversalValue type for SurrealDB ID: {other:?}. \
+            "Unsupported Value type for SurrealDB ID: {other:?}. \
              Supported types: Text, VarChar, Char, Int32, Int64, Uuid, Ulid, Array"
         ),
     }
 }
 
-/// Convert one element of a composite (Array) record ID to a SurrealDB [`Value`].
-fn universal_value_to_id_array_element(value: &UniversalValue) -> Result<Value> {
+/// Convert one element of a composite (Array) record ID to a SurrealDB [`DbValue`].
+fn universal_value_to_id_array_element(value: &Value) -> Result<DbValue> {
     match value {
-        UniversalValue::Text(s) => Ok(Value::String(s.clone())),
-        UniversalValue::VarChar { value, .. } | UniversalValue::Char { value, .. } => {
-            Ok(Value::String(value.clone()))
+        Value::Text(s) => Ok(DbValue::String(s.clone())),
+        Value::VarChar { value, .. } | Value::Char { value, .. } => {
+            Ok(DbValue::String(value.clone()))
         }
-        UniversalValue::Int8 { value, .. } => Ok(Value::Number(Number::Int(*value as i64))),
-        UniversalValue::Int16(n) => Ok(Value::Number(Number::Int(*n as i64))),
-        UniversalValue::Int32(n) => Ok(Value::Number(Number::Int(*n as i64))),
-        UniversalValue::Int64(n) => Ok(Value::Number(Number::Int(*n))),
-        UniversalValue::Bool(b) => Ok(Value::Bool(*b)),
-        UniversalValue::Null => Ok(Value::None),
-        UniversalValue::Uuid(u) => Ok(Value::Uuid(surrealdb::types::Uuid::from(*u))),
-        UniversalValue::Ulid(u) => Ok(Value::String(u.to_string())),
-        UniversalValue::Array { .. } => {
+        Value::Int8 { value, .. } => Ok(DbValue::Number(Number::Int(*value as i64))),
+        Value::Int16(n) => Ok(DbValue::Number(Number::Int(*n as i64))),
+        Value::Int32(n) => Ok(DbValue::Number(Number::Int(*n as i64))),
+        Value::Int64(n) => Ok(DbValue::Number(Number::Int(*n))),
+        Value::Bool(b) => Ok(DbValue::Bool(*b)),
+        Value::Null => Ok(DbValue::None),
+        Value::Uuid(u) => Ok(DbValue::Uuid(surrealdb::types::Uuid::from(*u))),
+        Value::Ulid(u) => Ok(DbValue::String(u.to_string())),
+        Value::Array { .. } => {
             bail!("Nested arrays are not supported in composite SurrealDB IDs")
         }
         other => bail!(
@@ -70,17 +70,17 @@ fn universal_value_to_id_array_element(value: &UniversalValue) -> Result<Value> 
     }
 }
 
-/// Convert UniversalRow to RecordWithSurrealValues.
+/// Convert Row to RecordWithSurrealValues.
 ///
 /// Returns an error if the row's ID type is not supported.
-pub fn universal_row_to_surreal_record(
-    row: &UniversalRow,
+pub fn row_to_surreal_record(
+    row: &Row,
     zero_temporal: ZeroTemporalPolicy,
 ) -> Result<RecordWithSurrealValues> {
-    let id = universal_value_to_surreal_id(&row.id)?;
+    let id = value_to_surreal_id(&row.id)?;
     let record_id = RecordId::new(row.table.as_str(), id);
 
-    let data: HashMap<String, Value> = row
+    let data: HashMap<String, DbValue> = row
         .fields
         .iter()
         .map(|(k, v)| {
@@ -93,38 +93,38 @@ pub fn universal_row_to_surreal_record(
     Ok(RecordWithSurrealValues::new(record_id, data))
 }
 
-/// Write a batch of UniversalRows to SurrealDB.
+/// Write a batch of Rows to SurrealDB.
 ///
 /// Returns an error if any row has an unsupported ID type.
-pub async fn write_universal_rows(
+pub async fn write_rows(
     surreal: &Surreal<surrealdb::engine::any::Any>,
-    rows: &[UniversalRow],
+    rows: &[Row],
     zero_temporal: ZeroTemporalPolicy,
 ) -> Result<()> {
     for row in rows {
-        let record = universal_row_to_surreal_record(row, zero_temporal)?;
+        let record = row_to_surreal_record(row, zero_temporal)?;
         write_record(surreal, &record).await?;
     }
     Ok(())
 }
 
-/// Convert UniversalRelation to SurrealDB Relation.
+/// Convert Relation to SurrealDB Relation.
 ///
 /// Returns an error if any ID type is not supported.
-pub fn universal_relation_to_surreal_relation(
-    rel: &UniversalRelation,
+pub fn relation_to_surreal_relation(
+    rel: &Relation,
     zero_temporal: ZeroTemporalPolicy,
-) -> Result<Relation> {
+) -> Result<SurrealRelation> {
     // Convert the relation's own ID
-    let id = universal_value_to_surreal_id(&rel.id)?;
+    let id = value_to_surreal_id(&rel.id)?;
     let record_id = RecordId::new(rel.relation_type.as_str(), id);
 
     // Convert input (source) RecordId
-    let input_id = universal_value_to_surreal_id(&rel.input.id)?;
+    let input_id = value_to_surreal_id(&rel.input.id)?;
     let input_record_id = RecordId::new(rel.input.table.as_str(), input_id);
 
     // Convert output (target) RecordId
-    let output_id = universal_value_to_surreal_id(&rel.output.id)?;
+    let output_id = value_to_surreal_id(&rel.output.id)?;
     let output_record_id = RecordId::new(rel.output.table.as_str(), output_id);
 
     // Convert data
@@ -138,7 +138,7 @@ pub fn universal_relation_to_surreal_relation(
         })
         .collect();
 
-    Ok(Relation {
+    Ok(SurrealRelation {
         id: record_id,
         input: input_record_id,
         output: output_record_id,
@@ -146,16 +146,16 @@ pub fn universal_relation_to_surreal_relation(
     })
 }
 
-/// Write a batch of UniversalRelations to SurrealDB.
+/// Write a batch of Relations to SurrealDB.
 ///
 /// Returns an error if any relation has an unsupported ID type.
-pub async fn write_universal_relations(
+pub async fn write_relations(
     surreal: &Surreal<surrealdb::engine::any::Any>,
-    relations: &[UniversalRelation],
+    relations: &[Relation],
     zero_temporal: ZeroTemporalPolicy,
 ) -> Result<()> {
     for rel in relations {
-        let surreal_rel = universal_relation_to_surreal_relation(rel, zero_temporal)?;
+        let surreal_rel = relation_to_surreal_relation(rel, zero_temporal)?;
         write_relation(surreal, &surreal_rel).await?;
     }
     Ok(())
@@ -164,113 +164,110 @@ pub async fn write_universal_relations(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sync_core::UniversalValue;
+    use sync_core::Value;
 
     #[test]
-    fn test_universal_value_to_surreal_id_text() {
-        let value = UniversalValue::Text("user123".to_string());
-        let id = universal_value_to_surreal_id(&value).unwrap();
+    fn test_value_to_surreal_id_text() {
+        let value = Value::Text("user123".to_string());
+        let id = value_to_surreal_id(&value).unwrap();
         assert!(matches!(id, RecordIdKey::String(s) if s == "user123"));
     }
 
     #[test]
-    fn test_universal_value_to_surreal_id_int32() {
-        let value = UniversalValue::Int32(42);
-        let id = universal_value_to_surreal_id(&value).unwrap();
+    fn test_value_to_surreal_id_int32() {
+        let value = Value::Int32(42);
+        let id = value_to_surreal_id(&value).unwrap();
         assert!(matches!(id, RecordIdKey::Number(n) if n == 42));
     }
 
     #[test]
-    fn test_universal_value_to_surreal_id_int64() {
-        let value = UniversalValue::Int64(9999999999);
-        let id = universal_value_to_surreal_id(&value).unwrap();
+    fn test_value_to_surreal_id_int64() {
+        let value = Value::Int64(9999999999);
+        let id = value_to_surreal_id(&value).unwrap();
         assert!(matches!(id, RecordIdKey::Number(n) if n == 9999999999));
     }
 
     #[test]
-    fn test_universal_value_to_surreal_id_uuid() {
+    fn test_value_to_surreal_id_uuid() {
         let uuid = uuid::Uuid::new_v4();
-        let value = UniversalValue::Uuid(uuid);
-        let id = universal_value_to_surreal_id(&value).unwrap();
+        let value = Value::Uuid(uuid);
+        let id = value_to_surreal_id(&value).unwrap();
         assert!(matches!(id, RecordIdKey::Uuid(_)));
     }
 
     #[test]
-    fn test_universal_value_to_surreal_id_ulid() {
+    fn test_value_to_surreal_id_ulid() {
         let ulid = ulid::Ulid::new();
         let ulid_str = ulid.to_string();
-        let value = UniversalValue::Ulid(ulid);
-        let id = universal_value_to_surreal_id(&value).unwrap();
+        let value = Value::Ulid(ulid);
+        let id = value_to_surreal_id(&value).unwrap();
         assert!(matches!(id, RecordIdKey::String(s) if s == ulid_str));
     }
 
     #[test]
-    fn test_universal_value_to_surreal_id_unsupported() {
-        let value = UniversalValue::Float64(1.23);
-        let result = universal_value_to_surreal_id(&value);
+    fn test_value_to_surreal_id_unsupported() {
+        let value = Value::Float64(1.23);
+        let result = value_to_surreal_id(&value);
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert!(err.to_string().contains("Unsupported UniversalValue type"));
+        assert!(err.to_string().contains("Unsupported Value type"));
     }
 
     #[test]
-    fn test_universal_value_to_surreal_id_bool_unsupported() {
-        let value = UniversalValue::Bool(true);
-        let result = universal_value_to_surreal_id(&value);
+    fn test_value_to_surreal_id_bool_unsupported() {
+        let value = Value::Bool(true);
+        let result = value_to_surreal_id(&value);
         assert!(result.is_err());
     }
 
     #[test]
-    fn test_universal_value_to_surreal_id_array_ints() {
-        let value = UniversalValue::Array {
-            elements: vec![UniversalValue::Int32(4), UniversalValue::Int64(2)],
-            element_type: Box::new(sync_core::UniversalType::Int32),
+    fn test_value_to_surreal_id_array_ints() {
+        let value = Value::Array {
+            elements: vec![Value::Int32(4), Value::Int64(2)],
+            element_type: Box::new(sync_core::Type::Int32),
         };
-        let id = universal_value_to_surreal_id(&value).unwrap();
+        let id = value_to_surreal_id(&value).unwrap();
         match id {
             RecordIdKey::Array(arr) => {
                 assert_eq!(arr.len(), 2);
-                assert!(matches!(&arr[0], Value::Number(Number::Int(4))));
-                assert!(matches!(&arr[1], Value::Number(Number::Int(2))));
+                assert!(matches!(&arr[0], DbValue::Number(Number::Int(4))));
+                assert!(matches!(&arr[1], DbValue::Number(Number::Int(2))));
             }
             other => panic!("expected RecordIdKey::Array, got {other:?}"),
         }
     }
 
     #[test]
-    fn test_universal_value_to_surreal_id_array_mixed() {
+    fn test_value_to_surreal_id_array_mixed() {
         let uuid = uuid::Uuid::new_v4();
-        let value = UniversalValue::Array {
-            elements: vec![
-                UniversalValue::Text("a_b".to_string()),
-                UniversalValue::Uuid(uuid),
-            ],
-            element_type: Box::new(sync_core::UniversalType::Text),
+        let value = Value::Array {
+            elements: vec![Value::Text("a_b".to_string()), Value::Uuid(uuid)],
+            element_type: Box::new(sync_core::Type::Text),
         };
-        let id = universal_value_to_surreal_id(&value).unwrap();
+        let id = value_to_surreal_id(&value).unwrap();
         assert!(matches!(id, RecordIdKey::Array(arr) if arr.len() == 2));
     }
 
     #[test]
-    fn test_universal_value_to_surreal_id_array_empty_rejected() {
-        let value = UniversalValue::Array {
+    fn test_value_to_surreal_id_array_empty_rejected() {
+        let value = Value::Array {
             elements: vec![],
-            element_type: Box::new(sync_core::UniversalType::Text),
+            element_type: Box::new(sync_core::Type::Text),
         };
-        let err = universal_value_to_surreal_id(&value).unwrap_err();
+        let err = value_to_surreal_id(&value).unwrap_err();
         assert!(err.to_string().contains("must not be empty"));
     }
 
     #[test]
-    fn test_universal_value_to_surreal_id_nested_array_rejected() {
-        let value = UniversalValue::Array {
-            elements: vec![UniversalValue::Array {
-                elements: vec![UniversalValue::Int32(1)],
-                element_type: Box::new(sync_core::UniversalType::Int32),
+    fn test_value_to_surreal_id_nested_array_rejected() {
+        let value = Value::Array {
+            elements: vec![Value::Array {
+                elements: vec![Value::Int32(1)],
+                element_type: Box::new(sync_core::Type::Int32),
             }],
-            element_type: Box::new(sync_core::UniversalType::Text),
+            element_type: Box::new(sync_core::Type::Text),
         };
-        let err = universal_value_to_surreal_id(&value).unwrap_err();
+        let err = value_to_surreal_id(&value).unwrap_err();
         assert!(err.to_string().contains("Nested arrays"));
     }
 }

--- a/crates/surreal3-sink/src/sink_impl.rs
+++ b/crates/surreal3-sink/src/sink_impl.rs
@@ -4,12 +4,10 @@ use anyhow::Result;
 use surreal_sink::SurrealSink;
 use surrealdb::engine::any::Any;
 use surrealdb::Surreal;
-use sync_core::{
-    UniversalChange, UniversalRelation, UniversalRelationChange, UniversalRow, ZeroTemporalPolicy,
-};
+use sync_core::{Change, Relation, RelationChange, Row, ZeroTemporalPolicy};
 
-use crate::rows::{write_universal_relations, write_universal_rows};
-use crate::write::{apply_universal_change, apply_universal_relation_change};
+use crate::rows::{write_relations, write_rows};
+use crate::write::{apply_change, apply_relation_change};
 
 /// Wrapper around Surreal<Any> that implements SurrealSink.
 ///
@@ -61,22 +59,19 @@ impl Surreal3Sink {
 
 #[async_trait::async_trait]
 impl SurrealSink for Surreal3Sink {
-    async fn write_universal_rows(&self, rows: &[UniversalRow]) -> Result<()> {
-        write_universal_rows(&self.client, rows, self.zero_temporal).await
+    async fn write_rows(&self, rows: &[Row]) -> Result<()> {
+        write_rows(&self.client, rows, self.zero_temporal).await
     }
 
-    async fn write_universal_relations(&self, relations: &[UniversalRelation]) -> Result<()> {
-        write_universal_relations(&self.client, relations, self.zero_temporal).await
+    async fn write_relations(&self, relations: &[Relation]) -> Result<()> {
+        write_relations(&self.client, relations, self.zero_temporal).await
     }
 
-    async fn apply_universal_change(&self, change: &UniversalChange) -> Result<()> {
-        apply_universal_change(&self.client, change, self.zero_temporal).await
+    async fn apply_change(&self, change: &Change) -> Result<()> {
+        apply_change(&self.client, change, self.zero_temporal).await
     }
 
-    async fn apply_universal_relation_change(
-        &self,
-        change: &UniversalRelationChange,
-    ) -> Result<()> {
-        apply_universal_relation_change(&self.client, change, self.zero_temporal).await
+    async fn apply_relation_change(&self, change: &RelationChange) -> Result<()> {
+        apply_relation_change(&self.client, change, self.zero_temporal).await
     }
 }

--- a/crates/surreal3-sink/src/write.rs
+++ b/crates/surreal3-sink/src/write.rs
@@ -1,13 +1,13 @@
-use crate::Change;
+use crate::Mutation;
 use std::collections::HashMap;
 use std::time::Duration;
 use surreal3_types::{RecordWithSurrealValues as Record, Relation, SurrealValue};
 use surrealdb::types::{Number, RecordId, RecordIdKey, Value};
 use surrealdb::Surreal;
-use sync_core::{UniversalChange, UniversalChangeOp, UniversalRelationChange, ZeroTemporalPolicy};
+use sync_core::{Change, ChangeOp, RelationChange, ZeroTemporalPolicy};
 use tokio::time::sleep;
 
-use crate::rows::{universal_relation_to_surreal_relation, universal_value_to_surreal_id};
+use crate::rows::{relation_to_surreal_relation, value_to_surreal_id};
 
 /// Convert a `RecordIdKey` to a `Value` suitable for parameter binding.
 ///
@@ -69,17 +69,17 @@ fn is_retriable_transaction_error(error: &surrealdb::Error) -> bool {
 }
 
 // Apply a single change event to SurrealDB
-pub async fn apply_change(
+pub async fn apply_mutation(
     surreal: &Surreal<surrealdb::engine::any::Any>,
-    change: &Change,
+    change: &Mutation,
 ) -> anyhow::Result<()> {
     match change {
-        Change::UpsertRecord(record) => {
+        Mutation::UpsertRecord(record) => {
             write_record(surreal, record).await?;
 
             tracing::trace!("Successfully upserted record: {record:?}");
         }
-        Change::DeleteRecord(record_id) => {
+        Mutation::DeleteRecord(record_id) => {
             let query = "DELETE type::record($record_tb, $record_key)".to_string();
             tracing::trace!("Executing SurrealDB query: {}", query);
             log::info!("🔧 migrate_change executing: {query} for record: {record_id:?}");
@@ -92,12 +92,12 @@ pub async fn apply_change(
 
             tracing::trace!("Successfully deleted record: {:?}", record_id);
         }
-        Change::UpsertRelation(relation) => {
+        Mutation::UpsertRelation(relation) => {
             write_relation(surreal, relation).await?;
 
             tracing::trace!("Successfully upserted relation: {relation:?}");
         }
-        Change::DeleteRelation(record_id) => {
+        Mutation::DeleteRelation(record_id) => {
             let query = "DELETE type::record($relation_tb, $relation_key)".to_string();
             tracing::trace!("Executing SurrealDB query: {}", query);
             log::info!("🔧 migrate_change executing: {query} for relation: {record_id:?}");
@@ -115,22 +115,22 @@ pub async fn apply_change(
     Ok(())
 }
 
-/// Apply a UniversalChange event to SurrealDB.
+/// Apply a Change event to SurrealDB.
 ///
-/// Converts UniversalChange to the appropriate SurrealDB operation and executes it.
-pub async fn apply_universal_change(
+/// Converts Change to the appropriate SurrealDB operation and executes it.
+pub async fn apply_change(
     surreal: &Surreal<surrealdb::engine::any::Any>,
-    change: &UniversalChange,
+    change: &Change,
     zero_temporal: ZeroTemporalPolicy,
 ) -> anyhow::Result<()> {
-    // Convert ID from UniversalValue to SurrealDB ID
-    let surreal_id = universal_value_to_surreal_id(&change.id)?;
+    // Convert ID from Value to SurrealDB ID
+    let surreal_id = value_to_surreal_id(&change.id)?;
     let record_id = RecordId::new(change.table.as_str(), surreal_id);
 
     match change.operation {
-        UniversalChangeOp::Create | UniversalChangeOp::Update => {
-            // Convert data from HashMap<String, UniversalValue> to HashMap<String, surrealdb::types::Value>
-            let data = change.data.as_ref().ok_or_else(|| {
+        ChangeOp::Create | ChangeOp::Update => {
+            // Convert data from HashMap<String, Value> to HashMap<String, surrealdb::types::Value>
+            let data = change.fields.as_ref().ok_or_else(|| {
                 anyhow::anyhow!(
                     "Create/Update change must have data, but found None for table '{}'",
                     change.table
@@ -150,7 +150,7 @@ pub async fn apply_universal_change(
 
             tracing::trace!("Successfully upserted record: {record_id:?}");
         }
-        UniversalChangeOp::Delete => {
+        ChangeOp::Delete => {
             let query = "DELETE type::record($record_tb, $record_key)".to_string();
             tracing::trace!("Executing SurrealDB query: {}", query);
 
@@ -446,7 +446,7 @@ pub async fn write_relation(
     Err(anyhow::anyhow!(error_msg))
 }
 
-pub async fn write_relations(
+pub async fn write_native_relations(
     surreal: &Surreal<surrealdb::engine::any::Any>,
     table_name: &str,
     batch: &[Relation],
@@ -470,24 +470,23 @@ pub async fn write_relations(
     Ok(())
 }
 
-/// Apply a UniversalRelationChange event to SurrealDB.
-pub async fn apply_universal_relation_change(
+/// Apply a RelationChange event to SurrealDB.
+pub async fn apply_relation_change(
     surreal: &Surreal<surrealdb::engine::any::Any>,
-    change: &UniversalRelationChange,
+    change: &RelationChange,
     zero_temporal: ZeroTemporalPolicy,
 ) -> anyhow::Result<()> {
     match change.operation {
-        UniversalChangeOp::Create | UniversalChangeOp::Update => {
-            let surreal_rel =
-                universal_relation_to_surreal_relation(&change.relation, zero_temporal)?;
+        ChangeOp::Create | ChangeOp::Update => {
+            let surreal_rel = relation_to_surreal_relation(&change.relation, zero_temporal)?;
             write_relation(surreal, &surreal_rel).await?;
             tracing::trace!(
                 "Successfully upserted relation: {:?}",
                 change.relation.relation_type
             );
         }
-        UniversalChangeOp::Delete => {
-            let surreal_id = universal_value_to_surreal_id(&change.relation.id)?;
+        ChangeOp::Delete => {
+            let surreal_id = value_to_surreal_id(&change.relation.id)?;
             let query = "DELETE type::record($relation_tb, $relation_key)".to_string();
             let mut q = surreal.query(query);
             q = q.bind(("relation_tb", change.relation.relation_type.clone()));

--- a/crates/surreal3-types/src/forward.rs
+++ b/crates/surreal3-types/src/forward.rs
@@ -5,65 +5,62 @@
 use rust_decimal::Decimal;
 use std::collections::BTreeMap;
 use std::str::FromStr;
-use surrealdb::types::{Array, Datetime, Number, Object, RecordId, RecordIdKey, Value};
-use sync_core::{TypedValue, UniversalType, UniversalValue};
+use surrealdb::types::{Array, Datetime, Number, Object, RecordId, RecordIdKey, Value as DbValue};
+use sync_core::{Type, TypedValue, Value};
 
 /// Wrapper for SurrealDB values.
 #[derive(Debug, Clone)]
-pub struct SurrealValue(pub Value);
+pub struct SurrealValue(pub DbValue);
 
 impl SurrealValue {
     /// Get the inner SurrealDB value.
-    pub fn into_inner(self) -> Value {
+    pub fn into_inner(self) -> DbValue {
         self.0
     }
 
     /// Get a reference to the inner SurrealDB value.
-    pub fn as_inner(&self) -> &Value {
+    pub fn as_inner(&self) -> &DbValue {
         &self.0
     }
 
     /// Convert a zero-temporal sentinel using the given sink policy.
     pub fn from_zero_temporal(
-        intended_type: &UniversalType,
+        intended_type: &Type,
         source: Option<&str>,
         policy: sync_core::ZeroTemporalPolicy,
     ) -> Self {
         match policy {
-            sync_core::ZeroTemporalPolicy::None => SurrealValue(Value::None),
-            sync_core::ZeroTemporalPolicy::Null => SurrealValue(Value::Null),
+            sync_core::ZeroTemporalPolicy::None => SurrealValue(DbValue::None),
+            sync_core::ZeroTemporalPolicy::Null => SurrealValue(DbValue::Null),
             sync_core::ZeroTemporalPolicy::String => {
                 let s = source
-                    .unwrap_or_else(|| UniversalValue::canonical_zero_literal(intended_type))
+                    .unwrap_or_else(|| Value::canonical_zero_literal(intended_type))
                     .to_string();
-                SurrealValue(Value::String(s))
+                SurrealValue(DbValue::String(s))
             }
         }
     }
 
-    /// Convert a [`UniversalValue`] with an explicit zero-temporal policy.
-    pub fn from_universal_with_policy(
-        value: UniversalValue,
-        policy: sync_core::ZeroTemporalPolicy,
-    ) -> Self {
+    /// Convert a [`Value`] with an explicit zero-temporal policy.
+    pub fn from_universal_with_policy(value: Value, policy: sync_core::ZeroTemporalPolicy) -> Self {
         match value {
-            UniversalValue::ZeroTemporal {
+            Value::ZeroTemporal {
                 intended_type,
                 source,
             } => Self::from_zero_temporal(&intended_type, source.as_deref(), policy),
-            UniversalValue::Array { elements, .. } => {
-                let surreal_arr: Vec<Value> = elements
+            Value::Array { elements, .. } => {
+                let surreal_arr: Vec<DbValue> = elements
                     .into_iter()
                     .map(|v| Self::from_universal_with_policy(v, policy).into_inner())
                     .collect();
-                SurrealValue(Value::Array(Array::from(surreal_arr)))
+                SurrealValue(DbValue::Array(Array::from(surreal_arr)))
             }
-            UniversalValue::Object(map) => {
+            Value::Object(map) => {
                 let mut obj = BTreeMap::new();
                 for (k, v) in map {
                     obj.insert(k, Self::from_universal_with_policy(v, policy).into_inner());
                 }
-                SurrealValue(Value::Object(Object::from(obj)))
+                SurrealValue(DbValue::Object(Object::from(obj)))
             }
             other => SurrealValue::from(other),
         }
@@ -73,33 +70,29 @@ impl SurrealValue {
     pub fn from_typed_with_policy(tv: TypedValue, policy: sync_core::ZeroTemporalPolicy) -> Self {
         match (&tv.sync_type, &tv.value) {
             // JSON can be a string that needs parsing
-            (UniversalType::Json, UniversalValue::Text(s)) => {
-                match serde_json::from_str::<serde_json::Value>(s) {
-                    Ok(v) => SurrealValue(json_to_surreal(&v)),
-                    Err(_) => SurrealValue(Value::String(s.clone())),
-                }
-            }
-            (UniversalType::Jsonb, UniversalValue::Text(s)) => {
-                match serde_json::from_str::<serde_json::Value>(s) {
-                    Ok(v) => SurrealValue(json_to_surreal(&v)),
-                    Err(_) => SurrealValue(Value::String(s.clone())),
-                }
-            }
+            (Type::Json, Value::Text(s)) => match serde_json::from_str::<serde_json::Value>(s) {
+                Ok(v) => SurrealValue(json_to_surreal(&v)),
+                Err(_) => SurrealValue(DbValue::String(s.clone())),
+            },
+            (Type::Jsonb, Value::Text(s)) => match serde_json::from_str::<serde_json::Value>(s) {
+                Ok(v) => SurrealValue(json_to_surreal(&v)),
+                Err(_) => SurrealValue(DbValue::String(s.clone())),
+            },
             // JSON can also be an array (e.g., from MySQL SET columns or JSON arrays)
-            (UniversalType::Json, UniversalValue::Array { elements, .. }) => {
-                let surreal_arr: Vec<Value> =
+            (Type::Json, Value::Array { elements, .. }) => {
+                let surreal_arr: Vec<DbValue> =
                     elements.iter().map(generated_value_to_surreal).collect();
-                SurrealValue(Value::Array(Array::from(surreal_arr)))
+                SurrealValue(DbValue::Array(Array::from(surreal_arr)))
             }
-            (UniversalType::Jsonb, UniversalValue::Array { elements, .. }) => {
-                let surreal_arr: Vec<Value> =
+            (Type::Jsonb, Value::Array { elements, .. }) => {
+                let surreal_arr: Vec<DbValue> =
                     elements.iter().map(generated_value_to_surreal).collect();
-                SurrealValue(Value::Array(Array::from(surreal_arr)))
+                SurrealValue(DbValue::Array(Array::from(surreal_arr)))
             }
 
             // Array types need recursive conversion with element type info
-            (UniversalType::Array { element_type }, UniversalValue::Array { elements, .. }) => {
-                let surreal_arr: Vec<Value> = elements
+            (Type::Array { element_type }, Value::Array { elements, .. }) => {
+                let surreal_arr: Vec<DbValue> = elements
                     .iter()
                     .map(|v| {
                         let tv = TypedValue {
@@ -109,10 +102,10 @@ impl SurrealValue {
                         Self::from_typed_with_policy(tv, policy).into_inner()
                     })
                     .collect();
-                SurrealValue(Value::Array(Array::from(surreal_arr)))
+                SurrealValue(DbValue::Array(Array::from(surreal_arr)))
             }
 
-            // For all other cases, delegate to policy-aware UniversalValue conversion
+            // For all other cases, delegate to policy-aware Value conversion
             _ => Self::from_universal_with_policy(tv.value, policy),
         }
     }
@@ -124,159 +117,155 @@ impl From<TypedValue> for SurrealValue {
     }
 }
 
-impl From<UniversalValue> for SurrealValue {
-    fn from(value: UniversalValue) -> Self {
+impl From<Value> for SurrealValue {
+    fn from(value: Value) -> Self {
         match value {
             // Null
-            UniversalValue::Null => SurrealValue(Value::None),
+            Value::Null => SurrealValue(DbValue::None),
 
             // Boolean
-            UniversalValue::Bool(b) => SurrealValue(Value::Bool(b)),
+            Value::Bool(b) => SurrealValue(DbValue::Bool(b)),
 
             // Integer types
-            UniversalValue::Int8 { value, .. } => {
-                SurrealValue(Value::Number(Number::Int(value as i64)))
-            }
-            UniversalValue::Int16(i) => SurrealValue(Value::Number(Number::Int(i as i64))),
-            UniversalValue::Int32(i) => SurrealValue(Value::Number(Number::Int(i as i64))),
-            UniversalValue::Int64(i) => SurrealValue(Value::Number(Number::Int(i))),
+            Value::Int8 { value, .. } => SurrealValue(DbValue::Number(Number::Int(value as i64))),
+            Value::Int16(i) => SurrealValue(DbValue::Number(Number::Int(i as i64))),
+            Value::Int32(i) => SurrealValue(DbValue::Number(Number::Int(i as i64))),
+            Value::Int64(i) => SurrealValue(DbValue::Number(Number::Int(i))),
 
             // Floating point
-            UniversalValue::Float32(f) => SurrealValue(Value::Number(Number::Float(f as f64))),
-            UniversalValue::Float64(f) => SurrealValue(Value::Number(Number::Float(f))),
+            Value::Float32(f) => SurrealValue(DbValue::Number(Number::Float(f as f64))),
+            Value::Float64(f) => SurrealValue(DbValue::Number(Number::Float(f))),
 
             // Decimal - try to parse as rust_decimal, fallback to float
-            UniversalValue::Decimal { value, .. } => {
+            Value::Decimal { value, .. } => {
                 match Decimal::from_str(&value) {
-                    Ok(dec) => SurrealValue(Value::Number(Number::Decimal(dec))),
+                    Ok(dec) => SurrealValue(DbValue::Number(Number::Decimal(dec))),
                     Err(_) => {
                         // Can't fit in rust_decimal - convert to f64
                         // TODO: Add option to store as String if user requests high precision preservation
                         let f: f64 = value.parse().unwrap_or(0.0);
-                        SurrealValue(Value::Number(Number::Float(f)))
+                        SurrealValue(DbValue::Number(Number::Float(f)))
                     }
                 }
             }
 
             // String types - auto-detect ISO 8601 duration strings
-            UniversalValue::Char { value, .. } => {
+            Value::Char { value, .. } => {
                 if let Some(duration) = try_parse_iso8601_duration(&value) {
-                    SurrealValue(Value::Duration(surrealdb::types::Duration::from(duration)))
+                    SurrealValue(DbValue::Duration(surrealdb::types::Duration::from(
+                        duration,
+                    )))
                 } else {
-                    SurrealValue(Value::String(value))
+                    SurrealValue(DbValue::String(value))
                 }
             }
-            UniversalValue::VarChar { value, .. } => {
+            Value::VarChar { value, .. } => {
                 if let Some(duration) = try_parse_iso8601_duration(&value) {
-                    SurrealValue(Value::Duration(surrealdb::types::Duration::from(duration)))
+                    SurrealValue(DbValue::Duration(surrealdb::types::Duration::from(
+                        duration,
+                    )))
                 } else {
-                    SurrealValue(Value::String(value))
+                    SurrealValue(DbValue::String(value))
                 }
             }
-            UniversalValue::Text(s) => {
+            Value::Text(s) => {
                 // Auto-detect ISO 8601 duration strings (PTxxxS format) and convert to Duration
                 if let Some(duration) = try_parse_iso8601_duration(&s) {
-                    SurrealValue(Value::Duration(surrealdb::types::Duration::from(duration)))
+                    SurrealValue(DbValue::Duration(surrealdb::types::Duration::from(
+                        duration,
+                    )))
                 } else {
-                    SurrealValue(Value::String(s))
+                    SurrealValue(DbValue::String(s))
                 }
             }
 
             // Binary types
-            UniversalValue::Blob(b) => SurrealValue(Value::Bytes(surrealdb::types::Bytes::from(b))),
-            UniversalValue::Bytes(b) => {
-                SurrealValue(Value::Bytes(surrealdb::types::Bytes::from(b)))
-            }
+            Value::Blob(b) => SurrealValue(DbValue::Bytes(surrealdb::types::Bytes::from(b))),
+            Value::Bytes(b) => SurrealValue(DbValue::Bytes(surrealdb::types::Bytes::from(b))),
 
             // Date/time types
-            UniversalValue::Date(dt) => {
-                SurrealValue(Value::String(dt.format("%Y-%m-%d").to_string()))
-            }
+            Value::Date(dt) => SurrealValue(DbValue::String(dt.format("%Y-%m-%d").to_string())),
             // Note: Using "%H:%M:%S%.f" to preserve fractional seconds from PostgreSQL TIME type.
             // While SurrealDB doesn't have a native TIME type, storing as string with full precision
             // ensures no data loss during sync.
-            UniversalValue::Time(dt) => {
-                SurrealValue(Value::String(dt.format("%H:%M:%S%.f").to_string()))
-            }
-            UniversalValue::LocalDateTime(dt) => SurrealValue(Value::Datetime(Datetime::from(dt))),
-            UniversalValue::LocalDateTimeNano(dt) => {
-                SurrealValue(Value::Datetime(Datetime::from(dt)))
-            }
-            UniversalValue::ZonedDateTime(dt) => SurrealValue(Value::Datetime(Datetime::from(dt))),
+            Value::Time(dt) => SurrealValue(DbValue::String(dt.format("%H:%M:%S%.f").to_string())),
+            Value::LocalDateTime(dt) => SurrealValue(DbValue::Datetime(Datetime::from(dt))),
+            Value::LocalDateTimeNano(dt) => SurrealValue(DbValue::Datetime(Datetime::from(dt))),
+            Value::ZonedDateTime(dt) => SurrealValue(DbValue::Datetime(Datetime::from(dt))),
             // TIMETZ - stored as string to preserve timezone format.
             // Note: We intentionally do NOT use Datetime here because time and datetime
             // are fundamentally different types. Datetime implies a specific point in time,
             // while TIMETZ represents a daily recurring time in a specific timezone.
             // Misusing Datetime to represent time would lose semantic meaning.
-            UniversalValue::TimeTz(s) => SurrealValue(Value::String(s)),
+            Value::TimeTz(s) => SurrealValue(DbValue::String(s)),
 
             // UUID
-            UniversalValue::Uuid(u) => SurrealValue(Value::Uuid(surrealdb::types::Uuid::from(u))),
+            Value::Uuid(u) => SurrealValue(DbValue::Uuid(surrealdb::types::Uuid::from(u))),
 
             // ULID - convert to string since SurrealDB doesn't have native ULID ID type
-            UniversalValue::Ulid(u) => SurrealValue(Value::String(u.to_string())),
+            Value::Ulid(u) => SurrealValue(DbValue::String(u.to_string())),
 
             // JSON types
-            UniversalValue::Json(json_val) => SurrealValue(json_to_surreal(&json_val)),
-            UniversalValue::Jsonb(json_val) => SurrealValue(json_to_surreal(&json_val)),
+            Value::Json(json_val) => SurrealValue(json_to_surreal(&json_val)),
+            Value::Jsonb(json_val) => SurrealValue(json_to_surreal(&json_val)),
 
             // Array
-            UniversalValue::Array { elements, .. } => {
-                let surreal_arr: Vec<Value> = elements
+            Value::Array { elements, .. } => {
+                let surreal_arr: Vec<DbValue> = elements
                     .into_iter()
                     .map(|v| SurrealValue::from(v).into_inner())
                     .collect();
-                SurrealValue(Value::Array(Array::from(surreal_arr)))
+                SurrealValue(DbValue::Array(Array::from(surreal_arr)))
             }
 
             // Set - stored as array of strings
-            UniversalValue::Set { elements, .. } => {
-                let surreal_arr: Vec<Value> = elements.into_iter().map(Value::String).collect();
-                SurrealValue(Value::Array(Array::from(surreal_arr)))
+            Value::Set { elements, .. } => {
+                let surreal_arr: Vec<DbValue> = elements.into_iter().map(DbValue::String).collect();
+                SurrealValue(DbValue::Array(Array::from(surreal_arr)))
             }
 
             // Enum - stored as string
-            UniversalValue::Enum { value, .. } => SurrealValue(Value::String(value)),
+            Value::Enum { value, .. } => SurrealValue(DbValue::String(value)),
 
             // Geometry - convert to JSON object
-            UniversalValue::Geometry { data, .. } => {
+            Value::Geometry { data, .. } => {
                 use sync_core::values::GeometryData;
                 let GeometryData(json_val) = data;
                 SurrealValue(json_to_surreal(&json_val))
             }
 
             // Duration - convert to SurrealDB Duration
-            UniversalValue::Duration(d) => {
-                SurrealValue(Value::Duration(surrealdb::types::Duration::from(d)))
+            Value::Duration(d) => {
+                SurrealValue(DbValue::Duration(surrealdb::types::Duration::from(d)))
             }
 
             // Thing - record reference
-            UniversalValue::Thing { table, id } => {
+            Value::Thing { table, id } => {
                 // Convert the ID to a SurrealDB ID type
                 let surreal_id = match id.as_ref() {
-                    UniversalValue::Text(s) => RecordIdKey::String(s.clone()),
-                    UniversalValue::Int32(i) => RecordIdKey::Number(*i as i64),
-                    UniversalValue::Int64(i) => RecordIdKey::Number(*i),
-                    UniversalValue::Uuid(u) => RecordIdKey::Uuid(surrealdb::types::Uuid::from(*u)),
-                    UniversalValue::Ulid(u) => RecordIdKey::String(u.to_string()),
+                    Value::Text(s) => RecordIdKey::String(s.clone()),
+                    Value::Int32(i) => RecordIdKey::Number(*i as i64),
+                    Value::Int64(i) => RecordIdKey::Number(*i),
+                    Value::Uuid(u) => RecordIdKey::Uuid(surrealdb::types::Uuid::from(*u)),
+                    Value::Ulid(u) => RecordIdKey::String(u.to_string()),
                     // For unsupported types, convert to string representation
                     other => RecordIdKey::String(format!("{other:?}")),
                 };
                 let record_id = RecordId::new(table.as_str(), surreal_id);
-                SurrealValue(Value::RecordId(record_id))
+                SurrealValue(DbValue::RecordId(record_id))
             }
 
             // Object - nested document
-            UniversalValue::Object(map) => {
+            Value::Object(map) => {
                 let mut obj = BTreeMap::new();
                 for (k, v) in map {
                     obj.insert(k.clone(), generated_value_to_surreal(&v));
                 }
-                SurrealValue(Value::Object(Object::from(obj)))
+                SurrealValue(DbValue::Object(Object::from(obj)))
             }
 
             // Zero temporal — default sink policy is NONE (see ZeroTemporalPolicy)
-            UniversalValue::ZeroTemporal {
+            Value::ZeroTemporal {
                 intended_type,
                 source,
             } => SurrealValue::from_zero_temporal(
@@ -288,28 +277,28 @@ impl From<UniversalValue> for SurrealValue {
     }
 }
 
-/// Convert a UniversalValue to a SurrealDB Value (without type context).
-/// This is a helper for internal use - prefer using `From<UniversalValue>` trait.
-fn generated_value_to_surreal(value: &UniversalValue) -> Value {
+/// Convert a Value to a SurrealDB DbValue (without type context).
+/// This is a helper for internal use - prefer using `From<Value>` trait.
+fn generated_value_to_surreal(value: &Value) -> DbValue {
     SurrealValue::from(value.clone()).into_inner()
 }
 
-/// Convert a serde_json::Value to SurrealDB Value.
-fn json_to_surreal(value: &serde_json::Value) -> Value {
+/// Convert a serde_json::Value to SurrealDB DbValue.
+fn json_to_surreal(value: &serde_json::Value) -> DbValue {
     match value {
-        serde_json::Value::Null => Value::None,
-        serde_json::Value::Bool(b) => Value::Bool(*b),
+        serde_json::Value::Null => DbValue::None,
+        serde_json::Value::Bool(b) => DbValue::Bool(*b),
         serde_json::Value::Number(n) => {
             if let Some(i) = n.as_i64() {
-                Value::Number(Number::Int(i))
+                DbValue::Number(Number::Int(i))
             } else if let Some(f) = n.as_f64() {
-                Value::Number(Number::Float(f))
+                DbValue::Number(Number::Float(f))
             } else {
-                Value::None
+                DbValue::None
             }
         }
-        serde_json::Value::String(s) => Value::String(s.clone()),
-        serde_json::Value::Array(arr) => Value::Array(Array::from(
+        serde_json::Value::String(s) => DbValue::String(s.clone()),
+        serde_json::Value::Array(arr) => DbValue::Array(Array::from(
             arr.iter().map(json_to_surreal).collect::<Vec<_>>(),
         )),
         serde_json::Value::Object(map) => {
@@ -317,7 +306,7 @@ fn json_to_surreal(value: &serde_json::Value) -> Value {
             for (k, v) in map {
                 obj.insert(k.clone(), json_to_surreal(v));
             }
-            Value::Object(Object::from(obj))
+            DbValue::Object(Object::from(obj))
         }
     }
 }
@@ -346,15 +335,15 @@ fn try_parse_iso8601_duration(s: &str) -> Option<std::time::Duration> {
 /// Create a SurrealDB RecordId (record ID).
 ///
 /// Returns an error for unsupported ID types.
-pub fn create_thing(table: &str, id: &UniversalValue) -> anyhow::Result<RecordId> {
+pub fn create_thing(table: &str, id: &Value) -> anyhow::Result<RecordId> {
     let id_part = match id {
-        UniversalValue::Text(s) => RecordIdKey::String(s.clone()),
-        UniversalValue::Int32(i) => RecordIdKey::Number(*i as i64),
-        UniversalValue::Int64(i) => RecordIdKey::Number(*i),
-        UniversalValue::Uuid(u) => RecordIdKey::Uuid(surrealdb::types::Uuid::from(*u)),
-        UniversalValue::Ulid(u) => RecordIdKey::String(u.to_string()),
+        Value::Text(s) => RecordIdKey::String(s.clone()),
+        Value::Int32(i) => RecordIdKey::Number(*i as i64),
+        Value::Int64(i) => RecordIdKey::Number(*i),
+        Value::Uuid(u) => RecordIdKey::Uuid(surrealdb::types::Uuid::from(*u)),
+        Value::Ulid(u) => RecordIdKey::String(u.to_string()),
         other => anyhow::bail!(
-            "Unsupported UniversalValue type for SurrealDB ID: {other:?}. \
+            "Unsupported Value type for SurrealDB ID: {other:?}. \
              Supported types: Text, Int32, Int64, Uuid, Ulid"
         ),
     };
@@ -379,7 +368,7 @@ where
 /// before creating SurrealDB records.
 pub fn typed_values_to_surreal_map(
     typed_values: std::collections::HashMap<String, TypedValue>,
-) -> std::collections::HashMap<String, Value> {
+) -> std::collections::HashMap<String, DbValue> {
     typed_values
         .into_iter()
         .map(|(k, v)| (k, SurrealValue::from(v).into_inner()))
@@ -391,22 +380,22 @@ pub fn typed_values_to_surreal_map(
 #[derive(Debug, Clone)]
 pub struct RecordWithSurrealValues {
     pub id: RecordId,
-    pub data: std::collections::HashMap<String, Value>,
+    pub data: std::collections::HashMap<String, DbValue>,
 }
 
 impl RecordWithSurrealValues {
     /// Create a new record with the given ID and data.
-    pub fn new(id: RecordId, data: std::collections::HashMap<String, Value>) -> Self {
+    pub fn new(id: RecordId, data: std::collections::HashMap<String, DbValue>) -> Self {
         Self { id, data }
     }
 
     /// Get the upsert content as a SurrealDB Object.
-    pub fn get_upsert_content(&self) -> Value {
+    pub fn get_upsert_content(&self) -> DbValue {
         let mut m = BTreeMap::new();
         for (k, v) in &self.data {
             m.insert(k.clone(), v.clone());
         }
-        Value::Object(Object::from(m))
+        DbValue::Object(Object::from(m))
     }
 }
 
@@ -417,31 +406,31 @@ mod tests {
 
     #[test]
     fn test_null_conversion() {
-        let tv = TypedValue::null(UniversalType::Text);
+        let tv = TypedValue::null(Type::Text);
         let surreal_val: SurrealValue = tv.into();
-        assert!(matches!(surreal_val.0, Value::None));
+        assert!(matches!(surreal_val.0, DbValue::None));
     }
 
     #[test]
     fn test_zero_temporal_policies() {
-        let zero = UniversalValue::zero_temporal(UniversalType::Date, Some("0000-00-00".into()));
+        let zero = Value::zero_temporal(Type::Date, Some("0000-00-00".into()));
 
         let none = SurrealValue::from_universal_with_policy(
             zero.clone(),
             sync_core::ZeroTemporalPolicy::None,
         );
-        assert!(matches!(none.0, Value::None));
+        assert!(matches!(none.0, DbValue::None));
 
         let null = SurrealValue::from_universal_with_policy(
             zero.clone(),
             sync_core::ZeroTemporalPolicy::Null,
         );
-        assert!(matches!(null.0, Value::Null));
+        assert!(matches!(null.0, DbValue::Null));
 
         let string =
             SurrealValue::from_universal_with_policy(zero, sync_core::ZeroTemporalPolicy::String);
         match string.0 {
-            Value::String(s) => assert_eq!(s, "0000-00-00"),
+            DbValue::String(s) => assert_eq!(s, "0000-00-00"),
             other => panic!("expected String, got {other:?}"),
         }
     }
@@ -450,32 +439,32 @@ mod tests {
     fn test_bool_conversion() {
         let tv = TypedValue::bool(true);
         let surreal_val: SurrealValue = tv.into();
-        assert!(matches!(surreal_val.0, Value::Bool(true)));
+        assert!(matches!(surreal_val.0, DbValue::Bool(true)));
 
         let tv = TypedValue::bool(false);
         let surreal_val: SurrealValue = tv.into();
-        assert!(matches!(surreal_val.0, Value::Bool(false)));
+        assert!(matches!(surreal_val.0, DbValue::Bool(false)));
     }
 
     #[test]
     fn test_tinyint_conversion() {
         let tv = TypedValue::int8(127, 4);
         let surreal_val: SurrealValue = tv.into();
-        assert!(matches!(surreal_val.0, Value::Number(Number::Int(127))));
+        assert!(matches!(surreal_val.0, DbValue::Number(Number::Int(127))));
     }
 
     #[test]
     fn test_smallint_conversion() {
         let tv = TypedValue::int16(32000);
         let surreal_val: SurrealValue = tv.into();
-        assert!(matches!(surreal_val.0, Value::Number(Number::Int(32000))));
+        assert!(matches!(surreal_val.0, DbValue::Number(Number::Int(32000))));
     }
 
     #[test]
     fn test_int_conversion() {
         let tv = TypedValue::int32(12345);
         let surreal_val: SurrealValue = tv.into();
-        assert!(matches!(surreal_val.0, Value::Number(Number::Int(12345))));
+        assert!(matches!(surreal_val.0, DbValue::Number(Number::Int(12345))));
     }
 
     #[test]
@@ -484,7 +473,7 @@ mod tests {
         let surreal_val: SurrealValue = tv.into();
         assert!(matches!(
             surreal_val.0,
-            Value::Number(Number::Int(9876543210))
+            DbValue::Number(Number::Int(9876543210))
         ));
     }
 
@@ -492,7 +481,7 @@ mod tests {
     fn test_float_conversion() {
         let tv = TypedValue::float32(1.234);
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Number(Number::Float(f)) = surreal_val.0 {
+        if let DbValue::Number(Number::Float(f)) = surreal_val.0 {
             assert!((f - 1.234).abs() < 0.0001);
         } else {
             panic!("Expected Float");
@@ -503,7 +492,7 @@ mod tests {
     fn test_double_conversion() {
         let tv = TypedValue::float64(1.23456);
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Number(Number::Float(f)) = surreal_val.0 {
+        if let DbValue::Number(Number::Float(f)) = surreal_val.0 {
             assert!((f - 1.23456).abs() < 0.00001);
         } else {
             panic!("Expected Float");
@@ -514,7 +503,7 @@ mod tests {
     fn test_decimal_conversion() {
         let tv = TypedValue::decimal("123.45", 10, 2);
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Number(Number::Decimal(d)) = surreal_val.0 {
+        if let DbValue::Number(Number::Decimal(d)) = surreal_val.0 {
             assert_eq!(d.to_string(), "123.45");
         } else {
             panic!("Expected Decimal");
@@ -523,10 +512,10 @@ mod tests {
 
     #[test]
     fn test_high_precision_decimal_conversion() {
-        // Value exceeding rust_decimal MAX should be stored as float
+        // DbValue exceeding rust_decimal MAX should be stored as float
         let tv = TypedValue::decimal("12345678901234567890123456789012345678901234567890", 50, 0);
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Number(Number::Float(f)) = surreal_val.0 {
+        if let DbValue::Number(Number::Float(f)) = surreal_val.0 {
             // Large numbers get converted to f64 (with precision loss)
             assert!(f > 1e49);
         } else {
@@ -541,7 +530,7 @@ mod tests {
     fn test_char_conversion() {
         let tv = TypedValue::char_type("test", 10);
         let surreal_val: SurrealValue = tv.into();
-        if let Value::String(s) = surreal_val.0 {
+        if let DbValue::String(s) = surreal_val.0 {
             assert_eq!(s, "test");
         } else {
             panic!("Expected String");
@@ -552,7 +541,7 @@ mod tests {
     fn test_text_conversion() {
         let tv = TypedValue::text("hello world");
         let surreal_val: SurrealValue = tv.into();
-        if let Value::String(s) = surreal_val.0 {
+        if let DbValue::String(s) = surreal_val.0 {
             assert_eq!(s, "hello world");
         } else {
             panic!("Expected String");
@@ -563,7 +552,7 @@ mod tests {
     fn test_bytes_conversion() {
         let tv = TypedValue::bytes(vec![0xDE, 0xAD, 0xBE, 0xEF]);
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Bytes(b) = surreal_val.0 {
+        if let DbValue::Bytes(b) = surreal_val.0 {
             assert_eq!(&*b.into_inner(), &[0xDE, 0xAD, 0xBE, 0xEF]);
         } else {
             panic!("Expected Bytes");
@@ -575,7 +564,7 @@ mod tests {
         let u = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
         let tv = TypedValue::uuid(u);
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Uuid(uuid) = surreal_val.0 {
+        if let DbValue::Uuid(uuid) = surreal_val.0 {
             let inner: uuid::Uuid = uuid.into();
             assert_eq!(inner.to_string(), "550e8400-e29b-41d4-a716-446655440000");
         } else {
@@ -588,7 +577,7 @@ mod tests {
         let dt = Utc.with_ymd_and_hms(2024, 6, 15, 10, 30, 0).unwrap();
         let tv = TypedValue::datetime(dt);
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Datetime(sdt) = surreal_val.0 {
+        if let DbValue::Datetime(sdt) = surreal_val.0 {
             let inner: chrono::DateTime<chrono::Utc> = sdt.into();
             assert_eq!(inner.year(), 2024);
             assert_eq!(inner.month(), 6);
@@ -603,7 +592,7 @@ mod tests {
         let dt = Utc.with_ymd_and_hms(2024, 6, 15, 0, 0, 0).unwrap();
         let tv = TypedValue::date(dt);
         let surreal_val: SurrealValue = tv.into();
-        if let Value::String(s) = surreal_val.0 {
+        if let DbValue::String(s) = surreal_val.0 {
             assert_eq!(s, "2024-06-15");
         } else {
             panic!("Expected String");
@@ -615,7 +604,7 @@ mod tests {
         let dt = Utc.with_ymd_and_hms(2024, 6, 15, 14, 30, 45).unwrap();
         let tv = TypedValue::time(dt);
         let surreal_val: SurrealValue = tv.into();
-        if let Value::String(s) = surreal_val.0 {
+        if let DbValue::String(s) = surreal_val.0 {
             assert_eq!(s, "14:30:45");
         } else {
             panic!("Expected String");
@@ -630,11 +619,11 @@ mod tests {
         });
 
         let tv = TypedValue {
-            sync_type: UniversalType::Json,
-            value: UniversalValue::Json(Box::new(json)),
+            sync_type: Type::Json,
+            value: Value::Json(Box::new(json)),
         };
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Object(obj) = surreal_val.0 {
+        if let DbValue::Object(obj) = surreal_val.0 {
             assert!(obj.get("name").is_some());
             assert!(obj.get("count").is_some());
         } else {
@@ -645,11 +634,11 @@ mod tests {
     #[test]
     fn test_json_string_conversion() {
         let tv = TypedValue {
-            sync_type: UniversalType::Json,
-            value: UniversalValue::Text(r#"{"key": "value"}"#.to_string()),
+            sync_type: Type::Json,
+            value: Value::Text(r#"{"key": "value"}"#.to_string()),
         };
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Object(obj) = surreal_val.0 {
+        if let DbValue::Object(obj) = surreal_val.0 {
             assert!(obj.get("key").is_some());
         } else {
             panic!("Expected Object");
@@ -659,15 +648,11 @@ mod tests {
     #[test]
     fn test_array_int_conversion() {
         let tv = TypedValue::array(
-            vec![
-                UniversalValue::Int32(1),
-                UniversalValue::Int32(2),
-                UniversalValue::Int32(3),
-            ],
-            UniversalType::Int32,
+            vec![Value::Int32(1), Value::Int32(2), Value::Int32(3)],
+            Type::Int32,
         );
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Array(arr) = surreal_val.0 {
+        if let DbValue::Array(arr) = surreal_val.0 {
             assert_eq!(arr.len(), 3);
         } else {
             panic!("Expected Array");
@@ -677,14 +662,11 @@ mod tests {
     #[test]
     fn test_array_text_conversion() {
         let tv = TypedValue::array(
-            vec![
-                UniversalValue::Text("a".to_string()),
-                UniversalValue::Text("b".to_string()),
-            ],
-            UniversalType::Text,
+            vec![Value::Text("a".to_string()), Value::Text("b".to_string())],
+            Type::Text,
         );
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Array(arr) = surreal_val.0 {
+        if let DbValue::Array(arr) = surreal_val.0 {
             assert_eq!(arr.len(), 2);
         } else {
             panic!("Expected Array");
@@ -698,7 +680,7 @@ mod tests {
             vec!["a".to_string(), "b".to_string(), "c".to_string()],
         );
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Array(arr) = surreal_val.0 {
+        if let DbValue::Array(arr) = surreal_val.0 {
             assert_eq!(arr.len(), 2);
         } else {
             panic!("Expected Array");
@@ -710,7 +692,7 @@ mod tests {
         let tv =
             TypedValue::enum_type("active", vec!["active".to_string(), "inactive".to_string()]);
         let surreal_val: SurrealValue = tv.into();
-        if let Value::String(s) = surreal_val.0 {
+        if let DbValue::String(s) = surreal_val.0 {
             assert_eq!(s, "active");
         } else {
             panic!("Expected String");
@@ -726,19 +708,19 @@ mod tests {
         let tv = TypedValue::geometry_geojson(json, sync_core::GeometryType::Point);
         let surreal_val: SurrealValue = tv.into();
         // With the simplified conversion, this will be a JSON object
-        assert!(matches!(surreal_val.0, Value::Object(_)));
+        assert!(matches!(surreal_val.0, DbValue::Object(_)));
     }
 
     #[test]
     fn test_create_thing_string() {
-        let id = UniversalValue::Text("user123".to_string());
+        let id = Value::Text("user123".to_string());
         let record_id = create_thing("users", &id).unwrap();
         assert_eq!(record_id.table.as_str(), "users");
     }
 
     #[test]
     fn test_create_thing_int() {
-        let id = UniversalValue::Int64(42);
+        let id = Value::Int64(42);
         let record_id = create_thing("users", &id).unwrap();
         assert_eq!(record_id.table.as_str(), "users");
     }
@@ -746,7 +728,7 @@ mod tests {
     #[test]
     fn test_create_thing_uuid() {
         let u = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
-        let id = UniversalValue::Uuid(u);
+        let id = Value::Uuid(u);
         let record_id = create_thing("users", &id).unwrap();
         assert_eq!(record_id.table.as_str(), "users");
     }
@@ -754,14 +736,14 @@ mod tests {
     #[test]
     fn test_create_thing_ulid() {
         let u = ulid::Ulid::new();
-        let id = UniversalValue::Ulid(u);
+        let id = Value::Ulid(u);
         let record_id = create_thing("users", &id).unwrap();
         assert_eq!(record_id.table.as_str(), "users");
     }
 
     #[test]
     fn test_create_thing_unsupported_type() {
-        let id = UniversalValue::Float64(1.23);
+        let id = Value::Float64(1.23);
         let result = create_thing("users", &id);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Unsupported"));
@@ -787,7 +769,7 @@ mod tests {
         // gets auto-detected and converted to a SurrealDB Duration
         let tv = TypedValue::text("PT181S");
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Duration(d) = surreal_val.0 {
+        if let DbValue::Duration(d) = surreal_val.0 {
             let std_duration: std::time::Duration = d.into();
             assert_eq!(std_duration.as_secs(), 181);
         } else {
@@ -801,7 +783,7 @@ mod tests {
         // gets auto-detected and converted to a SurrealDB Duration
         let tv = TypedValue::varchar("PT181S", 64);
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Duration(d) = surreal_val.0 {
+        if let DbValue::Duration(d) = surreal_val.0 {
             let std_duration: std::time::Duration = d.into();
             assert_eq!(std_duration.as_secs(), 181);
         } else {
@@ -814,7 +796,7 @@ mod tests {
         // Test duration with nanoseconds: PT60.123456789S
         let tv = TypedValue::text("PT60.123456789S");
         let surreal_val: SurrealValue = tv.into();
-        if let Value::Duration(d) = surreal_val.0 {
+        if let DbValue::Duration(d) = surreal_val.0 {
             let std_duration: std::time::Duration = d.into();
             assert_eq!(std_duration.as_secs(), 60);
             assert_eq!(std_duration.subsec_nanos(), 123456789);
@@ -828,7 +810,7 @@ mod tests {
         // Regular text should remain as a string
         let tv = TypedValue::text("hello world");
         let surreal_val: SurrealValue = tv.into();
-        if let Value::String(s) = surreal_val.0 {
+        if let DbValue::String(s) = surreal_val.0 {
             assert_eq!(s, "hello world");
         } else {
             panic!("Expected String, got {:?}", surreal_val.0);

--- a/crates/surreal3-types/src/record.rs
+++ b/crates/surreal3-types/src/record.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use surrealdb::types::{RecordId, RecordIdKey};
-use sync_core::{TypedValue, UniversalValue};
+use sync_core::{TypedValue, Value};
 
 /// Convert typed values to a SurrealDB record using a specified field as the ID.
 /// The field is removed from the typed values map and used as a part of the record ID.
@@ -11,7 +11,7 @@ pub fn typed_values_to_record_using_field_as_id(
 ) -> anyhow::Result<crate::RecordWithSurrealValues> {
     // Extract ID from typed values
     let surreal_id = if let Some(id_value) = typed_values.remove(id_field) {
-        universal_value_to_surreal_id(&id_value.value)?
+        value_to_surreal_id(&id_value.value)?
     } else {
         anyhow::bail!(format!("Message has no '{id_field}' field"));
     };
@@ -49,13 +49,13 @@ fn typed_values_to_record_with_id(
     Ok(r)
 }
 
-/// Convert a UniversalValue to a SurrealDB ID.
-fn universal_value_to_surreal_id(value: &UniversalValue) -> Result<RecordIdKey> {
+/// Convert a Value to a SurrealDB ID.
+fn value_to_surreal_id(value: &Value) -> Result<RecordIdKey> {
     match value {
-        UniversalValue::Int32(i) => Ok(RecordIdKey::Number(*i as i64)),
-        UniversalValue::Int64(i) => Ok(RecordIdKey::Number(*i)),
-        UniversalValue::Text(s) => Ok(RecordIdKey::String(s.clone())),
-        UniversalValue::Uuid(u) => Ok(RecordIdKey::Uuid(surrealdb::types::Uuid::from(*u))),
+        Value::Int32(i) => Ok(RecordIdKey::Number(*i as i64)),
+        Value::Int64(i) => Ok(RecordIdKey::Number(*i)),
+        Value::Text(s) => Ok(RecordIdKey::String(s.clone())),
+        Value::Uuid(u) => Ok(RecordIdKey::Uuid(surrealdb::types::Uuid::from(*u))),
         other => anyhow::bail!("Cannot convert {other:?} to SurrealDB ID"),
     }
 }

--- a/crates/surreal3-types/src/reverse.rs
+++ b/crates/surreal3-types/src/reverse.rs
@@ -4,21 +4,21 @@
 
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
-use surrealdb::types::{Number, Object, RecordIdKey, Value};
-use sync_core::{TypedValue, UniversalType, UniversalValue};
+use surrealdb::types::{Number, Object, RecordIdKey, Value as DbValue};
+use sync_core::{Type, TypedValue, Value};
 
 /// SurrealDB value paired with schema information for type-aware conversion.
 #[derive(Debug, Clone)]
 pub struct SurrealValueWithSchema {
     /// The SurrealDB value.
-    pub value: Value,
+    pub value: DbValue,
     /// The expected sync type for conversion.
-    pub sync_type: UniversalType,
+    pub sync_type: Type,
 }
 
 impl SurrealValueWithSchema {
     /// Create a new SurrealValueWithSchema.
-    pub fn new(value: Value, sync_type: UniversalType) -> Self {
+    pub fn new(value: DbValue, sync_type: Type) -> Self {
         Self { value, sync_type }
     }
 
@@ -32,137 +32,133 @@ impl From<SurrealValueWithSchema> for TypedValue {
     fn from(sv: SurrealValueWithSchema) -> Self {
         match (&sv.sync_type, &sv.value) {
             // Null/None
-            (sync_type, Value::None) => TypedValue::null(sync_type.clone()),
+            (sync_type, DbValue::None) => TypedValue::null(sync_type.clone()),
 
             // Boolean
-            (UniversalType::Bool, Value::Bool(b)) => TypedValue::bool(*b),
+            (Type::Bool, DbValue::Bool(b)) => TypedValue::bool(*b),
 
             // Integer types
-            (UniversalType::Int8 { width }, Value::Number(Number::Int(i))) => TypedValue {
-                sync_type: UniversalType::Int8 { width: *width },
-                value: UniversalValue::Int32(*i as i32),
+            (Type::Int8 { width }, DbValue::Number(Number::Int(i))) => TypedValue {
+                sync_type: Type::Int8 { width: *width },
+                value: Value::Int32(*i as i32),
             },
-            (UniversalType::Int16, Value::Number(Number::Int(i))) => TypedValue::int16(*i as i16),
-            (UniversalType::Int32, Value::Number(Number::Int(i))) => TypedValue::int32(*i as i32),
-            (UniversalType::Int64, Value::Number(Number::Int(i))) => TypedValue::int64(*i),
+            (Type::Int16, DbValue::Number(Number::Int(i))) => TypedValue::int16(*i as i16),
+            (Type::Int32, DbValue::Number(Number::Int(i))) => TypedValue::int32(*i as i32),
+            (Type::Int64, DbValue::Number(Number::Int(i))) => TypedValue::int64(*i),
 
             // Floating point
-            (UniversalType::Float32, Value::Number(Number::Float(f))) => {
-                TypedValue::float32(*f as f32)
-            }
-            (UniversalType::Float64, Value::Number(Number::Float(f))) => TypedValue::float64(*f),
+            (Type::Float32, DbValue::Number(Number::Float(f))) => TypedValue::float32(*f as f32),
+            (Type::Float64, DbValue::Number(Number::Float(f))) => TypedValue::float64(*f),
 
             // Decimal
-            (UniversalType::Decimal { precision, scale }, Value::Number(Number::Decimal(d))) => {
+            (Type::Decimal { precision, scale }, DbValue::Number(Number::Decimal(d))) => {
                 TypedValue::decimal(d.to_string(), *precision, *scale)
             }
-            (UniversalType::Decimal { precision, scale }, Value::String(s)) => {
+            (Type::Decimal { precision, scale }, DbValue::String(s)) => {
                 TypedValue::decimal(s.as_str(), *precision, *scale)
             }
 
             // String types
-            (UniversalType::Char { length }, Value::String(s)) => TypedValue {
-                sync_type: UniversalType::Char { length: *length },
-                value: UniversalValue::Text(s.clone()),
+            (Type::Char { length }, DbValue::String(s)) => TypedValue {
+                sync_type: Type::Char { length: *length },
+                value: Value::Text(s.clone()),
             },
-            (UniversalType::VarChar { length }, Value::String(s)) => TypedValue {
-                sync_type: UniversalType::VarChar { length: *length },
-                value: UniversalValue::Text(s.clone()),
+            (Type::VarChar { length }, DbValue::String(s)) => TypedValue {
+                sync_type: Type::VarChar { length: *length },
+                value: Value::Text(s.clone()),
             },
-            (UniversalType::Text, Value::String(s)) => TypedValue::text(s.clone()),
+            (Type::Text, DbValue::String(s)) => TypedValue::text(s.clone()),
 
             // Binary types
-            (UniversalType::Blob, Value::Bytes(b)) => TypedValue {
-                sync_type: UniversalType::Blob,
-                value: UniversalValue::Bytes(b.clone().into_inner().to_vec()),
+            (Type::Blob, DbValue::Bytes(b)) => TypedValue {
+                sync_type: Type::Blob,
+                value: Value::Bytes(b.clone().into_inner().to_vec()),
             },
-            (UniversalType::Bytes, Value::Bytes(b)) => {
-                TypedValue::bytes(b.clone().into_inner().to_vec())
-            }
+            (Type::Bytes, DbValue::Bytes(b)) => TypedValue::bytes(b.clone().into_inner().to_vec()),
 
             // UUID
-            (UniversalType::Uuid, Value::Uuid(u)) => {
+            (Type::Uuid, DbValue::Uuid(u)) => {
                 let inner: uuid::Uuid = (*u).into();
                 TypedValue::uuid(inner)
             }
             // UUID might also be stored as string
-            (UniversalType::Uuid, Value::String(s)) => {
+            (Type::Uuid, DbValue::String(s)) => {
                 if let Ok(uuid) = uuid::Uuid::parse_str(s.as_str()) {
                     TypedValue::uuid(uuid)
                 } else {
-                    TypedValue::null(UniversalType::Uuid)
+                    TypedValue::null(Type::Uuid)
                 }
             }
 
             // Date/time types
-            (UniversalType::LocalDateTime, Value::Datetime(dt)) => {
+            (Type::LocalDateTime, DbValue::Datetime(dt)) => {
                 let inner: chrono::DateTime<chrono::Utc> = (*dt).into();
                 TypedValue::datetime(inner)
             }
-            (UniversalType::LocalDateTimeNano, Value::Datetime(dt)) => {
+            (Type::LocalDateTimeNano, DbValue::Datetime(dt)) => {
                 let inner: chrono::DateTime<chrono::Utc> = (*dt).into();
                 TypedValue {
-                    sync_type: UniversalType::LocalDateTimeNano,
-                    value: UniversalValue::LocalDateTime(inner),
+                    sync_type: Type::LocalDateTimeNano,
+                    value: Value::LocalDateTime(inner),
                 }
             }
-            (UniversalType::ZonedDateTime, Value::Datetime(dt)) => {
+            (Type::ZonedDateTime, DbValue::Datetime(dt)) => {
                 let inner: chrono::DateTime<chrono::Utc> = (*dt).into();
                 TypedValue {
-                    sync_type: UniversalType::ZonedDateTime,
-                    value: UniversalValue::LocalDateTime(inner),
+                    sync_type: Type::ZonedDateTime,
+                    value: Value::LocalDateTime(inner),
                 }
             }
 
             // Date stored as string
-            (UniversalType::Date, Value::String(s)) => {
+            (Type::Date, DbValue::String(s)) => {
                 if let Ok(dt) = chrono::NaiveDate::parse_from_str(s.as_str(), "%Y-%m-%d") {
                     let datetime = dt.and_hms_opt(0, 0, 0).unwrap();
                     let utc_dt = DateTime::<Utc>::from_naive_utc_and_offset(datetime, Utc);
                     TypedValue {
-                        sync_type: UniversalType::Date,
-                        value: UniversalValue::LocalDateTime(utc_dt),
+                        sync_type: Type::Date,
+                        value: Value::LocalDateTime(utc_dt),
                     }
                 } else {
-                    TypedValue::null(UniversalType::Date)
+                    TypedValue::null(Type::Date)
                 }
             }
 
             // Time stored as string
-            (UniversalType::Time, Value::String(s)) => {
+            (Type::Time, DbValue::String(s)) => {
                 if let Ok(time) = chrono::NaiveTime::parse_from_str(s.as_str(), "%H:%M:%S") {
                     let datetime = chrono::NaiveDate::from_ymd_opt(1970, 1, 1)
                         .unwrap()
                         .and_time(time);
                     let utc_dt = DateTime::<Utc>::from_naive_utc_and_offset(datetime, Utc);
                     TypedValue {
-                        sync_type: UniversalType::Time,
-                        value: UniversalValue::LocalDateTime(utc_dt),
+                        sync_type: Type::Time,
+                        value: Value::LocalDateTime(utc_dt),
                     }
                 } else {
-                    TypedValue::null(UniversalType::Time)
+                    TypedValue::null(Type::Time)
                 }
             }
 
             // JSON types
-            (UniversalType::Json, Value::Object(obj)) => {
+            (Type::Json, DbValue::Object(obj)) => {
                 let json_val = object_to_serde_json(obj);
                 TypedValue {
-                    sync_type: UniversalType::Json,
-                    value: UniversalValue::Json(Box::new(json_val)),
+                    sync_type: Type::Json,
+                    value: Value::Json(Box::new(json_val)),
                 }
             }
-            (UniversalType::Jsonb, Value::Object(obj)) => {
+            (Type::Jsonb, DbValue::Object(obj)) => {
                 let json_val = object_to_serde_json(obj);
                 TypedValue {
-                    sync_type: UniversalType::Jsonb,
-                    value: UniversalValue::Json(Box::new(json_val)),
+                    sync_type: Type::Jsonb,
+                    value: Value::Json(Box::new(json_val)),
                 }
             }
 
             // Array types
-            (UniversalType::Array { element_type }, Value::Array(arr)) => {
-                let values: Vec<UniversalValue> = arr
+            (Type::Array { element_type }, DbValue::Array(arr)) => {
+                let values: Vec<Value> = arr
                     .iter()
                     .map(|v| {
                         let sv = SurrealValueWithSchema::new(v.clone(), (**element_type).clone());
@@ -173,67 +169,67 @@ impl From<SurrealValueWithSchema> for TypedValue {
             }
 
             // Set - stored as array
-            (UniversalType::Set { values: set_values }, Value::Array(arr)) => {
-                let values: Vec<UniversalValue> = arr
+            (Type::Set { values: set_values }, DbValue::Array(arr)) => {
+                let values: Vec<Value> = arr
                     .iter()
                     .filter_map(|v| {
-                        if let Value::String(s) = v {
-                            Some(UniversalValue::Text(s.clone()))
+                        if let DbValue::String(s) = v {
+                            Some(Value::Text(s.clone()))
                         } else {
                             None
                         }
                     })
                     .collect();
                 TypedValue {
-                    sync_type: UniversalType::Set {
+                    sync_type: Type::Set {
                         values: set_values.clone(),
                     },
-                    value: UniversalValue::Array {
+                    value: Value::Array {
                         elements: values,
-                        element_type: Box::new(UniversalType::Text),
+                        element_type: Box::new(Type::Text),
                     },
                 }
             }
 
             // Enum - stored as string
             (
-                UniversalType::Enum {
+                Type::Enum {
                     values: enum_values,
                 },
-                Value::String(s),
+                DbValue::String(s),
             ) => TypedValue {
-                sync_type: UniversalType::Enum {
+                sync_type: Type::Enum {
                     values: enum_values.clone(),
                 },
-                value: UniversalValue::Text(s.clone()),
+                value: Value::Text(s.clone()),
             },
 
             // Geometry types - stored as SurrealDB Geometry
-            (UniversalType::Geometry { geometry_type }, Value::Geometry(geo)) => {
+            (Type::Geometry { geometry_type }, DbValue::Geometry(geo)) => {
                 let json_val = geometry_to_serde_json(geo);
                 TypedValue {
-                    sync_type: UniversalType::Geometry {
+                    sync_type: Type::Geometry {
                         geometry_type: geometry_type.clone(),
                     },
-                    value: UniversalValue::Json(Box::new(json_val)),
+                    value: Value::Json(Box::new(json_val)),
                 }
             }
 
             // Thing - record reference (now RecordId in v3)
-            (UniversalType::Thing, Value::RecordId(record_id)) => {
+            (Type::Thing, DbValue::RecordId(record_id)) => {
                 let table = record_id.table.as_str().to_string();
                 let id = match &record_id.key {
-                    RecordIdKey::String(s) => UniversalValue::Text(s.clone()),
-                    RecordIdKey::Number(n) => UniversalValue::Int64(*n),
+                    RecordIdKey::String(s) => Value::Text(s.clone()),
+                    RecordIdKey::Number(n) => Value::Int64(*n),
                     RecordIdKey::Uuid(u) => {
                         let inner: uuid::Uuid = (*u).into();
-                        UniversalValue::Uuid(inner)
+                        Value::Uuid(inner)
                     }
-                    _ => UniversalValue::Text(format!("{:?}", record_id.key)),
+                    _ => Value::Text(format!("{:?}", record_id.key)),
                 };
                 TypedValue {
-                    sync_type: UniversalType::Thing,
-                    value: UniversalValue::Thing {
+                    sync_type: Type::Thing,
+                    value: Value::Thing {
                         table,
                         id: Box::new(id),
                     },
@@ -246,9 +242,9 @@ impl From<SurrealValueWithSchema> for TypedValue {
     }
 }
 
-/// Convert a SurrealDB Object to a HashMap of UniversalValue.
+/// Convert a SurrealDB Object to a HashMap of Value.
 #[allow(dead_code)]
-fn object_to_hashmap(obj: &Object) -> HashMap<String, UniversalValue> {
+fn object_to_hashmap(obj: &Object) -> HashMap<String, Value> {
     let mut map = HashMap::new();
     for (key, value) in obj.iter() {
         map.insert(key.clone(), surreal_value_to_generated(value));
@@ -256,74 +252,73 @@ fn object_to_hashmap(obj: &Object) -> HashMap<String, UniversalValue> {
     map
 }
 
-/// Convert a SurrealDB Value to UniversalValue (without type context).
+/// Convert a SurrealDB DbValue to Value (without type context).
 #[allow(dead_code)]
-fn surreal_value_to_generated(value: &Value) -> UniversalValue {
+fn surreal_value_to_generated(value: &DbValue) -> Value {
     match value {
-        Value::None => UniversalValue::Null,
-        Value::Bool(b) => UniversalValue::Bool(*b),
-        Value::Number(Number::Int(i)) => UniversalValue::Int64(*i),
-        Value::Number(Number::Float(f)) => UniversalValue::Float64(*f),
-        Value::Number(Number::Decimal(d)) => UniversalValue::Decimal {
+        DbValue::None => Value::Null,
+        DbValue::Bool(b) => Value::Bool(*b),
+        DbValue::Number(Number::Int(i)) => Value::Int64(*i),
+        DbValue::Number(Number::Float(f)) => Value::Float64(*f),
+        DbValue::Number(Number::Decimal(d)) => Value::Decimal {
             value: d.to_string(),
             precision: 38,
             scale: 10,
         },
-        Value::String(s) => UniversalValue::Text(s.clone()),
-        Value::Bytes(b) => UniversalValue::Bytes(b.clone().into_inner().to_vec()),
-        Value::Uuid(u) => {
+        DbValue::String(s) => Value::Text(s.clone()),
+        DbValue::Bytes(b) => Value::Bytes(b.clone().into_inner().to_vec()),
+        DbValue::Uuid(u) => {
             let inner: uuid::Uuid = (*u).into();
-            UniversalValue::Uuid(inner)
+            Value::Uuid(inner)
         }
-        Value::Datetime(dt) => {
+        DbValue::Datetime(dt) => {
             let inner: chrono::DateTime<chrono::Utc> = (*dt).into();
-            UniversalValue::LocalDateTime(inner)
+            Value::LocalDateTime(inner)
         }
-        Value::Array(arr) => {
-            let elements: Vec<UniversalValue> =
-                arr.iter().map(surreal_value_to_generated).collect();
-            UniversalValue::Array {
+        DbValue::Array(arr) => {
+            let elements: Vec<Value> = arr.iter().map(surreal_value_to_generated).collect();
+            Value::Array {
                 elements,
-                element_type: Box::new(UniversalType::Json),
+                element_type: Box::new(Type::Json),
             }
         }
-        Value::Object(obj) => {
-            // Convert SurrealDB Object to UniversalValue::Object
+        DbValue::Object(obj) => {
+            // Convert SurrealDB Object to Value::Object
             let mut map = std::collections::HashMap::new();
             for (k, v) in obj.iter() {
                 map.insert(k.clone(), surreal_value_to_generated(v));
             }
-            UniversalValue::Object(map)
+            Value::Object(map)
         }
-        // RecordId (was Thing in v2) - convert to UniversalValue::Thing
-        Value::RecordId(record_id) => {
+        // RecordId (was Thing in v2) - convert to Value::Thing
+        DbValue::RecordId(record_id) => {
             let table = record_id.table.as_str().to_string();
             let id = match &record_id.key {
-                RecordIdKey::String(s) => UniversalValue::Text(s.clone()),
-                RecordIdKey::Number(n) => UniversalValue::Int64(*n),
+                RecordIdKey::String(s) => Value::Text(s.clone()),
+                RecordIdKey::Number(n) => Value::Int64(*n),
                 RecordIdKey::Uuid(u) => {
                     let inner: uuid::Uuid = (*u).into();
-                    UniversalValue::Uuid(inner)
+                    Value::Uuid(inner)
                 }
-                _ => UniversalValue::Text(format!("{:?}", record_id.key)),
+                _ => Value::Text(format!("{:?}", record_id.key)),
             };
-            UniversalValue::Thing {
+            Value::Thing {
                 table,
                 id: Box::new(id),
             }
         }
         // Duration - convert to string
-        Value::Duration(dur) => {
+        DbValue::Duration(dur) => {
             let std_dur: std::time::Duration = (*dur).into();
-            UniversalValue::Text(format!("PT{}S", std_dur.as_secs()))
+            Value::Text(format!("PT{}S", std_dur.as_secs()))
         }
         // Geometry - convert to object
-        Value::Geometry(geo) => {
+        DbValue::Geometry(geo) => {
             let json_val = geometry_to_serde_json(geo);
-            UniversalValue::Json(Box::new(json_val))
+            Value::Json(Box::new(json_val))
         }
         // Other types - convert to null
-        _ => UniversalValue::Null,
+        _ => Value::Null,
     }
 }
 
@@ -379,37 +374,37 @@ fn object_to_serde_json(obj: &Object) -> serde_json::Value {
     serde_json::Value::Object(map)
 }
 
-/// Convert a SurrealDB Value to serde_json::Value.
-fn surreal_value_to_json(value: &Value) -> serde_json::Value {
+/// Convert a SurrealDB DbValue to serde_json::Value.
+fn surreal_value_to_json(value: &DbValue) -> serde_json::Value {
     match value {
-        Value::None | Value::Null => serde_json::Value::Null,
-        Value::Bool(b) => serde_json::Value::Bool(*b),
-        Value::Number(n) => match n {
+        DbValue::None | DbValue::Null => serde_json::Value::Null,
+        DbValue::Bool(b) => serde_json::Value::Bool(*b),
+        DbValue::Number(n) => match n {
             Number::Int(i) => serde_json::json!(i),
             Number::Float(f) => serde_json::json!(f),
             Number::Decimal(d) => serde_json::json!(d.to_string()),
         },
-        Value::String(s) => serde_json::Value::String(s.clone()),
-        Value::Datetime(dt) => {
+        DbValue::String(s) => serde_json::Value::String(s.clone()),
+        DbValue::Datetime(dt) => {
             let inner: chrono::DateTime<chrono::Utc> = (*dt).into();
             serde_json::Value::String(inner.to_rfc3339())
         }
-        Value::Uuid(u) => {
+        DbValue::Uuid(u) => {
             let inner: uuid::Uuid = (*u).into();
             serde_json::Value::String(inner.to_string())
         }
-        Value::Array(arr) => {
+        DbValue::Array(arr) => {
             let values: Vec<serde_json::Value> = arr.iter().map(surreal_value_to_json).collect();
             serde_json::Value::Array(values)
         }
-        Value::Object(obj) => object_to_serde_json(obj),
-        Value::Geometry(geo) => geometry_to_serde_json(geo),
+        DbValue::Object(obj) => object_to_serde_json(obj),
+        DbValue::Geometry(geo) => geometry_to_serde_json(geo),
         _ => serde_json::Value::Null,
     }
 }
 
 /// Extract a typed value from a SurrealDB Object field.
-pub fn extract_field(obj: &Object, field: &str, sync_type: &UniversalType) -> TypedValue {
+pub fn extract_field(obj: &Object, field: &str, sync_type: &Type) -> TypedValue {
     match obj.get(field) {
         Some(value) => {
             SurrealValueWithSchema::new(value.clone(), sync_type.clone()).to_typed_value()
@@ -421,7 +416,7 @@ pub fn extract_field(obj: &Object, field: &str, sync_type: &UniversalType) -> Ty
 /// Convert a complete SurrealDB Object to a map of TypedValues using schema.
 pub fn object_to_typed_values(
     obj: &Object,
-    schema: &[(String, UniversalType)],
+    schema: &[(String, Type)],
 ) -> HashMap<String, TypedValue> {
     let mut result = HashMap::new();
     for (field_name, sync_type) in schema {
@@ -440,43 +435,38 @@ mod tests {
 
     #[test]
     fn test_null_conversion() {
-        let sv = SurrealValueWithSchema::new(Value::None, UniversalType::Text);
+        let sv = SurrealValueWithSchema::new(DbValue::None, Type::Text);
         let tv = TypedValue::from(sv);
-        assert!(matches!(tv.value, UniversalValue::Null));
+        assert!(matches!(tv.value, Value::Null));
     }
 
     #[test]
     fn test_bool_conversion() {
-        let sv = SurrealValueWithSchema::new(Value::Bool(true), UniversalType::Bool);
+        let sv = SurrealValueWithSchema::new(DbValue::Bool(true), Type::Bool);
         let tv = TypedValue::from(sv);
-        assert!(matches!(tv.value, UniversalValue::Bool(true)));
+        assert!(matches!(tv.value, Value::Bool(true)));
     }
 
     #[test]
     fn test_int_conversion() {
-        let sv = SurrealValueWithSchema::new(Value::Number(Number::Int(42)), UniversalType::Int32);
+        let sv = SurrealValueWithSchema::new(DbValue::Number(Number::Int(42)), Type::Int32);
         let tv = TypedValue::from(sv);
-        assert!(matches!(tv.value, UniversalValue::Int32(42)));
+        assert!(matches!(tv.value, Value::Int32(42)));
     }
 
     #[test]
     fn test_bigint_conversion() {
-        let sv = SurrealValueWithSchema::new(
-            Value::Number(Number::Int(9876543210)),
-            UniversalType::Int64,
-        );
+        let sv = SurrealValueWithSchema::new(DbValue::Number(Number::Int(9876543210)), Type::Int64);
         let tv = TypedValue::from(sv);
-        assert!(matches!(tv.value, UniversalValue::Int64(9876543210)));
+        assert!(matches!(tv.value, Value::Int64(9876543210)));
     }
 
     #[test]
     fn test_float_conversion() {
-        let sv = SurrealValueWithSchema::new(
-            Value::Number(Number::Float(1.23456)),
-            UniversalType::Float64,
-        );
+        let sv =
+            SurrealValueWithSchema::new(DbValue::Number(Number::Float(1.23456)), Type::Float64);
         let tv = TypedValue::from(sv);
-        if let UniversalValue::Float64(f) = tv.value {
+        if let Value::Float64(f) = tv.value {
             assert!((f - 1.23456).abs() < 0.00001);
         } else {
             panic!("Expected Float64");
@@ -487,14 +477,14 @@ mod tests {
     fn test_decimal_conversion() {
         let dec = rust_decimal::Decimal::from_str_exact("123.456").unwrap();
         let sv = SurrealValueWithSchema::new(
-            Value::Number(Number::Decimal(dec)),
-            UniversalType::Decimal {
+            DbValue::Number(Number::Decimal(dec)),
+            Type::Decimal {
                 precision: 10,
                 scale: 3,
             },
         );
         let tv = TypedValue::from(sv);
-        if let UniversalValue::Decimal {
+        if let Value::Decimal {
             value,
             precision,
             scale,
@@ -510,45 +500,40 @@ mod tests {
 
     #[test]
     fn test_string_conversion() {
-        let sv = SurrealValueWithSchema::new(
-            Value::String("hello world".to_string()),
-            UniversalType::Text,
-        );
+        let sv =
+            SurrealValueWithSchema::new(DbValue::String("hello world".to_string()), Type::Text);
         let tv = TypedValue::from(sv);
-        assert!(matches!(tv.value, UniversalValue::Text(ref s) if s == "hello world"));
+        assert!(matches!(tv.value, Value::Text(ref s) if s == "hello world"));
     }
 
     #[test]
     fn test_varchar_conversion() {
         let sv = SurrealValueWithSchema::new(
-            Value::String("test".to_string()),
-            UniversalType::VarChar { length: 100 },
+            DbValue::String("test".to_string()),
+            Type::VarChar { length: 100 },
         );
         let tv = TypedValue::from(sv);
-        assert!(matches!(
-            tv.sync_type,
-            UniversalType::VarChar { length: 100 }
-        ));
-        assert!(matches!(tv.value, UniversalValue::Text(ref s) if s == "test"));
+        assert!(matches!(tv.sync_type, Type::VarChar { length: 100 }));
+        assert!(matches!(tv.value, Value::Text(ref s) if s == "test"));
     }
 
     #[test]
     fn test_bytes_conversion() {
         let bytes = surrealdb::types::Bytes::from(vec![0x01, 0x02, 0x03]);
-        let sv = SurrealValueWithSchema::new(Value::Bytes(bytes), UniversalType::Bytes);
+        let sv = SurrealValueWithSchema::new(DbValue::Bytes(bytes), Type::Bytes);
         let tv = TypedValue::from(sv);
-        assert!(matches!(tv.value, UniversalValue::Bytes(ref b) if *b == vec![0x01, 0x02, 0x03]));
+        assert!(matches!(tv.value, Value::Bytes(ref b) if *b == vec![0x01, 0x02, 0x03]));
     }
 
     #[test]
     fn test_uuid_conversion() {
         let uuid = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
         let sv = SurrealValueWithSchema::new(
-            Value::Uuid(surrealdb::types::Uuid::from(uuid)),
-            UniversalType::Uuid,
+            DbValue::Uuid(surrealdb::types::Uuid::from(uuid)),
+            Type::Uuid,
         );
         let tv = TypedValue::from(sv);
-        if let UniversalValue::Uuid(u) = tv.value {
+        if let Value::Uuid(u) = tv.value {
             assert_eq!(u, uuid);
         } else {
             panic!("Expected Uuid");
@@ -558,11 +543,11 @@ mod tests {
     #[test]
     fn test_uuid_from_string() {
         let sv = SurrealValueWithSchema::new(
-            Value::String("550e8400-e29b-41d4-a716-446655440000".to_string()),
-            UniversalType::Uuid,
+            DbValue::String("550e8400-e29b-41d4-a716-446655440000".to_string()),
+            Type::Uuid,
         );
         let tv = TypedValue::from(sv);
-        if let UniversalValue::Uuid(u) = tv.value {
+        if let Value::Uuid(u) = tv.value {
             assert_eq!(u.to_string(), "550e8400-e29b-41d4-a716-446655440000");
         } else {
             panic!("Expected Uuid");
@@ -572,12 +557,10 @@ mod tests {
     #[test]
     fn test_datetime_conversion() {
         let dt = Utc.with_ymd_and_hms(2024, 6, 15, 10, 30, 0).unwrap();
-        let sv = SurrealValueWithSchema::new(
-            Value::Datetime(Datetime::from(dt)),
-            UniversalType::LocalDateTime,
-        );
+        let sv =
+            SurrealValueWithSchema::new(DbValue::Datetime(Datetime::from(dt)), Type::LocalDateTime);
         let tv = TypedValue::from(sv);
-        if let UniversalValue::LocalDateTime(result_dt) = tv.value {
+        if let Value::LocalDateTime(result_dt) = tv.value {
             assert_eq!(result_dt.year(), 2024);
             assert_eq!(result_dt.month(), 6);
             assert_eq!(result_dt.day(), 15);
@@ -588,12 +571,9 @@ mod tests {
 
     #[test]
     fn test_date_from_string() {
-        let sv = SurrealValueWithSchema::new(
-            Value::String("2024-06-15".to_string()),
-            UniversalType::Date,
-        );
+        let sv = SurrealValueWithSchema::new(DbValue::String("2024-06-15".to_string()), Type::Date);
         let tv = TypedValue::from(sv);
-        if let UniversalValue::LocalDateTime(dt) = tv.value {
+        if let Value::LocalDateTime(dt) = tv.value {
             assert_eq!(dt.format("%Y-%m-%d").to_string(), "2024-06-15");
         } else {
             panic!("Expected DateTime");
@@ -602,10 +582,9 @@ mod tests {
 
     #[test]
     fn test_time_from_string() {
-        let sv =
-            SurrealValueWithSchema::new(Value::String("14:30:45".to_string()), UniversalType::Time);
+        let sv = SurrealValueWithSchema::new(DbValue::String("14:30:45".to_string()), Type::Time);
         let tv = TypedValue::from(sv);
-        if let UniversalValue::LocalDateTime(dt) = tv.value {
+        if let Value::LocalDateTime(dt) = tv.value {
             assert_eq!(dt.format("%H:%M:%S").to_string(), "14:30:45");
         } else {
             panic!("Expected DateTime");
@@ -615,13 +594,13 @@ mod tests {
     #[test]
     fn test_object_to_json() {
         let mut obj_map = BTreeMap::new();
-        obj_map.insert("name".to_string(), Value::String("test".to_string()));
-        obj_map.insert("count".to_string(), Value::Number(Number::Int(42)));
+        obj_map.insert("name".to_string(), DbValue::String("test".to_string()));
+        obj_map.insert("count".to_string(), DbValue::Number(Number::Int(42)));
         let obj = Object::from(obj_map);
 
-        let sv = SurrealValueWithSchema::new(Value::Object(obj), UniversalType::Json);
+        let sv = SurrealValueWithSchema::new(DbValue::Object(obj), Type::Json);
         let tv = TypedValue::from(sv);
-        if let UniversalValue::Json(json_val) = tv.value {
+        if let Value::Json(json_val) = tv.value {
             if let serde_json::Value::Object(map) = json_val.as_ref() {
                 assert!(
                     matches!(map.get("name"), Some(serde_json::Value::String(s)) if s == "test")
@@ -640,21 +619,21 @@ mod tests {
     #[test]
     fn test_array_int_conversion() {
         let arr = Array::from(vec![
-            Value::Number(Number::Int(1)),
-            Value::Number(Number::Int(2)),
-            Value::Number(Number::Int(3)),
+            DbValue::Number(Number::Int(1)),
+            DbValue::Number(Number::Int(2)),
+            DbValue::Number(Number::Int(3)),
         ]);
         let sv = SurrealValueWithSchema::new(
-            Value::Array(arr),
-            UniversalType::Array {
-                element_type: Box::new(UniversalType::Int32),
+            DbValue::Array(arr),
+            Type::Array {
+                element_type: Box::new(Type::Int32),
             },
         );
         let tv = TypedValue::from(sv);
-        if let UniversalValue::Array { elements, .. } = tv.value {
+        if let Value::Array { elements, .. } = tv.value {
             assert_eq!(elements.len(), 3);
             // Values are converted as Int32
-            assert!(matches!(elements[0], UniversalValue::Int32(1)));
+            assert!(matches!(elements[0], Value::Int32(1)));
         } else {
             panic!("Expected Array");
         }
@@ -663,17 +642,17 @@ mod tests {
     #[test]
     fn test_set_conversion() {
         let arr = Array::from(vec![
-            Value::String("a".to_string()),
-            Value::String("b".to_string()),
+            DbValue::String("a".to_string()),
+            DbValue::String("b".to_string()),
         ]);
         let sv = SurrealValueWithSchema::new(
-            Value::Array(arr),
-            UniversalType::Set {
+            DbValue::Array(arr),
+            Type::Set {
                 values: vec!["a".to_string(), "b".to_string(), "c".to_string()],
             },
         );
         let tv = TypedValue::from(sv);
-        if let UniversalValue::Array { elements, .. } = tv.value {
+        if let Value::Array { elements, .. } = tv.value {
             assert_eq!(elements.len(), 2);
         } else {
             panic!("Expected Array");
@@ -683,56 +662,56 @@ mod tests {
     #[test]
     fn test_enum_conversion() {
         let sv = SurrealValueWithSchema::new(
-            Value::String("active".to_string()),
-            UniversalType::Enum {
+            DbValue::String("active".to_string()),
+            Type::Enum {
                 values: vec!["active".to_string(), "inactive".to_string()],
             },
         );
         let tv = TypedValue::from(sv);
-        assert!(matches!(tv.value, UniversalValue::Text(ref s) if s == "active"));
+        assert!(matches!(tv.value, Value::Text(ref s) if s == "active"));
     }
 
     #[test]
     fn test_extract_field() {
         let mut obj_map = BTreeMap::new();
-        obj_map.insert("name".to_string(), Value::String("Alice".to_string()));
-        obj_map.insert("age".to_string(), Value::Number(Number::Int(30)));
+        obj_map.insert("name".to_string(), DbValue::String("Alice".to_string()));
+        obj_map.insert("age".to_string(), DbValue::Number(Number::Int(30)));
         let obj = Object::from(obj_map);
 
-        let name = extract_field(&obj, "name", &UniversalType::Text);
-        assert!(matches!(name.value, UniversalValue::Text(ref s) if s == "Alice"));
+        let name = extract_field(&obj, "name", &Type::Text);
+        assert!(matches!(name.value, Value::Text(ref s) if s == "Alice"));
 
-        let age = extract_field(&obj, "age", &UniversalType::Int32);
-        assert!(matches!(age.value, UniversalValue::Int32(30)));
+        let age = extract_field(&obj, "age", &Type::Int32);
+        assert!(matches!(age.value, Value::Int32(30)));
 
-        let missing = extract_field(&obj, "missing", &UniversalType::Text);
-        assert!(matches!(missing.value, UniversalValue::Null));
+        let missing = extract_field(&obj, "missing", &Type::Text);
+        assert!(matches!(missing.value, Value::Null));
     }
 
     #[test]
     fn test_object_to_typed_values() {
         let mut obj_map = BTreeMap::new();
-        obj_map.insert("name".to_string(), Value::String("Bob".to_string()));
-        obj_map.insert("active".to_string(), Value::Bool(true));
-        obj_map.insert("score".to_string(), Value::Number(Number::Float(95.5)));
+        obj_map.insert("name".to_string(), DbValue::String("Bob".to_string()));
+        obj_map.insert("active".to_string(), DbValue::Bool(true));
+        obj_map.insert("score".to_string(), DbValue::Number(Number::Float(95.5)));
         let obj = Object::from(obj_map);
 
         let schema = vec![
-            ("name".to_string(), UniversalType::Text),
-            ("active".to_string(), UniversalType::Bool),
-            ("score".to_string(), UniversalType::Float64),
+            ("name".to_string(), Type::Text),
+            ("active".to_string(), Type::Bool),
+            ("score".to_string(), Type::Float64),
         ];
 
         let values = object_to_typed_values(&obj, &schema);
         assert!(matches!(
             values.get("name").unwrap().value,
-            UniversalValue::Text(ref s) if s == "Bob"
+            Value::Text(ref s) if s == "Bob"
         ));
         assert!(matches!(
             values.get("active").unwrap().value,
-            UniversalValue::Bool(true)
+            Value::Bool(true)
         ));
-        if let UniversalValue::Float64(f) = values.get("score").unwrap().value {
+        if let Value::Float64(f) = values.get("score").unwrap().value {
             assert!((f - 95.5).abs() < 0.001);
         } else {
             panic!("Expected Float64");

--- a/crates/surreal3-types/src/schema.rs
+++ b/crates/surreal3-types/src/schema.rs
@@ -5,11 +5,11 @@
 //!
 //! ## Type System
 //!
-//! This module uses `UniversalType` from sync-core directly for schema representation,
+//! This module uses `Type` from sync-core directly for schema representation,
 //! along with `TableDefinition` and `DatabaseSchema` for schema structures.
 
 use surrealdb::types::{Number, RecordIdKey, Value};
-use sync_core::{DatabaseSchema, TableDefinition, UniversalType};
+use sync_core::{DatabaseSchema, TableDefinition, Type};
 
 /// Convert JSON value to surrealdb::types::Value using schema information for type precision.
 ///
@@ -35,16 +35,16 @@ pub fn json_to_surreal_with_table_schema(
     json_to_surreal_with_universal_type(value, column_type)
 }
 
-/// Convert JSON value to surrealdb::types::Value using UniversalType for type precision.
+/// Convert JSON value to surrealdb::types::Value using Type for type precision.
 ///
 /// This is the core conversion function that handles all type-specific conversions.
 pub fn json_to_surreal_with_universal_type(
     value: serde_json::Value,
-    column_type: Option<&UniversalType>,
+    column_type: Option<&Type>,
 ) -> anyhow::Result<Value> {
     match (value, column_type) {
         // High-precision decimal conversion
-        (serde_json::Value::Number(n), Some(UniversalType::Decimal { .. })) => {
+        (serde_json::Value::Number(n), Some(Type::Decimal { .. })) => {
             let decimal_str = n.to_string();
             // Try to parse as Decimal first
             if let Ok(dec) = rust_decimal::Decimal::from_str_exact(&decimal_str) {
@@ -58,7 +58,7 @@ pub fn json_to_surreal_with_universal_type(
         }
 
         // Timestamp conversion (LocalDateTime - without timezone)
-        (serde_json::Value::String(s), Some(UniversalType::LocalDateTime)) => {
+        (serde_json::Value::String(s), Some(Type::LocalDateTime)) => {
             use chrono::NaiveDateTime;
             // Try common timestamp formats
             if let Ok(ndt) = NaiveDateTime::parse_from_str(&s, "%Y-%m-%d %H:%M:%S") {
@@ -87,7 +87,7 @@ pub fn json_to_surreal_with_universal_type(
         }
 
         // Timestamp with timezone (ZonedDateTime)
-        (serde_json::Value::String(s), Some(UniversalType::ZonedDateTime)) => {
+        (serde_json::Value::String(s), Some(Type::ZonedDateTime)) => {
             if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(&s) {
                 Ok(Value::Datetime(surrealdb::types::Datetime::from(
                     dt.with_timezone(&chrono::Utc),
@@ -98,10 +98,10 @@ pub fn json_to_surreal_with_universal_type(
         }
 
         // UUID validation and preservation
-        (serde_json::Value::String(s), Some(UniversalType::Uuid)) => Ok(Value::String(s)),
+        (serde_json::Value::String(s), Some(Type::Uuid)) => Ok(Value::String(s)),
 
         // JSON type - parse if it's a string representation
-        (serde_json::Value::String(s), Some(UniversalType::Json | UniversalType::Jsonb)) => {
+        (serde_json::Value::String(s), Some(Type::Json | Type::Jsonb)) => {
             match serde_json::from_str::<serde_json::Value>(&s) {
                 Ok(parsed_json) => Ok(json_to_surreal_without_schema(parsed_json)),
                 Err(_) => Ok(Value::String(s)),
@@ -109,7 +109,7 @@ pub fn json_to_surreal_with_universal_type(
         }
 
         // Date conversion
-        (serde_json::Value::String(s), Some(UniversalType::Date)) => {
+        (serde_json::Value::String(s), Some(Type::Date)) => {
             if let Ok(date) = chrono::NaiveDate::parse_from_str(&s, "%Y-%m-%d") {
                 let dt = date
                     .and_hms_opt(0, 0, 0)
@@ -123,10 +123,10 @@ pub fn json_to_surreal_with_universal_type(
         }
 
         // Time conversion
-        (serde_json::Value::String(s), Some(UniversalType::Time)) => Ok(Value::String(s)),
+        (serde_json::Value::String(s), Some(Type::Time)) => Ok(Value::String(s)),
 
         // Boolean conversion - handle MySQL TINYINT(1) which comes as 0/1 integers
-        (serde_json::Value::Number(n), Some(UniversalType::Bool)) => {
+        (serde_json::Value::Number(n), Some(Type::Bool)) => {
             if let Some(i) = n.as_i64() {
                 Ok(Value::Bool(i != 0))
             } else {
@@ -137,7 +137,7 @@ pub fn json_to_surreal_with_universal_type(
         }
 
         // SET column conversion - handle MySQL SET columns encoded as comma-separated strings
-        (serde_json::Value::String(s), Some(UniversalType::Set { .. })) => {
+        (serde_json::Value::String(s), Some(Type::Set { .. })) => {
             if s.is_empty() {
                 Ok(Value::Array(surrealdb::types::Array::from(
                     Vec::<Value>::new(),
@@ -150,11 +150,11 @@ pub fn json_to_surreal_with_universal_type(
         }
 
         // Handle NULL SET columns
-        (serde_json::Value::Null, Some(UniversalType::Set { .. })) => Ok(Value::Null),
+        (serde_json::Value::Null, Some(Type::Set { .. })) => Ok(Value::Null),
 
         // Array type conversion
-        (serde_json::Value::String(s), Some(UniversalType::Array { element_type }))
-            if matches!(element_type.as_ref(), UniversalType::Text) =>
+        (serde_json::Value::String(s), Some(Type::Array { element_type }))
+            if matches!(element_type.as_ref(), Type::Text) =>
         {
             if s.is_empty() {
                 Ok(Value::Array(surrealdb::types::Array::from(
@@ -168,7 +168,7 @@ pub fn json_to_surreal_with_universal_type(
         }
 
         // Handle NULL Arrays
-        (serde_json::Value::Null, Some(UniversalType::Array { .. })) => Ok(Value::Null),
+        (serde_json::Value::Null, Some(Type::Array { .. })) => Ok(Value::Null),
 
         // For all other cases, use the generic JSON conversion
         (value, _) => Ok(json_to_surreal_without_schema(value)),
@@ -204,17 +204,14 @@ pub fn convert_id_with_database_schema(
     convert_id_with_universal_type(id_str, table_name, id_type)
 }
 
-/// Convert a string ID value to the proper SurrealDB ID type using UniversalType.
+/// Convert a string ID value to the proper SurrealDB ID type using Type.
 fn convert_id_with_universal_type(
     id_str: &str,
     table_name: &str,
-    id_type: &UniversalType,
+    id_type: &Type,
 ) -> anyhow::Result<RecordIdKey> {
     match id_type {
-        UniversalType::Int8 { .. }
-        | UniversalType::Int16
-        | UniversalType::Int32
-        | UniversalType::Int64 => {
+        Type::Int8 { .. } | Type::Int16 | Type::Int32 | Type::Int64 => {
             let id_int: i64 = id_str.parse().map_err(|e| {
                 anyhow::anyhow!(
                     "Failed to parse ID '{id_str}' as integer for table '{table_name}': {e}"
@@ -222,7 +219,7 @@ fn convert_id_with_universal_type(
             })?;
             Ok(RecordIdKey::Number(id_int))
         }
-        UniversalType::Uuid => {
+        Type::Uuid => {
             let uuid = uuid::Uuid::parse_str(id_str).map_err(|e| {
                 anyhow::anyhow!(
                     "Failed to parse ID '{id_str}' as UUID for table '{table_name}': {e}"
@@ -230,7 +227,7 @@ fn convert_id_with_universal_type(
             })?;
             Ok(RecordIdKey::Uuid(surrealdb::types::Uuid::from(uuid)))
         }
-        UniversalType::Text | UniversalType::VarChar { .. } | UniversalType::Char { .. } => {
+        Type::Text | Type::VarChar { .. } | Type::Char { .. } => {
             Ok(RecordIdKey::String(id_str.to_string()))
         }
         other => {
@@ -317,10 +314,10 @@ mod tests {
     fn test_new_schema_aware_decimal_conversion() {
         let schema = TableDefinition::new(
             "products",
-            ColumnDefinition::new("id", UniversalType::Int64),
+            ColumnDefinition::new("id", Type::Int64),
             vec![ColumnDefinition::new(
                 "price",
-                UniversalType::Decimal {
+                Type::Decimal {
                     precision: 10,
                     scale: 2,
                 },
@@ -341,11 +338,8 @@ mod tests {
     fn test_new_schema_aware_timestamp_conversion() {
         let schema = TableDefinition::new(
             "events",
-            ColumnDefinition::new("id", UniversalType::Int64),
-            vec![ColumnDefinition::new(
-                "created_at",
-                UniversalType::LocalDateTime,
-            )],
+            ColumnDefinition::new("id", Type::Int64),
+            vec![ColumnDefinition::new("created_at", Type::LocalDateTime)],
         );
 
         // Test timestamp conversion
@@ -362,7 +356,7 @@ mod tests {
     fn test_new_schema_aware_fallback() {
         let schema = TableDefinition::new(
             "test",
-            ColumnDefinition::new("id", UniversalType::Int64),
+            ColumnDefinition::new("id", Type::Int64),
             vec![], // Empty columns
         );
 
@@ -381,7 +375,7 @@ mod tests {
     fn test_new_convert_id_integer() {
         let schema = DatabaseSchema::new(vec![TableDefinition::new(
             "users",
-            ColumnDefinition::new("id", UniversalType::Int64),
+            ColumnDefinition::new("id", Type::Int64),
             vec![],
         )]);
 
@@ -397,7 +391,7 @@ mod tests {
     fn test_new_convert_id_uuid() {
         let schema = DatabaseSchema::new(vec![TableDefinition::new(
             "products",
-            ColumnDefinition::new("id", UniversalType::Uuid),
+            ColumnDefinition::new("id", Type::Uuid),
             vec![],
         )]);
 
@@ -417,7 +411,7 @@ mod tests {
     fn test_new_convert_id_string() {
         let schema = DatabaseSchema::new(vec![TableDefinition::new(
             "documents",
-            ColumnDefinition::new("id", UniversalType::Text),
+            ColumnDefinition::new("id", Type::Text),
             vec![],
         )]);
 
@@ -447,10 +441,10 @@ mod tests {
     fn test_new_set_column_conversion() {
         let schema = TableDefinition::new(
             "users",
-            ColumnDefinition::new("id", UniversalType::Int64),
+            ColumnDefinition::new("id", Type::Int64),
             vec![ColumnDefinition::new(
                 "roles",
-                UniversalType::Set {
+                Type::Set {
                     values: vec!["admin".to_string(), "user".to_string()],
                 },
             )],

--- a/crates/sync-core/src/foreign_keys.rs
+++ b/crates/sync-core/src/foreign_keys.rs
@@ -124,7 +124,7 @@ fn pk_is_composed_of_fk_columns(
 mod tests {
     use super::*;
     use crate::schema::ColumnDefinition;
-    use crate::types::UniversalType;
+    use crate::types::Type;
 
     fn make_table(
         name: &str,
@@ -132,17 +132,17 @@ mod tests {
         column_names: Vec<&str>,
         fks: Vec<ForeignKeyDefinition>,
     ) -> TableDefinition {
-        let primary_key = ColumnDefinition::new(pk_names[0], UniversalType::Int64);
+        let primary_key = ColumnDefinition::new(pk_names[0], Type::Int64);
 
         let mut columns: Vec<ColumnDefinition> = column_names
             .iter()
-            .map(|n| ColumnDefinition::new(*n, UniversalType::Int64))
+            .map(|n| ColumnDefinition::new(*n, Type::Int64))
             .collect();
 
         // For composite PK, add the extra PK columns to columns list
         for pk in &pk_names[1..] {
             if !column_names.contains(pk) {
-                columns.push(ColumnDefinition::new(*pk, UniversalType::Int64));
+                columns.push(ColumnDefinition::new(*pk, Type::Int64));
             }
         }
 

--- a/crates/sync-core/src/id_columns.rs
+++ b/crates/sync-core/src/id_columns.rs
@@ -4,8 +4,8 @@
 //! - [`flatten_composite_id`] — Array IDs → Text joined with a separator (for transforms / relations)
 
 use crate::schema::{ColumnDefinition, DatabaseSchema, TableDefinition};
-use crate::types::UniversalType;
-use crate::values::UniversalValue;
+use crate::types::Type;
+use crate::values::Value;
 use std::collections::HashMap;
 use thiserror::Error;
 
@@ -76,7 +76,7 @@ pub fn parse_id_column_overrides(
 ///
 /// For each overridden table:
 /// - Sets `primary_key` to the first column (type looked up from existing columns,
-///   or [`UniversalType::Text`] if missing).
+///   or [`Type::Text`] if missing).
 /// - Moves former PK / other columns so all non-first PK columns remain in `columns`.
 /// - Sets `composite_primary_key` when `cols.len() > 1`, otherwise clears it.
 pub fn apply_id_column_overrides(
@@ -116,7 +116,7 @@ fn apply_override_to_table(
     for name in cols {
         let def = by_name
             .remove(name)
-            .unwrap_or_else(|| ColumnDefinition::new(name.clone(), UniversalType::Text));
+            .unwrap_or_else(|| ColumnDefinition::new(name.clone(), Type::Text));
         pk_defs.push(def);
     }
 
@@ -140,41 +140,41 @@ fn apply_override_to_table(
 ///
 /// Scalar IDs are returned unchanged. Used by the `flatten_id` transform and
 /// by relation-edge ID flattening.
-pub fn flatten_composite_id(id: UniversalValue, separator: &str) -> UniversalValue {
+pub fn flatten_composite_id(id: Value, separator: &str) -> Value {
     match id {
-        UniversalValue::Array { elements, .. } => {
+        Value::Array { elements, .. } => {
             let parts: Vec<String> = elements.into_iter().map(stringify_id_part).collect();
-            UniversalValue::Text(parts.join(separator))
+            Value::Text(parts.join(separator))
         }
         other => other,
     }
 }
 
 /// Stringify one composite-key part for colon/separator joining.
-pub fn stringify_id_part(v: UniversalValue) -> String {
+pub fn stringify_id_part(v: Value) -> String {
     match v {
-        UniversalValue::Int8 { value, .. } => value.to_string(),
-        UniversalValue::Int16(n) => n.to_string(),
-        UniversalValue::Int32(n) => n.to_string(),
-        UniversalValue::Int64(n) => n.to_string(),
-        UniversalValue::Text(s) => s,
-        UniversalValue::VarChar { value, .. } | UniversalValue::Char { value, .. } => value,
-        UniversalValue::Uuid(u) => u.to_string(),
-        UniversalValue::Ulid(u) => u.to_string(),
-        UniversalValue::Bool(b) => b.to_string(),
-        UniversalValue::Null => String::new(),
+        Value::Int8 { value, .. } => value.to_string(),
+        Value::Int16(n) => n.to_string(),
+        Value::Int32(n) => n.to_string(),
+        Value::Int64(n) => n.to_string(),
+        Value::Text(s) => s,
+        Value::VarChar { value, .. } | Value::Char { value, .. } => value,
+        Value::Uuid(u) => u.to_string(),
+        Value::Ulid(u) => u.to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Null => String::new(),
         other => format!("{other:?}"),
     }
 }
 
 /// Build a record ID from ordered field values (single → scalar, multi → Array).
-pub fn build_composite_record_id(parts: Vec<UniversalValue>) -> UniversalValue {
+pub fn build_composite_record_id(parts: Vec<Value>) -> Value {
     match parts.len() {
-        0 => UniversalValue::Null,
+        0 => Value::Null,
         1 => parts.into_iter().next().unwrap(),
-        _ => UniversalValue::Array {
+        _ => Value::Array {
             elements: parts,
-            element_type: Box::new(UniversalType::Text),
+            element_type: Box::new(Type::Text),
         },
     }
 }
@@ -186,10 +186,10 @@ mod tests {
     fn sample_schema() -> DatabaseSchema {
         DatabaseSchema::new(vec![TableDefinition::new(
             "ledger",
-            ColumnDefinition::new("a", UniversalType::Int32),
+            ColumnDefinition::new("a", Type::Int32),
             vec![
-                ColumnDefinition::new("b", UniversalType::Int32),
-                ColumnDefinition::new("amount", UniversalType::Int64),
+                ColumnDefinition::new("b", Type::Int32),
+                ColumnDefinition::new("amount", Type::Int64),
             ],
         )])
     }
@@ -224,20 +224,16 @@ mod tests {
 
     #[test]
     fn flatten_joins_with_separator() {
-        let id = UniversalValue::Array {
-            elements: vec![UniversalValue::Int32(4), UniversalValue::Text("x".into())],
-            element_type: Box::new(UniversalType::Text),
+        let id = Value::Array {
+            elements: vec![Value::Int32(4), Value::Text("x".into())],
+            element_type: Box::new(Type::Text),
         };
-        assert_eq!(
-            flatten_composite_id(id, ":"),
-            UniversalValue::Text("4:x".into())
-        );
+        assert_eq!(flatten_composite_id(id, ":"), Value::Text("4:x".into()));
     }
 
     #[test]
     fn build_composite_array() {
-        let id =
-            build_composite_record_id(vec![UniversalValue::Int32(1), UniversalValue::Int32(2)]);
-        assert!(matches!(id, UniversalValue::Array { elements, .. } if elements.len() == 2));
+        let id = build_composite_record_id(vec![Value::Int32(1), Value::Int32(2)]);
+        assert!(matches!(id, Value::Array { elements, .. } if elements.len() == 2));
     }
 }

--- a/crates/sync-core/src/lib.rs
+++ b/crates/sync-core/src/lib.rs
@@ -3,10 +3,10 @@
 //! This crate provides the foundational types used across the sync
 //! framework, including:
 //!
-//! - [`UniversalType`] - Universal type representation for all supported databases
-//! - [`UniversalValue`] - Raw generated values before type conversion
+//! - [`Type`] - Universal type representation for all supported databases
+//! - [`Value`] - Raw generated values before type conversion
 //! - [`TypedValue`] - Values with type information for conversion
-//! - [`UniversalRow`] - Intermediate row representation
+//! - [`Row`] - Intermediate row representation
 //! - [`Schema`] - Schema definitions loaded from YAML
 //!
 //! # Architecture
@@ -28,16 +28,16 @@
 //! # Example
 //!
 //! ```rust
-//! use sync_core::types::UniversalType;
-//! use sync_core::values::{UniversalValue, TypedValue};
+//! use sync_core::types::Type;
+//! use sync_core::values::{Value, TypedValue};
 //!
 //! // Create a typed value using factory methods
 //! let value = TypedValue::int32(42);
 //!
 //! // For dynamic types (e.g., from schema), use try_with_type for validation:
 //! let dynamic_value = TypedValue::try_with_type(
-//!     UniversalType::Int32,
-//!     UniversalValue::Int32(42)
+//!     Type::Int32,
+//!     Value::Int32(42)
 //! ).expect("valid type-value combination");
 //!
 //! // Type-specific crates implement From<TypedValue> for their native types:
@@ -74,10 +74,9 @@ pub use schema::{
 // Legacy alias for backwards compatibility
 #[deprecated(since = "1.0.0", note = "Use GeneratorSchema instead")]
 pub type LoadTestSchema = Schema;
-pub use relation_change::UniversalRelationChange;
-pub use types::{GeometryType, ToDdl, UniversalType};
+pub use relation_change::RelationChange;
+pub use types::{GeometryType, ToDdl, Type};
 pub use values::{
-    GeometryData, RowConverter, TypedValue, TypedValueError, UniversalChange, UniversalChangeOp,
-    UniversalRelation, UniversalRow, UniversalRowBuilder, UniversalThingRef, UniversalValue,
-    ZeroTemporalPolicy,
+    Change, ChangeOp, GeometryData, Relation, Row, RowBuilder, RowConverter, ThingRef, TypedValue,
+    TypedValueError, Value, ZeroTemporalPolicy,
 };

--- a/crates/sync-core/src/relation_change.rs
+++ b/crates/sync-core/src/relation_change.rs
@@ -1,9 +1,9 @@
 //! Relation change type for incremental sync of graph edges.
 //!
-//! Provides [`UniversalRelationChange`] which represents a create, update, or
+//! Provides [`RelationChange`] which represents a create, update, or
 //! delete operation on a SurrealDB relation (graph edge).
 
-use crate::values::{UniversalChangeOp, UniversalRelation};
+use crate::values::{ChangeOp, Relation};
 use serde::{Deserialize, Serialize};
 
 /// A change event for a graph relation (edge).
@@ -11,16 +11,16 @@ use serde::{Deserialize, Serialize};
 /// Used when a PostgreSQL join/relation table row is inserted, updated, or
 /// deleted and needs to be synced as a SurrealDB `RELATE` or `DELETE` operation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct UniversalRelationChange {
+pub struct RelationChange {
     /// The operation type (Create/Update/Delete)
-    pub operation: UniversalChangeOp,
+    pub operation: ChangeOp,
     /// The relation data (contains relation_type, id, input, output, data)
-    pub relation: UniversalRelation,
+    pub relation: Relation,
 }
 
-impl UniversalRelationChange {
+impl RelationChange {
     /// Create a new relation change.
-    pub fn new(operation: UniversalChangeOp, relation: UniversalRelation) -> Self {
+    pub fn new(operation: ChangeOp, relation: Relation) -> Self {
         Self {
             operation,
             relation,
@@ -28,51 +28,51 @@ impl UniversalRelationChange {
     }
 
     /// Create a CREATE relation change.
-    pub fn create(relation: UniversalRelation) -> Self {
-        Self::new(UniversalChangeOp::Create, relation)
+    pub fn create(relation: Relation) -> Self {
+        Self::new(ChangeOp::Create, relation)
     }
 
     /// Create an UPDATE relation change.
-    pub fn update(relation: UniversalRelation) -> Self {
-        Self::new(UniversalChangeOp::Update, relation)
+    pub fn update(relation: Relation) -> Self {
+        Self::new(ChangeOp::Update, relation)
     }
 
     /// Create a DELETE relation change.
-    pub fn delete(relation: UniversalRelation) -> Self {
-        Self::new(UniversalChangeOp::Delete, relation)
+    pub fn delete(relation: Relation) -> Self {
+        Self::new(ChangeOp::Delete, relation)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::values::{UniversalThingRef, UniversalValue};
+    use crate::values::{ThingRef, Value};
     use std::collections::HashMap;
 
     #[test]
     fn test_create_relation_change() {
-        let rel = UniversalRelation::new(
+        let rel = Relation::new(
             "book_tags",
-            UniversalValue::Int64(1),
-            UniversalThingRef::new("books", UniversalValue::Int64(10)),
-            UniversalThingRef::new("tags", UniversalValue::Int64(20)),
+            Value::Int64(1),
+            ThingRef::new("books", Value::Int64(10)),
+            ThingRef::new("tags", Value::Int64(20)),
             HashMap::new(),
         );
-        let change = UniversalRelationChange::create(rel);
-        assert_eq!(change.operation, UniversalChangeOp::Create);
+        let change = RelationChange::create(rel);
+        assert_eq!(change.operation, ChangeOp::Create);
         assert_eq!(change.relation.relation_type, "book_tags");
     }
 
     #[test]
     fn test_delete_relation_change() {
-        let rel = UniversalRelation::new(
+        let rel = Relation::new(
             "book_tags",
-            UniversalValue::Int64(1),
-            UniversalThingRef::new("books", UniversalValue::Int64(10)),
-            UniversalThingRef::new("tags", UniversalValue::Int64(20)),
+            Value::Int64(1),
+            ThingRef::new("books", Value::Int64(10)),
+            ThingRef::new("tags", Value::Int64(20)),
             HashMap::new(),
         );
-        let change = UniversalRelationChange::delete(rel);
-        assert_eq!(change.operation, UniversalChangeOp::Delete);
+        let change = RelationChange::delete(rel);
+        assert_eq!(change.operation, ChangeOp::Delete);
     }
 }

--- a/crates/sync-core/src/schema.rs
+++ b/crates/sync-core/src/schema.rs
@@ -21,7 +21,7 @@
 //! - Use generator types for test data generation (YAML schema files)
 
 use crate::foreign_keys::ForeignKeyDefinition;
-use crate::types::UniversalType;
+use crate::types::Type;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
@@ -70,7 +70,7 @@ pub struct ColumnDefinition {
 
     /// Column type
     #[serde(rename = "type")]
-    pub column_type: UniversalType,
+    pub column_type: Type,
 
     /// Whether this column is nullable
     #[serde(default)]
@@ -79,7 +79,7 @@ pub struct ColumnDefinition {
 
 impl ColumnDefinition {
     /// Create a new column definition.
-    pub fn new(name: impl Into<String>, column_type: UniversalType) -> Self {
+    pub fn new(name: impl Into<String>, column_type: Type) -> Self {
         Self {
             name: name.into(),
             column_type,
@@ -88,7 +88,7 @@ impl ColumnDefinition {
     }
 
     /// Create a new nullable column definition.
-    pub fn nullable(name: impl Into<String>, column_type: UniversalType) -> Self {
+    pub fn nullable(name: impl Into<String>, column_type: Type) -> Self {
         Self {
             name: name.into(),
             column_type,
@@ -147,7 +147,7 @@ impl TableDefinition {
     }
 
     /// Get the type of a column by name.
-    pub fn get_column_type(&self, name: &str) -> Option<&UniversalType> {
+    pub fn get_column_type(&self, name: &str) -> Option<&Type> {
         self.get_column(name).map(|c| &c.column_type)
     }
 
@@ -217,11 +217,7 @@ impl DatabaseSchema {
     }
 
     /// Get the type of a column in a specific table.
-    pub fn get_column_type(
-        &self,
-        table: &str,
-        column: &str,
-    ) -> Result<&UniversalType, SchemaError> {
+    pub fn get_column_type(&self, table: &str, column: &str) -> Result<&Type, SchemaError> {
         let table_schema = self
             .get_table(table)
             .ok_or_else(|| SchemaError::TableNotFound(table.to_string()))?;
@@ -364,7 +360,7 @@ pub struct GeneratorFieldDefinition {
 
     /// Field type (flattened from ColumnDefinition-like structure)
     #[serde(rename = "type")]
-    pub field_type: UniversalType,
+    pub field_type: Type,
 
     /// Generator configuration for this field
     pub generator: GeneratorConfig,
@@ -390,7 +386,7 @@ impl GeneratorFieldDefinition {
 pub struct GeneratorIDDefinition {
     /// Type of the primary key
     #[serde(rename = "type")]
-    pub id_type: UniversalType,
+    pub id_type: Type,
 
     /// Generator configuration for the primary key
     pub generator: GeneratorConfig,
@@ -428,7 +424,7 @@ impl GeneratorTableDefinition {
     }
 
     /// Get the type of a field by name.
-    pub fn get_field_type(&self, name: &str) -> Option<&UniversalType> {
+    pub fn get_field_type(&self, name: &str) -> Option<&Type> {
         self.get_field(name).map(|f| &f.field_type)
     }
 
@@ -508,7 +504,7 @@ impl GeneratorSchema {
     }
 
     /// Get the type of a field in a specific table.
-    pub fn get_field_type(&self, table: &str, field: &str) -> Result<&UniversalType, SchemaError> {
+    pub fn get_field_type(&self, table: &str, field: &str) -> Result<&Type, SchemaError> {
         let table_schema = self
             .get_table(table)
             .ok_or_else(|| SchemaError::TableNotFound(table.to_string()))?;
@@ -572,7 +568,7 @@ mod tests {
 
     #[test]
     fn test_column_definition_serde() {
-        let col = ColumnDefinition::new("email", UniversalType::VarChar { length: 255 });
+        let col = ColumnDefinition::new("email", Type::VarChar { length: 255 });
 
         let yaml = serde_yaml::to_string(&col).unwrap();
         let parsed: ColumnDefinition = serde_yaml::from_str(&yaml).unwrap();
@@ -586,23 +582,20 @@ mod tests {
     fn test_table_definition_get_column() {
         let table = TableDefinition::new(
             "users",
-            ColumnDefinition::new("id", UniversalType::Int64),
+            ColumnDefinition::new("id", Type::Int64),
             vec![
-                ColumnDefinition::new("email", UniversalType::VarChar { length: 255 }),
-                ColumnDefinition::nullable("bio", UniversalType::Text),
+                ColumnDefinition::new("email", Type::VarChar { length: 255 }),
+                ColumnDefinition::nullable("bio", Type::Text),
             ],
         );
 
         // Can find primary key
         let id_col = table.get_column("id").expect("id should exist");
-        assert_eq!(id_col.column_type, UniversalType::Int64);
+        assert_eq!(id_col.column_type, Type::Int64);
 
         // Can find regular column
         let email_col = table.get_column("email").expect("email should exist");
-        assert_eq!(
-            email_col.column_type,
-            UniversalType::VarChar { length: 255 }
-        );
+        assert_eq!(email_col.column_type, Type::VarChar { length: 255 });
 
         // Returns None for missing column
         assert!(table.get_column("nonexistent").is_none());
@@ -619,29 +612,29 @@ mod tests {
         let schema = DatabaseSchema::new(vec![
             TableDefinition::new(
                 "users",
-                ColumnDefinition::new("id", UniversalType::Uuid),
-                vec![ColumnDefinition::new("name", UniversalType::Text)],
+                ColumnDefinition::new("id", Type::Uuid),
+                vec![ColumnDefinition::new("name", Type::Text)],
             ),
             TableDefinition::new(
                 "posts",
-                ColumnDefinition::new("id", UniversalType::Int64),
-                vec![ColumnDefinition::new("title", UniversalType::Text)],
+                ColumnDefinition::new("id", Type::Int64),
+                vec![ColumnDefinition::new("title", Type::Text)],
             ),
         ]);
 
         // Can find tables
         let users = schema.get_table("users").expect("users should exist");
-        assert_eq!(users.primary_key.column_type, UniversalType::Uuid);
+        assert_eq!(users.primary_key.column_type, Type::Uuid);
 
         let posts = schema.get_table("posts").expect("posts should exist");
-        assert_eq!(posts.primary_key.column_type, UniversalType::Int64);
+        assert_eq!(posts.primary_key.column_type, Type::Int64);
 
         // Returns None for missing table
         assert!(schema.get_table("nonexistent").is_none());
 
         // Can get column type
         let col_type = schema.get_column_type("users", "name").unwrap();
-        assert_eq!(col_type, &UniversalType::Text);
+        assert_eq!(col_type, &Type::Text);
     }
 
     // ========================================================================
@@ -692,7 +685,7 @@ tables:
 
         let users = schema.get_table("users").unwrap();
         assert_eq!(users.name, "users");
-        assert_eq!(users.id.id_type, UniversalType::Uuid);
+        assert_eq!(users.id.id_type, Type::Uuid);
         assert_eq!(users.fields.len(), 3);
     }
 
@@ -701,10 +694,10 @@ tables:
         let schema = GeneratorSchema::from_yaml(SAMPLE_SCHEMA).unwrap();
 
         let email_type = schema.get_field_type("users", "email").unwrap();
-        assert_eq!(email_type, &UniversalType::VarChar { length: 255 });
+        assert_eq!(email_type, &Type::VarChar { length: 255 });
 
         let age_type = schema.get_field_type("users", "age").unwrap();
-        assert_eq!(age_type, &UniversalType::Int32);
+        assert_eq!(age_type, &Type::Int32);
     }
 
     #[test]
@@ -778,7 +771,7 @@ tables:
         // Test that GeneratorFieldDefinition serializes correctly
         let field = GeneratorFieldDefinition {
             name: "email".to_string(),
-            field_type: UniversalType::VarChar { length: 255 },
+            field_type: Type::VarChar { length: 255 },
             generator: GeneratorConfig::Pattern {
                 pattern: "user_{index}@test.com".to_string(),
             },
@@ -795,7 +788,7 @@ tables:
         // Test conversion to base ColumnDefinition
         let col = field.to_column_definition();
         assert_eq!(col.name, "email");
-        assert_eq!(col.column_type, UniversalType::VarChar { length: 255 });
+        assert_eq!(col.column_type, Type::VarChar { length: 255 });
         assert!(!col.nullable);
     }
 
@@ -809,12 +802,12 @@ tables:
 
         assert_eq!(db_schema.tables.len(), 1);
         let users = db_schema.get_table("users").expect("users should exist");
-        assert_eq!(users.primary_key.column_type, UniversalType::Uuid);
+        assert_eq!(users.primary_key.column_type, Type::Uuid);
         assert_eq!(users.columns.len(), 3);
 
         // Verify column lookup works
         let email_type = db_schema.get_column_type("users", "email").unwrap();
-        assert_eq!(email_type, &UniversalType::VarChar { length: 255 });
+        assert_eq!(email_type, &Type::VarChar { length: 255 });
     }
 
     #[test]

--- a/crates/sync-core/src/types.rs
+++ b/crates/sync-core/src/types.rs
@@ -1,6 +1,6 @@
 //! Core data types for the surreal-sync load testing framework.
 //!
-//! This module defines `UniversalType`, the universal type universe that represents
+//! This module defines `Type`, the universal type universe that represents
 //! all supported data types across different database sources and SurrealDB.
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -8,8 +8,8 @@ use std::collections::HashMap;
 
 /// Universal data type representation for surreal-sync.
 ///
-/// `UniversalType` represents the complete type universe across ALL supported data sources.
-/// Each database (including SurrealDB) defines its own mapping FROM UniversalType TO its
+/// `Type` represents the complete type universe across ALL supported data sources.
+/// Each database (including SurrealDB) defines its own mapping FROM Type TO its
 /// native type via `From`/`Into` trait implementations in the respective type crates.
 ///
 /// # Design Principles
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 /// 1. **Source-agnostic**: Represents the conceptual type, not any database's specific type
 /// 2. **Type-safe conversions**: All databases implement mapping via `From`/`Into` traits
 /// 3. **Precision preservation**: High-precision decimals exceeding SurrealDB's 128-bit are stored as strings
-/// 4. **DDL derivation**: Each database derives its DDL from UniversalType via the `ToDdl` trait
+/// 4. **DDL derivation**: Each database derives its DDL from Type via the `ToDdl` trait
 ///
 /// # YAML Format
 ///
@@ -39,7 +39,7 @@ use std::collections::HashMap;
 ///   scale: 2
 /// ```
 #[derive(Debug, Clone, PartialEq)]
-pub enum UniversalType {
+pub enum Type {
     // Boolean
     /// Boolean value
     Bool,
@@ -140,7 +140,7 @@ pub enum UniversalType {
     /// Array of a specific type
     Array {
         /// Element type
-        element_type: Box<UniversalType>,
+        element_type: Box<Type>,
     },
 
     /// MySQL SET type
@@ -199,10 +199,10 @@ pub enum GeometryType {
     GeometryCollection,
 }
 
-// Custom serialization/deserialization for UniversalType
+// Custom serialization/deserialization for Type
 // Supports both simple string format ("uuid", "int") and object format ({"type": "var_char", "length": 255})
 
-impl Serialize for UniversalType {
+impl Serialize for Type {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -288,20 +288,20 @@ impl Serialize for UniversalType {
     }
 }
 
-impl<'de> Deserialize<'de> for UniversalType {
+impl<'de> Deserialize<'de> for Type {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
         use serde::de::{Error, MapAccess, Visitor};
 
-        struct UniversalTypeVisitor;
+        struct TypeVisitor;
 
-        impl<'de> Visitor<'de> for UniversalTypeVisitor {
-            type Value = UniversalType;
+        impl<'de> Visitor<'de> for TypeVisitor {
+            type Value = Type;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-                formatter.write_str("a string or map representing a UniversalType")
+                formatter.write_str("a string or map representing a Type")
             }
 
             // Handle string format: "uuid", "int", etc.
@@ -310,28 +310,28 @@ impl<'de> Deserialize<'de> for UniversalType {
                 E: Error,
             {
                 match value {
-                    "bool" => Ok(UniversalType::Bool),
-                    "small_int" | "smallint" => Ok(UniversalType::Int16),
-                    "int" => Ok(UniversalType::Int32),
-                    "big_int" | "bigint" => Ok(UniversalType::Int64),
-                    "float" => Ok(UniversalType::Float32),
-                    "double" => Ok(UniversalType::Float64),
-                    "text" => Ok(UniversalType::Text),
-                    "blob" => Ok(UniversalType::Blob),
-                    "bytes" => Ok(UniversalType::Bytes),
-                    "date" => Ok(UniversalType::Date),
-                    "time" => Ok(UniversalType::Time),
-                    "date_time" | "datetime" => Ok(UniversalType::LocalDateTime),
-                    "date_time_nano" | "datetime_nano" => Ok(UniversalType::LocalDateTimeNano),
-                    "timestamp_tz" | "timestamptz" => Ok(UniversalType::ZonedDateTime),
-                    "time_tz" | "timetz" => Ok(UniversalType::TimeTz),
-                    "uuid" => Ok(UniversalType::Uuid),
-                    "ulid" => Ok(UniversalType::Ulid),
-                    "json" => Ok(UniversalType::Json),
-                    "jsonb" => Ok(UniversalType::Jsonb),
-                    "duration" => Ok(UniversalType::Duration),
-                    "thing" => Ok(UniversalType::Thing),
-                    "object" => Ok(UniversalType::Object),
+                    "bool" => Ok(Type::Bool),
+                    "small_int" | "smallint" => Ok(Type::Int16),
+                    "int" => Ok(Type::Int32),
+                    "big_int" | "bigint" => Ok(Type::Int64),
+                    "float" => Ok(Type::Float32),
+                    "double" => Ok(Type::Float64),
+                    "text" => Ok(Type::Text),
+                    "blob" => Ok(Type::Blob),
+                    "bytes" => Ok(Type::Bytes),
+                    "date" => Ok(Type::Date),
+                    "time" => Ok(Type::Time),
+                    "date_time" | "datetime" => Ok(Type::LocalDateTime),
+                    "date_time_nano" | "datetime_nano" => Ok(Type::LocalDateTimeNano),
+                    "timestamp_tz" | "timestamptz" => Ok(Type::ZonedDateTime),
+                    "time_tz" | "timetz" => Ok(Type::TimeTz),
+                    "uuid" => Ok(Type::Uuid),
+                    "ulid" => Ok(Type::Ulid),
+                    "json" => Ok(Type::Json),
+                    "jsonb" => Ok(Type::Jsonb),
+                    "duration" => Ok(Type::Duration),
+                    "thing" => Ok(Type::Thing),
+                    "object" => Ok(Type::Object),
                     _ => Err(E::custom(format!("unknown simple type: {value}"))),
                 }
             }
@@ -356,72 +356,71 @@ impl<'de> Deserialize<'de> for UniversalType {
 
                 match type_name.as_str() {
                     // Simple types that might appear in map format
-                    "bool" => Ok(UniversalType::Bool),
-                    "small_int" | "smallint" => Ok(UniversalType::Int16),
-                    "int" => Ok(UniversalType::Int32),
-                    "big_int" | "bigint" => Ok(UniversalType::Int64),
-                    "float" => Ok(UniversalType::Float32),
-                    "double" => Ok(UniversalType::Float64),
-                    "text" => Ok(UniversalType::Text),
-                    "blob" => Ok(UniversalType::Blob),
-                    "bytes" => Ok(UniversalType::Bytes),
-                    "date" => Ok(UniversalType::Date),
-                    "time" => Ok(UniversalType::Time),
-                    "date_time" | "datetime" => Ok(UniversalType::LocalDateTime),
-                    "date_time_nano" | "datetime_nano" => Ok(UniversalType::LocalDateTimeNano),
-                    "timestamp_tz" | "timestamptz" => Ok(UniversalType::ZonedDateTime),
-                    "time_tz" | "timetz" => Ok(UniversalType::TimeTz),
-                    "uuid" => Ok(UniversalType::Uuid),
-                    "ulid" => Ok(UniversalType::Ulid),
-                    "json" => Ok(UniversalType::Json),
-                    "jsonb" => Ok(UniversalType::Jsonb),
-                    "duration" => Ok(UniversalType::Duration),
-                    "thing" => Ok(UniversalType::Thing),
-                    "object" => Ok(UniversalType::Object),
+                    "bool" => Ok(Type::Bool),
+                    "small_int" | "smallint" => Ok(Type::Int16),
+                    "int" => Ok(Type::Int32),
+                    "big_int" | "bigint" => Ok(Type::Int64),
+                    "float" => Ok(Type::Float32),
+                    "double" => Ok(Type::Float64),
+                    "text" => Ok(Type::Text),
+                    "blob" => Ok(Type::Blob),
+                    "bytes" => Ok(Type::Bytes),
+                    "date" => Ok(Type::Date),
+                    "time" => Ok(Type::Time),
+                    "date_time" | "datetime" => Ok(Type::LocalDateTime),
+                    "date_time_nano" | "datetime_nano" => Ok(Type::LocalDateTimeNano),
+                    "timestamp_tz" | "timestamptz" => Ok(Type::ZonedDateTime),
+                    "time_tz" | "timetz" => Ok(Type::TimeTz),
+                    "uuid" => Ok(Type::Uuid),
+                    "ulid" => Ok(Type::Ulid),
+                    "json" => Ok(Type::Json),
+                    "jsonb" => Ok(Type::Jsonb),
+                    "duration" => Ok(Type::Duration),
+                    "thing" => Ok(Type::Thing),
+                    "object" => Ok(Type::Object),
 
                     // Complex types
                     "tiny_int" | "tinyint" => {
                         let width = get_field(&fields, "width").unwrap_or(1);
-                        Ok(UniversalType::Int8 { width })
+                        Ok(Type::Int8 { width })
                     }
                     "decimal" => {
                         let precision = get_field_required(&fields, "precision")?;
                         let scale = get_field_required(&fields, "scale")?;
-                        Ok(UniversalType::Decimal { precision, scale })
+                        Ok(Type::Decimal { precision, scale })
                     }
                     "char" => {
                         let length = get_field_required(&fields, "length")?;
-                        Ok(UniversalType::Char { length })
+                        Ok(Type::Char { length })
                     }
                     "var_char" | "varchar" => {
                         let length = get_field_required(&fields, "length")?;
-                        Ok(UniversalType::VarChar { length })
+                        Ok(Type::VarChar { length })
                     }
                     "array" => {
-                        let element_type: UniversalType =
-                            get_field_required(&fields, "element_type")?;
-                        Ok(UniversalType::Array {
+                        let element_type: Type = get_field_required(&fields, "element_type")?;
+                        Ok(Type::Array {
                             element_type: Box::new(element_type),
                         })
                     }
                     "set" => {
                         let values = get_field_required(&fields, "values")?;
-                        Ok(UniversalType::Set { values })
+                        Ok(Type::Set { values })
                     }
                     "enum" => {
                         let values = get_field_required(&fields, "values")?;
-                        Ok(UniversalType::Enum { values })
+                        Ok(Type::Enum { values })
                     }
                     "geometry" => {
                         let geometry_type = get_field_required(&fields, "geometry_type")?;
-                        Ok(UniversalType::Geometry { geometry_type })
+                        Ok(Type::Geometry { geometry_type })
                     }
                     _ => Err(M::Error::custom(format!("unknown type: {type_name}"))),
                 }
             }
         }
 
-        deserializer.deserialize_any(UniversalTypeVisitor)
+        deserializer.deserialize_any(TypeVisitor)
     }
 }
 
@@ -444,16 +443,16 @@ fn get_field_required<T: for<'de> Deserialize<'de>, E: serde::de::Error>(
         .map_err(|e| E::custom(format!("invalid field '{key}': {e}")))
 }
 
-/// Trait for generating DDL statements from `UniversalType`.
+/// Trait for generating DDL statements from `Type`.
 ///
 /// Each database-specific type crate implements this trait to generate
 /// appropriate DDL for creating tables with the correct column types.
 pub trait ToDdl {
-    /// Generate DDL type definition for the given `UniversalType`.
-    fn to_ddl(&self, sync_type: &UniversalType) -> String;
+    /// Generate DDL type definition for the given `Type`.
+    fn to_ddl(&self, sync_type: &Type) -> String;
 }
 
-impl UniversalType {
+impl Type {
     /// Create a new TinyInt type with the given display width.
     pub fn tiny_int(width: u8) -> Self {
         Self::Int8 { width }
@@ -475,7 +474,7 @@ impl UniversalType {
     }
 
     /// Create a new Array type with the given element type.
-    pub fn array(element_type: UniversalType) -> Self {
+    pub fn array(element_type: Type) -> Self {
         Self::Array {
             element_type: Box::new(element_type),
         }
@@ -539,52 +538,49 @@ mod tests {
 
     #[test]
     fn test_sync_data_type_constructors() {
-        assert_eq!(UniversalType::tiny_int(1), UniversalType::Int8 { width: 1 });
+        assert_eq!(Type::tiny_int(1), Type::Int8 { width: 1 });
         assert_eq!(
-            UniversalType::decimal(10, 2),
-            UniversalType::Decimal {
+            Type::decimal(10, 2),
+            Type::Decimal {
                 precision: 10,
                 scale: 2
             }
         );
-        assert_eq!(
-            UniversalType::varchar(255),
-            UniversalType::VarChar { length: 255 }
-        );
+        assert_eq!(Type::varchar(255), Type::VarChar { length: 255 });
     }
 
     #[test]
     fn test_type_categories() {
-        assert!(UniversalType::Int32.is_numeric());
-        assert!(UniversalType::decimal(10, 2).is_numeric());
-        assert!(!UniversalType::Text.is_numeric());
+        assert!(Type::Int32.is_numeric());
+        assert!(Type::decimal(10, 2).is_numeric());
+        assert!(!Type::Text.is_numeric());
 
-        assert!(UniversalType::Text.is_string());
-        assert!(UniversalType::varchar(255).is_string());
-        assert!(!UniversalType::Int32.is_string());
+        assert!(Type::Text.is_string());
+        assert!(Type::varchar(255).is_string());
+        assert!(!Type::Int32.is_string());
 
-        assert!(UniversalType::LocalDateTime.is_temporal());
-        assert!(UniversalType::Date.is_temporal());
-        assert!(!UniversalType::Int32.is_temporal());
+        assert!(Type::LocalDateTime.is_temporal());
+        assert!(Type::Date.is_temporal());
+        assert!(!Type::Int32.is_temporal());
 
-        assert!(UniversalType::Blob.is_binary());
-        assert!(UniversalType::Bytes.is_binary());
-        assert!(!UniversalType::Text.is_binary());
+        assert!(Type::Blob.is_binary());
+        assert!(Type::Bytes.is_binary());
+        assert!(!Type::Text.is_binary());
     }
 
     #[test]
     fn test_deserialize_simple_string() {
         let yaml = "uuid";
-        let parsed: UniversalType = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(parsed, UniversalType::Uuid);
+        let parsed: Type = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(parsed, Type::Uuid);
 
         let yaml = "int";
-        let parsed: UniversalType = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(parsed, UniversalType::Int32);
+        let parsed: Type = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(parsed, Type::Int32);
 
         let yaml = "text";
-        let parsed: UniversalType = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(parsed, UniversalType::Text);
+        let parsed: Type = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(parsed, Type::Text);
     }
 
     #[test]
@@ -593,18 +589,18 @@ mod tests {
 type: var_char
 length: 255
 "#;
-        let parsed: UniversalType = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(parsed, UniversalType::VarChar { length: 255 });
+        let parsed: Type = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(parsed, Type::VarChar { length: 255 });
 
         let yaml = r#"
 type: decimal
 precision: 10
 scale: 2
 "#;
-        let parsed: UniversalType = serde_yaml::from_str(yaml).unwrap();
+        let parsed: Type = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(
             parsed,
-            UniversalType::Decimal {
+            Type::Decimal {
                 precision: 10,
                 scale: 2
             }
@@ -614,25 +610,25 @@ scale: 2
 type: tiny_int
 width: 1
 "#;
-        let parsed: UniversalType = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(parsed, UniversalType::Int8 { width: 1 });
+        let parsed: Type = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(parsed, Type::Int8 { width: 1 });
     }
 
     #[test]
     fn test_serialize_deserialize_roundtrip() {
         let types = vec![
-            UniversalType::Bool,
-            UniversalType::tiny_int(1),
-            UniversalType::Int32,
-            UniversalType::decimal(10, 2),
-            UniversalType::varchar(255),
-            UniversalType::array(UniversalType::Int32),
-            UniversalType::enumeration(vec!["a".to_string(), "b".to_string()]),
+            Type::Bool,
+            Type::tiny_int(1),
+            Type::Int32,
+            Type::decimal(10, 2),
+            Type::varchar(255),
+            Type::array(Type::Int32),
+            Type::enumeration(vec!["a".to_string(), "b".to_string()]),
         ];
 
         for ty in types {
             let yaml = serde_yaml::to_string(&ty).unwrap();
-            let parsed: UniversalType = serde_yaml::from_str(&yaml).unwrap();
+            let parsed: Type = serde_yaml::from_str(&yaml).unwrap();
             assert_eq!(ty, parsed);
         }
     }

--- a/crates/sync-core/src/values.rs
+++ b/crates/sync-core/src/values.rs
@@ -4,7 +4,7 @@
 //! and type conversion between different database systems.
 
 use crate::schema::Schema;
-use crate::types::UniversalType;
+use crate::types::Type;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -17,34 +17,34 @@ use uuid::Uuid;
     "Type-value mismatch: expected {expected_value} for type {sync_type:?}, got {actual_value}"
 )]
 pub struct TypedValueError {
-    /// The UniversalType that was specified
-    pub sync_type: UniversalType,
+    /// The Type that was specified
+    pub sync_type: Type,
     /// Description of the expected value kind
     pub expected_value: String,
     /// Description of the actual value kind
     pub actual_value: String,
 }
 
-/// Universal value representation with 1:1 correspondence to `UniversalType`.
+/// Universal value representation with 1:1 correspondence to `Type`.
 ///
-/// Each variant of `UniversalValue` corresponds exactly to one variant of `UniversalType`,
+/// Each variant of `Value` corresponds exactly to one variant of `Type`,
 /// enabling deterministic conversion via `to_typed_value()` without inference or fallback.
 ///
 /// # Design Principles
 ///
-/// 1. **Exact correspondence**: Every `UniversalType` variant has exactly one matching `UniversalValue` variant
+/// 1. **Exact correspondence**: Every `Type` variant has exactly one matching `Value` variant
 /// 2. **No inference**: `to_typed_value()` is deterministic - no guessing or fallback
 /// 3. **Type metadata included**: Variants like `Char`, `VarChar`, `Decimal` include their type parameters
 /// 4. **Self-describing**: Each value knows its exact type without external context
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "value")]
-pub enum UniversalValue {
+pub enum Value {
     // === Boolean ===
-    /// Boolean value → `UniversalType::Bool`
+    /// Boolean value → `Type::Bool`
     Bool(bool),
 
     // === Integer types ===
-    /// Tiny integer with display width → `UniversalType::Int8 { width }`
+    /// Tiny integer with display width → `Type::Int8 { width }`
     Int8 {
         /// The integer value
         value: i8,
@@ -52,24 +52,24 @@ pub enum UniversalValue {
         width: u8,
     },
 
-    /// 16-bit signed integer → `UniversalType::Int16`
+    /// 16-bit signed integer → `Type::Int16`
     Int16(i16),
 
-    /// 32-bit signed integer → `UniversalType::Int32`
+    /// 32-bit signed integer → `Type::Int32`
     Int32(i32),
 
-    /// 64-bit signed integer → `UniversalType::Int64`
+    /// 64-bit signed integer → `Type::Int64`
     Int64(i64),
 
     // === Floating point types ===
-    /// 32-bit IEEE 754 floating point → `UniversalType::Float32`
+    /// 32-bit IEEE 754 floating point → `Type::Float32`
     Float32(f32),
 
-    /// 64-bit IEEE 754 floating point → `UniversalType::Float64`
+    /// 64-bit IEEE 754 floating point → `Type::Float64`
     Float64(f64),
 
     // === Exact numeric ===
-    /// Decimal value with precision/scale → `UniversalType::Decimal { precision, scale }`
+    /// Decimal value with precision/scale → `Type::Decimal { precision, scale }`
     Decimal {
         /// String representation of the decimal value
         value: String,
@@ -80,7 +80,7 @@ pub enum UniversalValue {
     },
 
     // === String types ===
-    /// Fixed-length character string → `UniversalType::Char { length }`
+    /// Fixed-length character string → `Type::Char { length }`
     Char {
         /// The string value
         value: String,
@@ -88,7 +88,7 @@ pub enum UniversalValue {
         length: u16,
     },
 
-    /// Variable-length character string → `UniversalType::VarChar { length }`
+    /// Variable-length character string → `Type::VarChar { length }`
     VarChar {
         /// The string value
         value: String,
@@ -96,34 +96,34 @@ pub enum UniversalValue {
         length: u16,
     },
 
-    /// Unlimited text → `UniversalType::Text`
+    /// Unlimited text → `Type::Text`
     Text(String),
 
     // === Binary types ===
-    /// Binary large object → `UniversalType::Blob`
+    /// Binary large object → `Type::Blob`
     Blob(Vec<u8>),
 
-    /// Binary data → `UniversalType::Bytes`
+    /// Binary data → `Type::Bytes`
     Bytes(Vec<u8>),
 
     // === Temporal types ===
-    /// Date only (YYYY-MM-DD) → `UniversalType::Date`
+    /// Date only (YYYY-MM-DD) → `Type::Date`
     Date(DateTime<Utc>),
 
-    /// Time only (HH:MM:SS) → `UniversalType::Time`
+    /// Time only (HH:MM:SS) → `Type::Time`
     Time(DateTime<Utc>),
 
-    /// Timestamp without timezone (microsecond precision) → `UniversalType::LocalDateTime`
+    /// Timestamp without timezone (microsecond precision) → `Type::LocalDateTime`
     LocalDateTime(DateTime<Utc>),
 
-    /// Timestamp with nanosecond precision → `UniversalType::LocalDateTimeNano`
+    /// Timestamp with nanosecond precision → `Type::LocalDateTimeNano`
     LocalDateTimeNano(DateTime<Utc>),
 
-    /// Timestamp with timezone → `UniversalType::ZonedDateTime`
+    /// Timestamp with timezone → `Type::ZonedDateTime`
     ZonedDateTime(DateTime<Utc>),
 
     /// Time with timezone (stored as string to preserve original format)
-    /// → `UniversalType::TimeTz`
+    /// → `Type::TimeTz`
     ///
     /// Note: We intentionally use String instead of DateTime because time and datetime
     /// are fundamentally different types. DateTime implies a specific point in time,
@@ -132,28 +132,28 @@ pub enum UniversalValue {
     TimeTz(String),
 
     // === Special types ===
-    /// UUID (128-bit) → `UniversalType::Uuid`
+    /// UUID (128-bit) → `Type::Uuid`
     Uuid(Uuid),
 
-    /// ULID (128-bit sortable identifier) → `UniversalType::Ulid`
+    /// ULID (128-bit sortable identifier) → `Type::Ulid`
     Ulid(ulid::Ulid),
 
-    /// JSON document → `UniversalType::Json`
+    /// JSON document → `Type::Json`
     Json(Box<serde_json::Value>),
 
-    /// Binary JSON (PostgreSQL JSONB) → `UniversalType::Jsonb`
+    /// Binary JSON (PostgreSQL JSONB) → `Type::Jsonb`
     Jsonb(Box<serde_json::Value>),
 
     // === Collection types ===
-    /// Array of a specific type → `UniversalType::Array { element_type }`
+    /// Array of a specific type → `Type::Array { element_type }`
     Array {
         /// The array elements
-        elements: Vec<UniversalValue>,
+        elements: Vec<Value>,
         /// Element type
-        element_type: Box<UniversalType>,
+        element_type: Box<Type>,
     },
 
-    /// MySQL SET type → `UniversalType::Set { values }`
+    /// MySQL SET type → `Type::Set { values }`
     Set {
         /// Selected values from the set
         elements: Vec<String>,
@@ -162,7 +162,7 @@ pub enum UniversalValue {
     },
 
     // === Enumeration ===
-    /// Enumeration type → `UniversalType::Enum { values }`
+    /// Enumeration type → `Type::Enum { values }`
     Enum {
         /// The selected enum value
         value: String,
@@ -171,7 +171,7 @@ pub enum UniversalValue {
     },
 
     // === Spatial ===
-    /// Spatial/geometry type → `UniversalType::Geometry { geometry_type }`
+    /// Spatial/geometry type → `Type::Geometry { geometry_type }`
     Geometry {
         /// Geometry data (WKB bytes or GeoJSON object)
         data: GeometryData,
@@ -179,23 +179,23 @@ pub enum UniversalValue {
         geometry_type: crate::types::GeometryType,
     },
 
-    /// Duration type → `UniversalType::Duration`
+    /// Duration type → `Type::Duration`
     Duration(std::time::Duration),
 
-    /// Record reference/link (e.g., SurrealDB Thing) → `UniversalType::Thing`
+    /// Record reference/link (e.g., SurrealDB Thing) → `Type::Thing`
     Thing {
         /// The target table/collection name
         table: String,
         /// The record ID (can be string, int, uuid, etc.)
-        id: Box<UniversalValue>,
+        id: Box<Value>,
     },
 
     /// Nested object/document (e.g., MongoDB embedded documents, SurrealDB objects)
-    /// → `UniversalType::Object`
+    /// → `Type::Object`
     ///
     /// This differs from Json/Jsonb which are serialized JSON storage types.
     /// Object represents a structured nested document with typed fields.
-    Object(HashMap<String, UniversalValue>),
+    Object(HashMap<String, Value>),
 
     /// Null value (can be any nullable type)
     Null,
@@ -203,18 +203,18 @@ pub enum UniversalValue {
     /// Source emitted a temporal that is not a valid calendar/chrono value
     /// (e.g. MySQL/MariaDB zero date `0000-00-00`).
     ///
-    /// Distinct from [`UniversalValue::Null`]: SQL NULL stays `Null`; MySQL-style
+    /// Distinct from [`Value::Null`]: SQL NULL stays `Null`; MySQL-style
     /// zero dates/timestamps use this sentinel so transforms retain the intended
     /// column type before the SurrealDB sink maps it.
     ZeroTemporal {
         /// Intended column type (`Date`, `Time`, `LocalDateTime`, `ZonedDateTime`, …)
-        intended_type: UniversalType,
+        intended_type: Type,
         /// Optional source literal for transforms/debugging, e.g. `"0000-00-00 00:00:00"`
         source: Option<String>,
     },
 }
 
-/// How the SurrealDB sink represents [`UniversalValue::ZeroTemporal`].
+/// How the SurrealDB sink represents [`Value::ZeroTemporal`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ZeroTemporalPolicy {
@@ -234,7 +234,7 @@ pub enum ZeroTemporalPolicy {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GeometryData(pub serde_json::Value);
 
-impl UniversalValue {
+impl Value {
     // === Factory methods ===
 
     /// Create a TinyInt value.
@@ -268,7 +268,7 @@ impl UniversalValue {
     }
 
     /// Create an Array value.
-    pub fn array(elements: Vec<UniversalValue>, element_type: UniversalType) -> Self {
+    pub fn array(elements: Vec<Value>, element_type: Type) -> Self {
         Self::Array {
             elements,
             element_type: Box::new(element_type),
@@ -313,7 +313,7 @@ impl UniversalValue {
     }
 
     /// Create a zero-temporal sentinel with the intended column type.
-    pub fn zero_temporal(intended_type: UniversalType, source: Option<String>) -> Self {
+    pub fn zero_temporal(intended_type: Type, source: Option<String>) -> Self {
         Self::ZeroTemporal {
             intended_type,
             source,
@@ -321,13 +321,13 @@ impl UniversalValue {
     }
 
     /// Canonical MySQL-style zero literal for an intended temporal type.
-    pub fn canonical_zero_literal(intended_type: &UniversalType) -> &'static str {
+    pub fn canonical_zero_literal(intended_type: &Type) -> &'static str {
         match intended_type {
-            UniversalType::Date => "0000-00-00",
-            UniversalType::Time | UniversalType::TimeTz => "00:00:00",
-            UniversalType::LocalDateTime
-            | UniversalType::LocalDateTimeNano
-            | UniversalType::ZonedDateTime => "0000-00-00 00:00:00",
+            Type::Date => "0000-00-00",
+            Type::Time | Type::TimeTz => "00:00:00",
+            Type::LocalDateTime | Type::LocalDateTimeNano | Type::ZonedDateTime => {
+                "0000-00-00 00:00:00"
+            }
             _ => "0000-00-00 00:00:00",
         }
     }
@@ -348,16 +348,16 @@ impl UniversalValue {
         year == 0 && month == 0 && day == 0
     }
 
-    /// Whether `intended_type` may be used with [`UniversalValue::ZeroTemporal`].
-    pub fn is_zero_temporal_type(intended_type: &UniversalType) -> bool {
+    /// Whether `intended_type` may be used with [`Value::ZeroTemporal`].
+    pub fn is_zero_temporal_type(intended_type: &Type) -> bool {
         matches!(
             intended_type,
-            UniversalType::Date
-                | UniversalType::Time
-                | UniversalType::LocalDateTime
-                | UniversalType::LocalDateTimeNano
-                | UniversalType::ZonedDateTime
-                | UniversalType::TimeTz
+            Type::Date
+                | Type::Time
+                | Type::LocalDateTime
+                | Type::LocalDateTimeNano
+                | Type::ZonedDateTime
+                | Type::TimeTz
         )
     }
 
@@ -462,7 +462,7 @@ impl UniversalValue {
     }
 
     /// Try to get this value as an array of elements.
-    pub fn as_array(&self) -> Option<&Vec<UniversalValue>> {
+    pub fn as_array(&self) -> Option<&Vec<Value>> {
         match self {
             Self::Array { elements, .. } => Some(elements),
             _ => None,
@@ -509,21 +509,21 @@ impl UniversalValue {
 
     /// Convert this value to a TypedValue deterministically.
     ///
-    /// Each `UniversalValue` variant maps to exactly one `UniversalType` variant,
+    /// Each `Value` variant maps to exactly one `Type` variant,
     /// so there is no inference or fallback - the mapping is deterministic.
     ///
     /// # Example
     ///
     /// ```rust
-    /// use sync_core::{UniversalValue, UniversalType};
+    /// use sync_core::{Value, Type};
     ///
-    /// let value = UniversalValue::Int32(42);
+    /// let value = Value::Int32(42);
     /// let typed = value.to_typed_value();
-    /// assert!(matches!(typed.sync_type, UniversalType::Int32));
+    /// assert!(matches!(typed.sync_type, Type::Int32));
     ///
-    /// let value = UniversalValue::Text("hello".to_string());
+    /// let value = Value::Text("hello".to_string());
     /// let typed = value.to_typed_value();
-    /// assert!(matches!(typed.sync_type, UniversalType::Text));
+    /// assert!(matches!(typed.sync_type, Type::Text));
     /// ```
     pub fn to_typed_value(self) -> TypedValue {
         let sync_type = self.to_type();
@@ -531,79 +531,79 @@ impl UniversalValue {
         TypedValue::new(sync_type, self)
     }
 
-    /// Get the corresponding UniversalType for this value.
+    /// Get the corresponding Type for this value.
     ///
     /// This is a deterministic 1:1 mapping - no inference or fallback.
-    pub fn to_type(&self) -> UniversalType {
+    pub fn to_type(&self) -> Type {
         match self {
-            Self::Bool(_) => UniversalType::Bool,
-            Self::Int8 { width, .. } => UniversalType::Int8 { width: *width },
-            Self::Int16(_) => UniversalType::Int16,
-            Self::Int32(_) => UniversalType::Int32,
-            Self::Int64(_) => UniversalType::Int64,
-            Self::Float32(_) => UniversalType::Float32,
-            Self::Float64(_) => UniversalType::Float64,
+            Self::Bool(_) => Type::Bool,
+            Self::Int8 { width, .. } => Type::Int8 { width: *width },
+            Self::Int16(_) => Type::Int16,
+            Self::Int32(_) => Type::Int32,
+            Self::Int64(_) => Type::Int64,
+            Self::Float32(_) => Type::Float32,
+            Self::Float64(_) => Type::Float64,
             Self::Decimal {
                 precision, scale, ..
-            } => UniversalType::Decimal {
+            } => Type::Decimal {
                 precision: *precision,
                 scale: *scale,
             },
-            Self::Char { length, .. } => UniversalType::Char { length: *length },
-            Self::VarChar { length, .. } => UniversalType::VarChar { length: *length },
-            Self::Text(_) => UniversalType::Text,
-            Self::Blob(_) => UniversalType::Blob,
-            Self::Bytes(_) => UniversalType::Bytes,
-            Self::Date(_) => UniversalType::Date,
-            Self::Time(_) => UniversalType::Time,
-            Self::LocalDateTime(_) => UniversalType::LocalDateTime,
-            Self::LocalDateTimeNano(_) => UniversalType::LocalDateTimeNano,
-            Self::ZonedDateTime(_) => UniversalType::ZonedDateTime,
-            Self::TimeTz(_) => UniversalType::TimeTz,
-            Self::Uuid(_) => UniversalType::Uuid,
-            Self::Ulid(_) => UniversalType::Ulid,
-            Self::Json(_) => UniversalType::Json,
-            Self::Jsonb(_) => UniversalType::Jsonb,
-            Self::Array { element_type, .. } => UniversalType::Array {
+            Self::Char { length, .. } => Type::Char { length: *length },
+            Self::VarChar { length, .. } => Type::VarChar { length: *length },
+            Self::Text(_) => Type::Text,
+            Self::Blob(_) => Type::Blob,
+            Self::Bytes(_) => Type::Bytes,
+            Self::Date(_) => Type::Date,
+            Self::Time(_) => Type::Time,
+            Self::LocalDateTime(_) => Type::LocalDateTime,
+            Self::LocalDateTimeNano(_) => Type::LocalDateTimeNano,
+            Self::ZonedDateTime(_) => Type::ZonedDateTime,
+            Self::TimeTz(_) => Type::TimeTz,
+            Self::Uuid(_) => Type::Uuid,
+            Self::Ulid(_) => Type::Ulid,
+            Self::Json(_) => Type::Json,
+            Self::Jsonb(_) => Type::Jsonb,
+            Self::Array { element_type, .. } => Type::Array {
                 element_type: element_type.clone(),
             },
-            Self::Set { allowed_values, .. } => UniversalType::Set {
+            Self::Set { allowed_values, .. } => Type::Set {
                 values: allowed_values.clone(),
             },
-            Self::Enum { allowed_values, .. } => UniversalType::Enum {
+            Self::Enum { allowed_values, .. } => Type::Enum {
                 values: allowed_values.clone(),
             },
-            Self::Geometry { geometry_type, .. } => UniversalType::Geometry {
+            Self::Geometry { geometry_type, .. } => Type::Geometry {
                 geometry_type: geometry_type.clone(),
             },
-            Self::Duration(_) => UniversalType::Duration,
-            Self::Thing { .. } => UniversalType::Thing,
-            Self::Object(_) => UniversalType::Object,
+            Self::Duration(_) => Type::Duration,
+            Self::Thing { .. } => Type::Thing,
+            Self::Object(_) => Type::Object,
             // Null doesn't have a single type - this is a special case
             // We use Text as a placeholder, but callers should handle Null explicitly
-            Self::Null => UniversalType::Text,
+            Self::Null => Type::Text,
             Self::ZeroTemporal { intended_type, .. } => intended_type.clone(),
         }
     }
 }
 
-/// Typed value with its UniversalType for conversion.
+/// Typed value with its Type for conversion.
 ///
-/// `TypedValue` combines a `UniversalValue` with its corresponding `UniversalType`,
+/// `TypedValue` combines a `Value` with its corresponding `Type`,
 /// providing the type context needed for `From`/`Into` trait implementations
 /// in the database-specific type crates.
 #[derive(Debug, Clone)]
 pub struct TypedValue {
     /// The extended type information
-    pub sync_type: UniversalType,
+    pub sync_type: Type,
 
     /// The raw generated value
-    pub value: UniversalValue,
+    pub value: Value,
 }
 
 impl TypedValue {
     /// Create a new typed value (internal use - prefer factory methods).
-    fn new(sync_type: UniversalType, value: UniversalValue) -> Self {
+    fn new(sync_type: Type, value: Value) -> Self {
         Self { sync_type, value }
     }
 
@@ -644,18 +644,15 @@ impl TypedValue {
     /// - `Set` type requires `Set` value
     /// - `Enum` type requires `Enum` value
     /// - `Geometry` type requires `Geometry` value
-    pub fn try_with_type(
-        sync_type: UniversalType,
-        value: UniversalValue,
-    ) -> Result<Self, TypedValueError> {
+    pub fn try_with_type(sync_type: Type, value: Value) -> Result<Self, TypedValueError> {
         // Null is always valid for any type
-        if matches!(value, UniversalValue::Null) {
+        if matches!(value, Value::Null) {
             return Ok(Self::new(sync_type, value));
         }
 
         // ZeroTemporal is valid when sync_type matches intended_type and is temporal
-        if let UniversalValue::ZeroTemporal { intended_type, .. } = &value {
-            if sync_type == *intended_type && UniversalValue::is_zero_temporal_type(&sync_type) {
+        if let Value::ZeroTemporal { intended_type, .. } = &value {
+            if sync_type == *intended_type && Value::is_zero_temporal_type(&sync_type) {
                 return Ok(Self::new(sync_type, value));
             }
             return Err(TypedValueError {
@@ -668,60 +665,60 @@ impl TypedValue {
         // Strict 1:1 validation - each type requires its exact corresponding value variant
         let is_valid = match (&sync_type, &value) {
             // Boolean
-            (UniversalType::Bool, UniversalValue::Bool(_)) => true,
+            (Type::Bool, Value::Bool(_)) => true,
 
             // Integer types - strict matching
-            (UniversalType::Int8 { .. }, UniversalValue::Int8 { .. }) => true,
-            (UniversalType::Int16, UniversalValue::Int16(_)) => true,
-            (UniversalType::Int32, UniversalValue::Int32(_)) => true,
-            (UniversalType::Int64, UniversalValue::Int64(_)) => true,
+            (Type::Int8 { .. }, Value::Int8 { .. }) => true,
+            (Type::Int16, Value::Int16(_)) => true,
+            (Type::Int32, Value::Int32(_)) => true,
+            (Type::Int64, Value::Int64(_)) => true,
 
             // Floating point types - strict matching
-            (UniversalType::Float32, UniversalValue::Float32(_)) => true,
-            (UniversalType::Float64, UniversalValue::Float64(_)) => true,
+            (Type::Float32, Value::Float32(_)) => true,
+            (Type::Float64, Value::Float64(_)) => true,
 
             // Decimal
-            (UniversalType::Decimal { .. }, UniversalValue::Decimal { .. }) => true,
+            (Type::Decimal { .. }, Value::Decimal { .. }) => true,
 
             // String types - strict matching
-            (UniversalType::Char { .. }, UniversalValue::Char { .. }) => true,
-            (UniversalType::VarChar { .. }, UniversalValue::VarChar { .. }) => true,
-            (UniversalType::Text, UniversalValue::Text(_)) => true,
+            (Type::Char { .. }, Value::Char { .. }) => true,
+            (Type::VarChar { .. }, Value::VarChar { .. }) => true,
+            (Type::Text, Value::Text(_)) => true,
 
             // Binary types - strict matching
-            (UniversalType::Blob, UniversalValue::Blob(_)) => true,
-            (UniversalType::Bytes, UniversalValue::Bytes(_)) => true,
+            (Type::Blob, Value::Blob(_)) => true,
+            (Type::Bytes, Value::Bytes(_)) => true,
 
             // Temporal types - strict matching
-            (UniversalType::Date, UniversalValue::Date(_)) => true,
-            (UniversalType::Time, UniversalValue::Time(_)) => true,
-            (UniversalType::LocalDateTime, UniversalValue::LocalDateTime(_)) => true,
-            (UniversalType::LocalDateTimeNano, UniversalValue::LocalDateTimeNano(_)) => true,
-            (UniversalType::ZonedDateTime, UniversalValue::ZonedDateTime(_)) => true,
-            (UniversalType::TimeTz, UniversalValue::TimeTz(_)) => true,
+            (Type::Date, Value::Date(_)) => true,
+            (Type::Time, Value::Time(_)) => true,
+            (Type::LocalDateTime, Value::LocalDateTime(_)) => true,
+            (Type::LocalDateTimeNano, Value::LocalDateTimeNano(_)) => true,
+            (Type::ZonedDateTime, Value::ZonedDateTime(_)) => true,
+            (Type::TimeTz, Value::TimeTz(_)) => true,
 
             // UUID
-            (UniversalType::Uuid, UniversalValue::Uuid(_)) => true,
+            (Type::Uuid, Value::Uuid(_)) => true,
 
             // JSON types - strict matching
-            (UniversalType::Json, UniversalValue::Json(_)) => true,
-            (UniversalType::Jsonb, UniversalValue::Jsonb(_)) => true,
+            (Type::Json, Value::Json(_)) => true,
+            (Type::Jsonb, Value::Jsonb(_)) => true,
 
             // Collection types - strict matching
-            (UniversalType::Array { .. }, UniversalValue::Array { .. }) => true,
-            (UniversalType::Set { .. }, UniversalValue::Set { .. }) => true,
+            (Type::Array { .. }, Value::Array { .. }) => true,
+            (Type::Set { .. }, Value::Set { .. }) => true,
 
             // Enumeration
-            (UniversalType::Enum { .. }, UniversalValue::Enum { .. }) => true,
+            (Type::Enum { .. }, Value::Enum { .. }) => true,
 
             // Geometry
-            (UniversalType::Geometry { .. }, UniversalValue::Geometry { .. }) => true,
+            (Type::Geometry { .. }, Value::Geometry { .. }) => true,
 
             // Duration
-            (UniversalType::Duration, UniversalValue::Duration(_)) => true,
+            (Type::Duration, Value::Duration(_)) => true,
 
             // Object
-            (UniversalType::Object, UniversalValue::Object(_)) => true,
+            (Type::Object, Value::Object(_)) => true,
 
             // All other combinations are invalid
             _ => false,
@@ -739,38 +736,38 @@ impl TypedValue {
     }
 
     /// Get the expected value description for a given type.
-    fn expected_value_description(sync_type: &UniversalType) -> String {
+    fn expected_value_description(sync_type: &Type) -> String {
         match sync_type {
-            UniversalType::Bool => "Bool".to_string(),
-            UniversalType::Int8 { .. } => "Int8".to_string(),
-            UniversalType::Int16 => "Int16".to_string(),
-            UniversalType::Int32 => "Int32".to_string(),
-            UniversalType::Int64 => "Int64".to_string(),
-            UniversalType::Float32 => "Float32".to_string(),
-            UniversalType::Float64 => "Float64".to_string(),
-            UniversalType::Decimal { .. } => "Decimal".to_string(),
-            UniversalType::Char { .. } => "Char".to_string(),
-            UniversalType::VarChar { .. } => "VarChar".to_string(),
-            UniversalType::Text => "Text".to_string(),
-            UniversalType::Blob => "Blob".to_string(),
-            UniversalType::Bytes => "Bytes".to_string(),
-            UniversalType::Date => "Date".to_string(),
-            UniversalType::Time => "Time".to_string(),
-            UniversalType::LocalDateTime => "LocalDateTime".to_string(),
-            UniversalType::LocalDateTimeNano => "LocalDateTimeNano".to_string(),
-            UniversalType::ZonedDateTime => "ZonedDateTime".to_string(),
-            UniversalType::TimeTz => "TimeTz".to_string(),
-            UniversalType::Uuid => "Uuid".to_string(),
-            UniversalType::Ulid => "Ulid".to_string(),
-            UniversalType::Json => "Json".to_string(),
-            UniversalType::Jsonb => "Jsonb".to_string(),
-            UniversalType::Array { .. } => "Array".to_string(),
-            UniversalType::Set { .. } => "Set".to_string(),
-            UniversalType::Enum { .. } => "Enum".to_string(),
-            UniversalType::Geometry { .. } => "Geometry".to_string(),
-            UniversalType::Duration => "Duration".to_string(),
-            UniversalType::Thing => "Thing".to_string(),
-            UniversalType::Object => "Object".to_string(),
+            Type::Bool => "Bool".to_string(),
+            Type::Int8 { .. } => "Int8".to_string(),
+            Type::Int16 => "Int16".to_string(),
+            Type::Int32 => "Int32".to_string(),
+            Type::Int64 => "Int64".to_string(),
+            Type::Float32 => "Float32".to_string(),
+            Type::Float64 => "Float64".to_string(),
+            Type::Decimal { .. } => "Decimal".to_string(),
+            Type::Char { .. } => "Char".to_string(),
+            Type::VarChar { .. } => "VarChar".to_string(),
+            Type::Text => "Text".to_string(),
+            Type::Blob => "Blob".to_string(),
+            Type::Bytes => "Bytes".to_string(),
+            Type::Date => "Date".to_string(),
+            Type::Time => "Time".to_string(),
+            Type::LocalDateTime => "LocalDateTime".to_string(),
+            Type::LocalDateTimeNano => "LocalDateTimeNano".to_string(),
+            Type::ZonedDateTime => "ZonedDateTime".to_string(),
+            Type::TimeTz => "TimeTz".to_string(),
+            Type::Uuid => "Uuid".to_string(),
+            Type::Ulid => "Ulid".to_string(),
+            Type::Json => "Json".to_string(),
+            Type::Jsonb => "Jsonb".to_string(),
+            Type::Array { .. } => "Array".to_string(),
+            Type::Set { .. } => "Set".to_string(),
+            Type::Enum { .. } => "Enum".to_string(),
+            Type::Geometry { .. } => "Geometry".to_string(),
+            Type::Duration => "Duration".to_string(),
+            Type::Thing => "Thing".to_string(),
+            Type::Object => "Object".to_string(),
         }
     }
 
@@ -782,71 +779,68 @@ impl TypedValue {
     /// This is useful when you're certain the combination is valid or when
     /// performance is critical and validation overhead is unacceptable.
     #[inline]
-    pub fn with_type_unchecked(sync_type: UniversalType, value: UniversalValue) -> Self {
+    pub fn with_type_unchecked(sync_type: Type, value: Value) -> Self {
         Self::new(sync_type, value)
     }
 
     /// Create a boolean typed value.
     pub fn bool(value: bool) -> Self {
-        Self::new(UniversalType::Bool, UniversalValue::Bool(value))
+        Self::new(Type::Bool, Value::Bool(value))
     }
 
     /// Create a smallint typed value.
     pub fn int16(value: i16) -> Self {
-        Self::new(UniversalType::Int16, UniversalValue::Int16(value))
+        Self::new(Type::Int16, Value::Int16(value))
     }
 
     /// Create an integer typed value.
     pub fn int32(value: i32) -> Self {
-        Self::new(UniversalType::Int32, UniversalValue::Int32(value))
+        Self::new(Type::Int32, Value::Int32(value))
     }
 
     /// Create a bigint typed value.
     pub fn int64(value: i64) -> Self {
-        Self::new(UniversalType::Int64, UniversalValue::Int64(value))
+        Self::new(Type::Int64, Value::Int64(value))
     }
 
     /// Create a double typed value.
     pub fn float64(value: f64) -> Self {
-        Self::new(UniversalType::Float64, UniversalValue::Float64(value))
+        Self::new(Type::Float64, Value::Float64(value))
     }
 
     /// Create a text typed value.
     pub fn text(value: impl Into<String>) -> Self {
-        Self::new(UniversalType::Text, UniversalValue::Text(value.into()))
+        Self::new(Type::Text, Value::Text(value.into()))
     }
 
     /// Create a bytes typed value.
     pub fn bytes(value: Vec<u8>) -> Self {
-        Self::new(UniversalType::Bytes, UniversalValue::Bytes(value))
+        Self::new(Type::Bytes, Value::Bytes(value))
     }
 
     /// Create a UUID typed value.
     pub fn uuid(value: Uuid) -> Self {
-        Self::new(UniversalType::Uuid, UniversalValue::Uuid(value))
+        Self::new(Type::Uuid, Value::Uuid(value))
     }
 
     /// Create a ULID typed value.
     pub fn ulid(value: ulid::Ulid) -> Self {
-        Self::new(UniversalType::Ulid, UniversalValue::Ulid(value))
+        Self::new(Type::Ulid, Value::Ulid(value))
     }
 
     /// Create a datetime typed value.
     pub fn datetime(value: DateTime<Utc>) -> Self {
-        Self::new(
-            UniversalType::LocalDateTime,
-            UniversalValue::LocalDateTime(value),
-        )
+        Self::new(Type::LocalDateTime, Value::LocalDateTime(value))
     }
 
     /// Create a float typed value.
     pub fn float32(value: f32) -> Self {
-        Self::new(UniversalType::Float32, UniversalValue::Float32(value))
+        Self::new(Type::Float32, Value::Float32(value))
     }
 
     /// Create a null typed value with a specified type.
-    pub fn null(sync_type: UniversalType) -> Self {
-        Self::new(sync_type, UniversalValue::Null)
+    pub fn null(sync_type: Type) -> Self {
+        Self::new(sync_type, Value::Null)
     }
 
     /// Create a zero-temporal typed value with the intended column type.
@@ -854,14 +848,14 @@ impl TypedValue {
     /// # Panics
     ///
     /// Panics if `intended_type` is not a temporal type allowed for zero temporals.
-    pub fn zero_temporal(intended_type: UniversalType, source: Option<String>) -> Self {
+    pub fn zero_temporal(intended_type: Type, source: Option<String>) -> Self {
         assert!(
-            UniversalValue::is_zero_temporal_type(&intended_type),
-            "zero_temporal requires a temporal UniversalType, got {intended_type:?}"
+            Value::is_zero_temporal_type(&intended_type),
+            "zero_temporal requires a temporal Type, got {intended_type:?}"
         );
         Self::new(
             intended_type.clone(),
-            UniversalValue::ZeroTemporal {
+            Value::ZeroTemporal {
                 intended_type,
                 source,
             },
@@ -871,8 +865,8 @@ impl TypedValue {
     /// Create a decimal typed value.
     pub fn decimal(value: impl Into<String>, precision: u8, scale: u8) -> Self {
         Self::new(
-            UniversalType::Decimal { precision, scale },
-            UniversalValue::Decimal {
+            Type::Decimal { precision, scale },
+            Value::Decimal {
                 value: value.into(),
                 precision,
                 scale,
@@ -881,12 +875,12 @@ impl TypedValue {
     }
 
     /// Create an array typed value.
-    pub fn array(elements: Vec<UniversalValue>, element_type: UniversalType) -> Self {
+    pub fn array(elements: Vec<Value>, element_type: Type) -> Self {
         Self::new(
-            UniversalType::Array {
+            Type::Array {
                 element_type: Box::new(element_type.clone()),
             },
-            UniversalValue::Array {
+            Value::Array {
                 elements,
                 element_type: Box::new(element_type),
             },
@@ -895,27 +889,24 @@ impl TypedValue {
 
     /// Create a JSON typed value from a serde_json::Value.
     pub fn json(value: serde_json::Value) -> Self {
-        Self::new(UniversalType::Json, UniversalValue::Json(Box::new(value)))
+        Self::new(Type::Json, Value::Json(Box::new(value)))
     }
 
     /// Create a JSONB typed value from a serde_json::Value.
     pub fn jsonb(value: serde_json::Value) -> Self {
-        Self::new(UniversalType::Jsonb, UniversalValue::Jsonb(Box::new(value)))
+        Self::new(Type::Jsonb, Value::Jsonb(Box::new(value)))
     }
 
     /// Create a TINYINT typed value with optional width.
     pub fn int8(value: i8, width: u8) -> Self {
-        Self::new(
-            UniversalType::Int8 { width },
-            UniversalValue::Int8 { value, width },
-        )
+        Self::new(Type::Int8 { width }, Value::Int8 { value, width })
     }
 
     /// Create a CHAR typed value with specified length.
     pub fn char_type(value: impl Into<String>, length: u16) -> Self {
         Self::new(
-            UniversalType::Char { length },
-            UniversalValue::Char {
+            Type::Char { length },
+            Value::Char {
                 value: value.into(),
                 length,
             },
@@ -925,8 +916,8 @@ impl TypedValue {
     /// Create a VARCHAR typed value with specified length.
     pub fn varchar(value: impl Into<String>, length: u16) -> Self {
         Self::new(
-            UniversalType::VarChar { length },
-            UniversalValue::VarChar {
+            Type::VarChar { length },
+            Value::VarChar {
                 value: value.into(),
                 length,
             },
@@ -935,42 +926,36 @@ impl TypedValue {
 
     /// Create a BLOB typed value.
     pub fn blob(value: Vec<u8>) -> Self {
-        Self::new(UniversalType::Blob, UniversalValue::Blob(value))
+        Self::new(Type::Blob, Value::Blob(value))
     }
 
     /// Create a DATE typed value from a DateTime.
     pub fn date(value: DateTime<Utc>) -> Self {
-        Self::new(UniversalType::Date, UniversalValue::Date(value))
+        Self::new(Type::Date, Value::Date(value))
     }
 
     /// Create a TIME typed value from a DateTime.
     pub fn time(value: DateTime<Utc>) -> Self {
-        Self::new(UniversalType::Time, UniversalValue::Time(value))
+        Self::new(Type::Time, Value::Time(value))
     }
 
     /// Create a TIMESTAMPTZ typed value.
     pub fn timestamptz(value: DateTime<Utc>) -> Self {
-        Self::new(
-            UniversalType::ZonedDateTime,
-            UniversalValue::ZonedDateTime(value),
-        )
+        Self::new(Type::ZonedDateTime, Value::ZonedDateTime(value))
     }
 
     /// Create a DATETIME with nanosecond precision typed value.
     pub fn datetime_nano(value: DateTime<Utc>) -> Self {
-        Self::new(
-            UniversalType::LocalDateTimeNano,
-            UniversalValue::LocalDateTimeNano(value),
-        )
+        Self::new(Type::LocalDateTimeNano, Value::LocalDateTimeNano(value))
     }
 
     /// Create an ENUM typed value.
     pub fn enum_type(value: impl Into<String>, variants: Vec<String>) -> Self {
         Self::new(
-            UniversalType::Enum {
+            Type::Enum {
                 values: variants.clone(),
             },
-            UniversalValue::Enum {
+            Value::Enum {
                 value: value.into(),
                 allowed_values: variants,
             },
@@ -980,10 +965,10 @@ impl TypedValue {
     /// Create a SET typed value.
     pub fn set(elements: Vec<String>, variants: Vec<String>) -> Self {
         Self::new(
-            UniversalType::Set {
+            Type::Set {
                 values: variants.clone(),
             },
-            UniversalValue::Set {
+            Value::Set {
                 elements,
                 allowed_values: variants,
             },
@@ -996,10 +981,10 @@ impl TypedValue {
         geometry_type: crate::types::GeometryType,
     ) -> Self {
         Self::new(
-            UniversalType::Geometry {
+            Type::Geometry {
                 geometry_type: geometry_type.clone(),
             },
-            UniversalValue::Geometry {
+            Value::Geometry {
                 data: GeometryData(value),
                 geometry_type,
             },
@@ -1013,17 +998,17 @@ impl TypedValue {
 
     /// Create a DURATION typed value.
     pub fn duration(value: std::time::Duration) -> Self {
-        Self::new(UniversalType::Duration, UniversalValue::Duration(value))
+        Self::new(Type::Duration, Value::Duration(value))
     }
 }
 
 /// Internal row representation - the intermediate format.
 ///
-/// `UniversalRow` represents a single row of data in the intermediate format,
+/// `Row` represents a single row of data in the intermediate format,
 /// produced by the data generator and consumed by both source populators
 /// and the streaming verifier.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct UniversalRow {
+pub struct Row {
     /// Table name
     pub table: String,
 
@@ -1031,19 +1016,19 @@ pub struct UniversalRow {
     pub index: u64,
 
     /// Primary key value
-    pub id: UniversalValue,
+    pub id: Value,
 
     /// Field values (column name -> value)
-    pub fields: HashMap<String, UniversalValue>,
+    pub fields: HashMap<String, Value>,
 }
 
-impl UniversalRow {
+impl Row {
     /// Create a new internal row.
     pub fn new(
         table: impl Into<String>,
         index: u64,
-        id: UniversalValue,
-        fields: HashMap<String, UniversalValue>,
+        id: Value,
+        fields: HashMap<String, Value>,
     ) -> Self {
         Self {
             table: table.into(),
@@ -1054,12 +1039,8 @@ impl UniversalRow {
     }
 
     /// Create a new internal row with a builder pattern.
-    pub fn builder(
-        table: impl Into<String>,
-        index: u64,
-        id: UniversalValue,
-    ) -> UniversalRowBuilder {
-        UniversalRowBuilder {
+    pub fn builder(table: impl Into<String>, index: u64, id: Value) -> RowBuilder {
+        RowBuilder {
             table: table.into(),
             index,
             id,
@@ -1068,7 +1049,7 @@ impl UniversalRow {
     }
 
     /// Get a field value by name.
-    pub fn get_field(&self, name: &str) -> Option<&UniversalValue> {
+    pub fn get_field(&self, name: &str) -> Option<&Value> {
         self.fields.get(name)
     }
 
@@ -1078,24 +1059,24 @@ impl UniversalRow {
     }
 }
 
-/// Builder for `UniversalRow`.
-pub struct UniversalRowBuilder {
+/// Builder for `Row`.
+pub struct RowBuilder {
     table: String,
     index: u64,
-    id: UniversalValue,
-    fields: HashMap<String, UniversalValue>,
+    id: Value,
+    fields: HashMap<String, Value>,
 }
 
-impl UniversalRowBuilder {
+impl RowBuilder {
     /// Add a field to the row.
-    pub fn field(mut self, name: impl Into<String>, value: UniversalValue) -> Self {
+    pub fn field(mut self, name: impl Into<String>, value: Value) -> Self {
         self.fields.insert(name.into(), value);
         self
     }
 
     /// Build the internal row.
-    pub fn build(self) -> UniversalRow {
-        UniversalRow {
+    pub fn build(self) -> Row {
+        Row {
             table: self.table,
             index: self.index,
             id: self.id,
@@ -1106,12 +1087,12 @@ impl UniversalRowBuilder {
 
 /// Converter that holds schema context for From implementations.
 ///
-/// `RowConverter` wraps an `UniversalRow` along with the schema context,
+/// `RowConverter` wraps an `Row` along with the schema context,
 /// enabling database-specific `From` implementations to look up type
 /// information for each field.
 pub struct RowConverter<'a> {
     /// The internal row to convert
-    pub row: UniversalRow,
+    pub row: Row,
 
     /// Schema providing type information for fields
     pub schema: &'a Schema,
@@ -1119,7 +1100,7 @@ pub struct RowConverter<'a> {
 
 impl<'a> RowConverter<'a> {
     /// Create a new row converter.
-    pub fn new(row: UniversalRow, schema: &'a Schema) -> Self {
+    pub fn new(row: Row, schema: &'a Schema) -> Self {
         Self { row, schema }
     }
 }
@@ -1130,7 +1111,7 @@ impl<'a> RowConverter<'a> {
 
 /// Operation type for incremental sync changes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum UniversalChangeOp {
+pub enum ChangeOp {
     /// Create a new record
     Create,
     /// Update an existing record
@@ -1142,56 +1123,48 @@ pub enum UniversalChangeOp {
 /// A database-agnostic change event for incremental sync.
 ///
 /// This type represents a change (INSERT/UPDATE/DELETE) from a source database
-/// in a universal format that can be converted to any target database format.
+/// in a shared IR that can be converted to any target database format.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct UniversalChange {
+pub struct Change {
     /// The operation type (Create/Update/Delete)
-    pub operation: UniversalChangeOp,
+    pub operation: ChangeOp,
     /// The table name
     pub table: String,
     /// The record ID
-    pub id: UniversalValue,
-    /// The record data (None for Delete operations)
-    pub data: Option<HashMap<String, UniversalValue>>,
+    pub id: Value,
+    /// Field values (None for Delete operations)
+    pub fields: Option<HashMap<String, Value>>,
 }
 
-impl UniversalChange {
+impl Change {
     /// Create a new change.
     pub fn new(
-        operation: UniversalChangeOp,
+        operation: ChangeOp,
         table: impl Into<String>,
-        id: UniversalValue,
-        data: Option<HashMap<String, UniversalValue>>,
+        id: Value,
+        fields: Option<HashMap<String, Value>>,
     ) -> Self {
         Self {
             operation,
             table: table.into(),
             id,
-            data,
+            fields,
         }
     }
 
     /// Create a CREATE change.
-    pub fn create(
-        table: impl Into<String>,
-        id: UniversalValue,
-        data: HashMap<String, UniversalValue>,
-    ) -> Self {
-        Self::new(UniversalChangeOp::Create, table, id, Some(data))
+    pub fn create(table: impl Into<String>, id: Value, fields: HashMap<String, Value>) -> Self {
+        Self::new(ChangeOp::Create, table, id, Some(fields))
     }
 
     /// Create an UPDATE change.
-    pub fn update(
-        table: impl Into<String>,
-        id: UniversalValue,
-        data: HashMap<String, UniversalValue>,
-    ) -> Self {
-        Self::new(UniversalChangeOp::Update, table, id, Some(data))
+    pub fn update(table: impl Into<String>, id: Value, fields: HashMap<String, Value>) -> Self {
+        Self::new(ChangeOp::Update, table, id, Some(fields))
     }
 
     /// Create a DELETE change.
-    pub fn delete(table: impl Into<String>, id: UniversalValue) -> Self {
-        Self::new(UniversalChangeOp::Delete, table, id, None)
+    pub fn delete(table: impl Into<String>, id: Value) -> Self {
+        Self::new(ChangeOp::Delete, table, id, None)
     }
 }
 
@@ -1205,33 +1178,33 @@ impl UniversalChange {
 /// like Neo4j and SurrealDB. It contains the relation type, IDs for both endpoints,
 /// and optional properties on the relation itself.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct UniversalRelation {
+pub struct Relation {
     /// The relation type (table name in SurrealDB terms)
     pub relation_type: String,
     /// The relation's own ID
-    pub id: UniversalValue,
+    pub id: Value,
     /// The source node reference (table name + id)
-    pub input: UniversalThingRef,
+    pub input: ThingRef,
     /// The target node reference (table name + id)
-    pub output: UniversalThingRef,
+    pub output: ThingRef,
     /// Properties on the relation itself
-    pub data: HashMap<String, UniversalValue>,
+    pub data: HashMap<String, Value>,
 }
 
 /// A reference to a record/node in a specific table.
 ///
 /// This is used to identify the endpoints of a relation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct UniversalThingRef {
+pub struct ThingRef {
     /// The table/collection name
     pub table: String,
     /// The record ID
-    pub id: UniversalValue,
+    pub id: Value,
 }
 
-impl UniversalThingRef {
+impl ThingRef {
     /// Create a new thing reference.
-    pub fn new(table: impl Into<String>, id: UniversalValue) -> Self {
+    pub fn new(table: impl Into<String>, id: Value) -> Self {
         Self {
             table: table.into(),
             id,
@@ -1239,14 +1212,14 @@ impl UniversalThingRef {
     }
 }
 
-impl UniversalRelation {
+impl Relation {
     /// Create a new relation.
     pub fn new(
         relation_type: impl Into<String>,
-        id: UniversalValue,
-        input: UniversalThingRef,
-        output: UniversalThingRef,
-        data: HashMap<String, UniversalValue>,
+        id: Value,
+        input: ThingRef,
+        output: ThingRef,
+        data: HashMap<String, Value>,
     ) -> Self {
         Self {
             relation_type: relation_type.into(),
@@ -1264,119 +1237,101 @@ mod tests {
 
     #[test]
     fn test_generated_value_accessors() {
-        assert_eq!(UniversalValue::Bool(true).as_bool(), Some(true));
-        assert_eq!(UniversalValue::Int32(42).as_i32(), Some(42));
-        assert_eq!(UniversalValue::Int64(100).as_i64(), Some(100));
-        assert_eq!(UniversalValue::Float64(3.15).as_f64(), Some(3.15));
-        assert_eq!(
-            UniversalValue::Text("test".to_string()).as_str(),
-            Some("test")
-        );
+        assert_eq!(Value::Bool(true).as_bool(), Some(true));
+        assert_eq!(Value::Int32(42).as_i32(), Some(42));
+        assert_eq!(Value::Int64(100).as_i64(), Some(100));
+        assert_eq!(Value::Float64(3.15).as_f64(), Some(3.15));
+        assert_eq!(Value::Text("test".to_string()).as_str(), Some("test"));
 
         // Cross-type conversions
-        assert_eq!(UniversalValue::Int32(42).as_i64(), Some(42));
-        assert_eq!(UniversalValue::Bool(true).as_i32(), None);
+        assert_eq!(Value::Int32(42).as_i64(), Some(42));
+        assert_eq!(Value::Bool(true).as_i32(), None);
     }
 
     #[test]
     fn test_typed_value_constructors() {
         let tv = TypedValue::bool(true);
-        assert_eq!(tv.sync_type, UniversalType::Bool);
-        assert_eq!(tv.value, UniversalValue::Bool(true));
+        assert_eq!(tv.sync_type, Type::Bool);
+        assert_eq!(tv.value, Value::Bool(true));
 
         let tv = TypedValue::int32(42);
-        assert_eq!(tv.sync_type, UniversalType::Int32);
-        assert_eq!(tv.value, UniversalValue::Int32(42));
+        assert_eq!(tv.sync_type, Type::Int32);
+        assert_eq!(tv.value, Value::Int32(42));
     }
 
     #[test]
     fn test_internal_row_builder() {
-        let row = UniversalRow::builder("users", 0, UniversalValue::Int64(1))
-            .field("name", UniversalValue::Text("Alice".to_string()))
-            .field("age", UniversalValue::Int32(30))
+        let row = Row::builder("users", 0, Value::Int64(1))
+            .field("name", Value::Text("Alice".to_string()))
+            .field("age", Value::Int32(30))
             .build();
 
         assert_eq!(row.table, "users");
         assert_eq!(row.index, 0);
-        assert_eq!(row.id, UniversalValue::Int64(1));
+        assert_eq!(row.id, Value::Int64(1));
         assert_eq!(row.field_count(), 2);
         assert_eq!(
             row.get_field("name"),
-            Some(&UniversalValue::Text("Alice".to_string()))
+            Some(&Value::Text("Alice".to_string()))
         );
-        assert_eq!(row.get_field("age"), Some(&UniversalValue::Int32(30)));
+        assert_eq!(row.get_field("age"), Some(&Value::Int32(30)));
     }
 
     #[test]
     fn test_try_with_type_valid_combinations() {
         // Bool type with Bool value
-        assert!(TypedValue::try_with_type(UniversalType::Bool, UniversalValue::Bool(true)).is_ok());
+        assert!(TypedValue::try_with_type(Type::Bool, Value::Bool(true)).is_ok());
 
         // Int type with Int value (strict 1:1)
-        assert!(TypedValue::try_with_type(UniversalType::Int32, UniversalValue::Int32(42)).is_ok());
+        assert!(TypedValue::try_with_type(Type::Int32, Value::Int32(42)).is_ok());
 
         // BigInt type with BigInt value (strict 1:1)
-        assert!(
-            TypedValue::try_with_type(UniversalType::Int64, UniversalValue::Int64(100)).is_ok()
-        );
+        assert!(TypedValue::try_with_type(Type::Int64, Value::Int64(100)).is_ok());
 
         // Text type with Text value (strict 1:1)
-        assert!(TypedValue::try_with_type(
-            UniversalType::Text,
-            UniversalValue::Text("hello".to_string())
-        )
-        .is_ok());
+        assert!(TypedValue::try_with_type(Type::Text, Value::Text("hello".to_string())).is_ok());
 
         // DateTime type with DateTime value
         assert!(TypedValue::try_with_type(
-            UniversalType::LocalDateTime,
-            UniversalValue::LocalDateTime(chrono::Utc::now())
+            Type::LocalDateTime,
+            Value::LocalDateTime(chrono::Utc::now())
         )
         .is_ok());
 
         // Date type with Date value (strict 1:1)
-        assert!(TypedValue::try_with_type(
-            UniversalType::Date,
-            UniversalValue::Date(chrono::Utc::now())
-        )
-        .is_ok());
+        assert!(TypedValue::try_with_type(Type::Date, Value::Date(chrono::Utc::now())).is_ok());
 
         // Null is always valid
-        assert!(TypedValue::try_with_type(UniversalType::Bool, UniversalValue::Null).is_ok());
-        assert!(TypedValue::try_with_type(UniversalType::Int32, UniversalValue::Null).is_ok());
-        assert!(TypedValue::try_with_type(UniversalType::Text, UniversalValue::Null).is_ok());
+        assert!(TypedValue::try_with_type(Type::Bool, Value::Null).is_ok());
+        assert!(TypedValue::try_with_type(Type::Int32, Value::Null).is_ok());
+        assert!(TypedValue::try_with_type(Type::Text, Value::Null).is_ok());
 
         // ZeroTemporal is valid when sync_type matches intended_type
         assert!(TypedValue::try_with_type(
-            UniversalType::Date,
-            UniversalValue::zero_temporal(UniversalType::Date, Some("0000-00-00".into()))
+            Type::Date,
+            Value::zero_temporal(Type::Date, Some("0000-00-00".into()))
         )
         .is_ok());
         assert!(TypedValue::try_with_type(
-            UniversalType::LocalDateTime,
-            UniversalValue::zero_temporal(
-                UniversalType::LocalDateTime,
-                Some("0000-00-00 00:00:00".into())
-            )
+            Type::LocalDateTime,
+            Value::zero_temporal(Type::LocalDateTime, Some("0000-00-00 00:00:00".into()))
         )
         .is_ok());
         // Mismatched intended_type is invalid
         assert!(TypedValue::try_with_type(
-            UniversalType::Date,
-            UniversalValue::zero_temporal(UniversalType::LocalDateTime, None)
+            Type::Date,
+            Value::zero_temporal(Type::LocalDateTime, None)
         )
         .is_err());
         // Non-temporal intended_type is invalid
-        assert!(TypedValue::try_with_type(
-            UniversalType::Text,
-            UniversalValue::zero_temporal(UniversalType::Text, None)
-        )
-        .is_err());
+        assert!(
+            TypedValue::try_with_type(Type::Text, Value::zero_temporal(Type::Text, None)).is_err()
+        );
 
         // JSON type with Json value (strict 1:1)
         assert!(TypedValue::try_with_type(
-            UniversalType::Json,
-            UniversalValue::Json(Box::new(serde_json::Value::Bool(true)))
+            Type::Json,
+            Value::Json(Box::new(serde_json::Value::Bool(true)))
         )
         .is_ok());
     }
@@ -1384,53 +1339,42 @@ mod tests {
     #[test]
     fn test_try_with_type_invalid_combinations() {
         // Bool type with wrong value types
-        let err =
-            TypedValue::try_with_type(UniversalType::Bool, UniversalValue::Int32(1)).unwrap_err();
+        let err = TypedValue::try_with_type(Type::Bool, Value::Int32(1)).unwrap_err();
         assert_eq!(err.expected_value, "Bool");
         assert_eq!(err.actual_value, "Int32");
 
         // Int type with wrong value types (strict 1:1 now)
         let err =
-            TypedValue::try_with_type(UniversalType::Int32, UniversalValue::Text("42".to_string()))
-                .unwrap_err();
+            TypedValue::try_with_type(Type::Int32, Value::Text("42".to_string())).unwrap_err();
         assert_eq!(err.expected_value, "Int32");
         assert_eq!(err.actual_value, "Text");
 
         // Int type no longer accepts BigInt (strict 1:1)
-        let err =
-            TypedValue::try_with_type(UniversalType::Int32, UniversalValue::Int64(42)).unwrap_err();
+        let err = TypedValue::try_with_type(Type::Int32, Value::Int64(42)).unwrap_err();
         assert_eq!(err.expected_value, "Int32");
         assert_eq!(err.actual_value, "Int64");
 
         // BigInt type no longer accepts Int (strict 1:1)
-        let err =
-            TypedValue::try_with_type(UniversalType::Int64, UniversalValue::Int32(42)).unwrap_err();
+        let err = TypedValue::try_with_type(Type::Int64, Value::Int32(42)).unwrap_err();
         assert_eq!(err.expected_value, "Int64");
         assert_eq!(err.actual_value, "Int32");
 
         // Text type with wrong value types
-        let err =
-            TypedValue::try_with_type(UniversalType::Text, UniversalValue::Int32(42)).unwrap_err();
+        let err = TypedValue::try_with_type(Type::Text, Value::Int32(42)).unwrap_err();
         assert_eq!(err.expected_value, "Text");
         assert_eq!(err.actual_value, "Int32");
 
         // Uuid type with Text value (strict 1:1)
-        let err = TypedValue::try_with_type(
-            UniversalType::Uuid,
-            UniversalValue::Text("not-a-uuid".to_string()),
-        )
-        .unwrap_err();
+        let err = TypedValue::try_with_type(Type::Uuid, Value::Text("not-a-uuid".to_string()))
+            .unwrap_err();
         assert_eq!(err.expected_value, "Uuid");
         assert_eq!(err.actual_value, "Text");
     }
 
     #[test]
     fn test_try_with_type_error_message() {
-        let err = TypedValue::try_with_type(
-            UniversalType::Bool,
-            UniversalValue::Text("true".to_string()),
-        )
-        .unwrap_err();
+        let err =
+            TypedValue::try_with_type(Type::Bool, Value::Text("true".to_string())).unwrap_err();
 
         let msg = err.to_string();
         assert!(msg.contains("Type-value mismatch"));
@@ -1440,81 +1384,77 @@ mod tests {
 
     #[test]
     fn test_variant_name() {
-        assert_eq!(UniversalValue::Bool(true).variant_name(), "Bool");
-        assert_eq!(UniversalValue::Int32(42).variant_name(), "Int32");
-        assert_eq!(UniversalValue::Int64(100).variant_name(), "Int64");
-        assert_eq!(UniversalValue::Float64(1.5).variant_name(), "Float64");
-        assert_eq!(
-            UniversalValue::Text("test".to_string()).variant_name(),
-            "Text"
-        );
-        assert_eq!(UniversalValue::Bytes(vec![1, 2, 3]).variant_name(), "Bytes");
-        assert_eq!(UniversalValue::Null.variant_name(), "Null");
+        assert_eq!(Value::Bool(true).variant_name(), "Bool");
+        assert_eq!(Value::Int32(42).variant_name(), "Int32");
+        assert_eq!(Value::Int64(100).variant_name(), "Int64");
+        assert_eq!(Value::Float64(1.5).variant_name(), "Float64");
+        assert_eq!(Value::Text("test".to_string()).variant_name(), "Text");
+        assert_eq!(Value::Bytes(vec![1, 2, 3]).variant_name(), "Bytes");
+        assert_eq!(Value::Null.variant_name(), "Null");
     }
 
     #[test]
     fn test_to_typed_value_deterministic() {
-        // Each UniversalValue variant should map to exactly one UniversalType
-        let value = UniversalValue::Int32(42);
+        // Each Value variant should map to exactly one Type
+        let value = Value::Int32(42);
         let typed = value.to_typed_value();
-        assert_eq!(typed.sync_type, UniversalType::Int32);
+        assert_eq!(typed.sync_type, Type::Int32);
 
-        let value = UniversalValue::Text("hello".to_string());
+        let value = Value::Text("hello".to_string());
         let typed = value.to_typed_value();
-        assert_eq!(typed.sync_type, UniversalType::Text);
+        assert_eq!(typed.sync_type, Type::Text);
 
-        let value = UniversalValue::Int64(100);
+        let value = Value::Int64(100);
         let typed = value.to_typed_value();
-        assert_eq!(typed.sync_type, UniversalType::Int64);
+        assert_eq!(typed.sync_type, Type::Int64);
 
-        let value = UniversalValue::Float64(3.15);
+        let value = Value::Float64(3.15);
         let typed = value.to_typed_value();
-        assert_eq!(typed.sync_type, UniversalType::Float64);
+        assert_eq!(typed.sync_type, Type::Float64);
 
-        let value = UniversalValue::Float32(1.5);
+        let value = Value::Float32(1.5);
         let typed = value.to_typed_value();
-        assert_eq!(typed.sync_type, UniversalType::Float32);
+        assert_eq!(typed.sync_type, Type::Float32);
 
-        let value = UniversalValue::Int16(100);
+        let value = Value::Int16(100);
         let typed = value.to_typed_value();
-        assert_eq!(typed.sync_type, UniversalType::Int16);
+        assert_eq!(typed.sync_type, Type::Int16);
 
-        let value = UniversalValue::Int8 { value: 1, width: 1 };
+        let value = Value::Int8 { value: 1, width: 1 };
         let typed = value.to_typed_value();
-        assert!(matches!(typed.sync_type, UniversalType::Int8 { width: 1 }));
+        assert!(matches!(typed.sync_type, Type::Int8 { width: 1 }));
     }
 
     #[test]
     fn universal_row_serde_roundtrip() {
-        let row = UniversalRow::builder("users", 7, UniversalValue::Int64(42))
-            .field("name", UniversalValue::Text("Alice".to_string()))
-            .field("active", UniversalValue::Bool(true))
+        let row = Row::builder("users", 7, Value::Int64(42))
+            .field("name", Value::Text("Alice".to_string()))
+            .field("active", Value::Bool(true))
             .build();
         let json = serde_json::to_string(&row).expect("serialize row");
-        let back: UniversalRow = serde_json::from_str(&json).expect("deserialize row");
+        let back: Row = serde_json::from_str(&json).expect("deserialize row");
         assert_eq!(back, row);
     }
 
     #[test]
     fn universal_change_serde_roundtrip_and_golden() {
         let mut data = HashMap::new();
-        data.insert("name".to_string(), UniversalValue::Text("Bob".to_string()));
-        let change = UniversalChange::create("users", UniversalValue::Int64(9), data);
+        data.insert("name".to_string(), Value::Text("Bob".to_string()));
+        let change = Change::create("users", Value::Int64(9), data);
 
         let json = serde_json::to_string(&change).expect("serialize change");
-        let back: UniversalChange = serde_json::from_str(&json).expect("deserialize change");
+        let back: Change = serde_json::from_str(&json).expect("deserialize change");
         assert_eq!(back, change);
 
         // Golden: fixed JSON (single field so HashMap order is irrelevant).
-        let golden = r#"{"operation":"Create","table":"users","id":{"type":"Int64","value":9},"data":{"name":{"type":"Text","value":"Bob"}}}"#;
-        let from_golden: UniversalChange =
-            serde_json::from_str(golden).expect("deserialize golden");
+        let golden = r#"{"operation":"Create","table":"users","id":{"type":"Int64","value":9},"fields":{"name":{"type":"Text","value":"Bob"}}}"#;
+        let from_golden: Change = serde_json::from_str(golden).expect("deserialize golden");
         assert_eq!(from_golden, change);
 
-        let delete = UniversalChange::delete("users", UniversalValue::Int64(9));
+        let delete = Change::delete("users", Value::Int64(9));
         let delete_json = serde_json::to_string(&delete).unwrap();
-        let delete_back: UniversalChange = serde_json::from_str(&delete_json).unwrap();
+        let delete_back: Change = serde_json::from_str(&delete_json).unwrap();
         assert_eq!(delete_back, delete);
-        assert!(delete_back.data.is_none());
+        assert!(delete_back.fields.is_none());
     }
 }

--- a/crates/sync-transform/src/apply/event.rs
+++ b/crates/sync-transform/src/apply/event.rs
@@ -1,6 +1,6 @@
 //! Unified apply events: row changes and relation (graph edge) changes.
 
-use sync_core::{UniversalChange, UniversalRelationChange};
+use sync_core::{Change, RelationChange};
 
 /// One item in the apply buffer / transform window / ordered sink queue.
 ///
@@ -8,23 +8,23 @@ use sync_core::{UniversalChange, UniversalRelationChange};
 /// source order across both kinds through the same max_in_flight window.
 ///
 /// [`RelationChange`](Self::RelationChange) is boxed to keep the enum compact
-/// (`UniversalRelationChange` is substantially larger than [`UniversalChange`]).
+/// (`RelationChange` is substantially larger than [`Change`]).
 #[derive(Debug, Clone)]
 pub enum ApplyEvent {
     /// Row create / update / delete.
-    Change(UniversalChange),
-    /// Graph-edge create / update / delete ([`UniversalRelationChange`]).
-    RelationChange(Box<UniversalRelationChange>),
+    Change(Change),
+    /// Graph-edge create / update / delete ([`RelationChange`]).
+    RelationChange(Box<RelationChange>),
 }
 
 impl ApplyEvent {
     /// Wrap a row change.
-    pub fn change(change: UniversalChange) -> Self {
+    pub fn change(change: Change) -> Self {
         Self::Change(change)
     }
 
     /// Wrap a relation change.
-    pub fn relation_change(change: UniversalRelationChange) -> Self {
+    pub fn relation_change(change: RelationChange) -> Self {
         Self::RelationChange(Box::new(change))
     }
 
@@ -55,12 +55,12 @@ impl<P> PositionedEvent<P> {
     }
 
     /// Positioned row change.
-    pub fn change(change: UniversalChange, position: P) -> Self {
+    pub fn change(change: Change, position: P) -> Self {
         Self::new(ApplyEvent::Change(change), position)
     }
 
     /// Positioned relation change.
-    pub fn relation_change(change: UniversalRelationChange, position: P) -> Self {
+    pub fn relation_change(change: RelationChange, position: P) -> Self {
         Self::new(ApplyEvent::relation_change(change), position)
     }
 }

--- a/crates/sync-transform/src/apply/feed.rs
+++ b/crates/sync-transform/src/apply/feed.rs
@@ -6,7 +6,7 @@
 
 use crate::apply::event::{ApplyEvent, PositionedEvent};
 use anyhow::Result;
-use sync_core::UniversalChange;
+use sync_core::Change;
 
 /// A CDC / incremental row event plus the source position to advance after sink success.
 ///
@@ -14,14 +14,14 @@ use sync_core::UniversalChange;
 #[derive(Debug, Clone)]
 pub struct PositionedChange<P> {
     /// Universal change to transform and apply.
-    pub change: UniversalChange,
+    pub change: Change,
     /// Source position associated with this change (checkpoint candidate).
     pub position: P,
 }
 
 impl<P> PositionedChange<P> {
     /// Construct a positioned change.
-    pub fn new(change: UniversalChange, position: P) -> Self {
+    pub fn new(change: Change, position: P) -> Self {
         Self { change, position }
     }
 

--- a/crates/sync-transform/src/apply/row_chunk.rs
+++ b/crates/sync-transform/src/apply/row_chunk.rs
@@ -8,7 +8,7 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use sync_core::{UniversalChange, UniversalRelation, UniversalRelationChange, UniversalRow};
+use sync_core::{Change, Relation, RelationChange, Row};
 
 use super::event::PositionedEvent;
 use super::source_driver::{CheckpointPolicy, SourceDriver};
@@ -18,7 +18,7 @@ use super::source_driver::{CheckpointPolicy, SourceDriver};
 /// Return `Ok(None)` (or an empty `Vec`) when there are no more rows.
 #[async_trait]
 pub trait RowChunkSource: Send {
-    async fn next_chunk(&mut self) -> Result<Option<Vec<UniversalRow>>>;
+    async fn next_chunk(&mut self) -> Result<Option<Vec<Row>>>;
 }
 
 /// Long-lived [`SourceDriver`] over a [`RowChunkSource`] (CSV-like full-sync pattern).
@@ -34,7 +34,7 @@ pub struct RowChunkDriver<C> {
 }
 
 impl<C> RowChunkDriver<C> {
-    /// Wrap a chunk source. `next_index` seeds [`UniversalRow::index`] / positions.
+    /// Wrap a chunk source. `next_index` seeds [`Row::index`] / positions.
     pub fn new(source: C) -> Self {
         Self {
             source,
@@ -78,7 +78,7 @@ where
                     row.index = self.next_index;
                     let pos = self.next_index;
                     self.next_index = self.next_index.saturating_add(1);
-                    let change = UniversalChange::update(row.table, row.id, row.fields);
+                    let change = Change::update(row.table, row.id, row.fields);
                     events.push(PositionedEvent::change(change, pos));
                 }
                 Ok(events)
@@ -107,7 +107,7 @@ where
 /// Produces successive relation chunks until the scan is exhausted.
 #[async_trait]
 pub trait RelationChunkSource: Send {
-    async fn next_chunk(&mut self) -> Result<Option<Vec<UniversalRelation>>>;
+    async fn next_chunk(&mut self) -> Result<Option<Vec<Relation>>>;
 }
 
 /// Long-lived [`SourceDriver`] over a [`RelationChunkSource`].
@@ -163,7 +163,7 @@ where
                 for relation in rels.drain(..) {
                     let pos = self.next_index;
                     self.next_index = self.next_index.saturating_add(1);
-                    let change = UniversalRelationChange::update(relation);
+                    let change = RelationChange::update(relation);
                     events.push(PositionedEvent::relation_change(change, pos));
                 }
                 Ok(events)

--- a/crates/sync-transform/src/apply/runtime.rs
+++ b/crates/sync-transform/src/apply/runtime.rs
@@ -19,22 +19,20 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Instant;
 use surreal_sink::SurrealSink;
-use sync_core::{
-    UniversalChange, UniversalChangeOp, UniversalRelation, UniversalRelationChange, UniversalRow,
-};
+use sync_core::{Change, ChangeOp, Relation, RelationChange, Row};
 use tokio::task::JoinSet;
 use tracing::warn;
 
 /// Transform then sink rows via the same overlapping [`ApplyContext`] window as
 /// CDC. Shared by full sync and snapshot flushes.
 ///
-/// Rows become upsert [`UniversalChange`]s and honor `max_in_flight` /
+/// Rows become upsert [`Change`]s and honor `max_in_flight` /
 /// `batch_size`. Homogeneous upsert batches coalesce to
-/// [`SurrealSink::write_universal_rows`] inside the ordered sink step.
+/// [`SurrealSink::write_rows`] inside the ordered sink step.
 pub async fn write_rows<S: SurrealSink>(
     sink: &S,
     pipeline: &Pipeline,
-    rows: Vec<UniversalRow>,
+    rows: Vec<Row>,
     opts: &ApplyOpts,
 ) -> Result<()> {
     write_rows_with(sink, Arc::new(pipeline.clone()), rows, opts).await
@@ -45,28 +43,28 @@ pub async fn write_rows<S: SurrealSink>(
 pub async fn write_relations<S: SurrealSink>(
     sink: &S,
     pipeline: &Pipeline,
-    relations: Vec<UniversalRelation>,
+    relations: Vec<Relation>,
     opts: &ApplyOpts,
 ) -> Result<()> {
     write_relations_with(sink, Arc::new(pipeline.clone()), relations, opts).await
 }
 
-/// Transform then apply each change via [`SurrealSink::apply_universal_change`].
+/// Transform then apply each change via [`SurrealSink::apply_change`].
 pub async fn apply_changes<S: SurrealSink>(
     sink: &S,
     pipeline: &Pipeline,
-    changes: Vec<UniversalChange>,
+    changes: Vec<Change>,
     opts: &ApplyOpts,
 ) -> Result<()> {
     apply_changes_with(sink, Arc::new(pipeline.clone()), changes, opts).await
 }
 
 /// Transform then apply each relation change via
-/// [`SurrealSink::apply_universal_relation_change`].
+/// [`SurrealSink::apply_relation_change`].
 pub async fn apply_relation_changes<S: SurrealSink>(
     sink: &S,
     pipeline: &Pipeline,
-    changes: Vec<UniversalRelationChange>,
+    changes: Vec<RelationChange>,
     opts: &ApplyOpts,
 ) -> Result<()> {
     apply_relation_changes_with(sink, Arc::new(pipeline.clone()), changes, opts).await
@@ -78,7 +76,7 @@ pub async fn apply_relation_changes<S: SurrealSink>(
 pub async fn apply_changes_with<S, T>(
     sink: &S,
     transformer: Arc<T>,
-    changes: Vec<UniversalChange>,
+    changes: Vec<Change>,
     opts: &ApplyOpts,
 ) -> Result<()>
 where
@@ -100,7 +98,7 @@ where
 pub async fn apply_relation_changes_with<S, T>(
     sink: &S,
     transformer: Arc<T>,
-    changes: Vec<UniversalRelationChange>,
+    changes: Vec<RelationChange>,
     opts: &ApplyOpts,
 ) -> Result<()>
 where
@@ -122,7 +120,7 @@ where
 pub async fn write_rows_with<S, T>(
     sink: &S,
     transformer: Arc<T>,
-    rows: Vec<UniversalRow>,
+    rows: Vec<Row>,
     opts: &ApplyOpts,
 ) -> Result<()>
 where
@@ -136,7 +134,7 @@ where
     // so max_in_flight can absorb slow transforms within a chunk.
     let mut ctx = ApplyContext::new(sink, transformer, opts);
     for (i, row) in rows.into_iter().enumerate() {
-        let change = UniversalChange::update(row.table, row.id, row.fields);
+        let change = Change::update(row.table, row.id, row.fields);
         ctx.push_change(change, i as u64).await?;
     }
     ctx.flush().await?;
@@ -147,7 +145,7 @@ where
 pub async fn write_relations_with<S, T>(
     sink: &S,
     transformer: Arc<T>,
-    relations: Vec<UniversalRelation>,
+    relations: Vec<Relation>,
     opts: &ApplyOpts,
 ) -> Result<()>
 where
@@ -159,7 +157,7 @@ where
     }
     let mut ctx = ApplyContext::new(sink, transformer, opts);
     for (i, relation) in relations.into_iter().enumerate() {
-        let change = UniversalRelationChange::update(relation);
+        let change = RelationChange::update(relation);
         ctx.push_relation_change(change, i as u64).await?;
     }
     ctx.flush().await?;
@@ -169,8 +167,8 @@ where
 /// Ordered sink apply for a transformed batch.
 ///
 /// Homogeneous upsert (`Update`) batches coalesce to
-/// [`SurrealSink::write_universal_rows`] /
-/// [`SurrealSink::write_universal_relations`] so large `write_rows` /
+/// [`SurrealSink::write_rows`] /
+/// [`SurrealSink::write_relations`] so large `write_rows` /
 /// `write_relations` vecs keep a bulk trait call **inside** the window. CDC
 /// `Create` / `Delete` (and mixed batches) stay on per-event apply.
 pub(crate) async fn apply_transformed_sink_events<S: SurrealSink>(
@@ -181,46 +179,38 @@ pub(crate) async fn apply_transformed_sink_events<S: SurrealSink>(
         return Ok(());
     }
     if let Some(rows) = try_coalesce_row_upserts(events) {
-        return sink
-            .write_universal_rows(&rows)
-            .await
-            .context("sink write_universal_rows");
+        return sink.write_rows(&rows).await.context("sink write_rows");
     }
     if let Some(relations) = try_coalesce_relation_upserts(events) {
         return sink
-            .write_universal_relations(&relations)
+            .write_relations(&relations)
             .await
-            .context("sink write_universal_relations");
+            .context("sink write_relations");
     }
     for event in events {
         match event {
             ApplyEvent::Change(change) => {
-                sink.apply_universal_change(change)
+                sink.apply_change(change)
                     .await
-                    .context("sink apply_universal_change")?;
+                    .context("sink apply_change")?;
             }
             ApplyEvent::RelationChange(change) => {
-                sink.apply_universal_relation_change(change)
+                sink.apply_relation_change(change)
                     .await
-                    .context("sink apply_universal_relation_change")?;
+                    .context("sink apply_relation_change")?;
             }
         }
     }
     Ok(())
 }
 
-fn try_coalesce_row_upserts(events: &[ApplyEvent]) -> Option<Vec<UniversalRow>> {
+fn try_coalesce_row_upserts(events: &[ApplyEvent]) -> Option<Vec<Row>> {
     let mut rows = Vec::with_capacity(events.len());
     for event in events {
         match event {
-            ApplyEvent::Change(change) if change.operation == UniversalChangeOp::Update => {
-                let data = change.data.as_ref()?.clone();
-                rows.push(UniversalRow::new(
-                    change.table.clone(),
-                    0,
-                    change.id.clone(),
-                    data,
-                ));
+            ApplyEvent::Change(change) if change.operation == ChangeOp::Update => {
+                let data = change.fields.as_ref()?.clone();
+                rows.push(Row::new(change.table.clone(), 0, change.id.clone(), data));
             }
             _ => return None,
         }
@@ -228,11 +218,11 @@ fn try_coalesce_row_upserts(events: &[ApplyEvent]) -> Option<Vec<UniversalRow>> 
     Some(rows)
 }
 
-fn try_coalesce_relation_upserts(events: &[ApplyEvent]) -> Option<Vec<UniversalRelation>> {
+fn try_coalesce_relation_upserts(events: &[ApplyEvent]) -> Option<Vec<Relation>> {
     let mut relations = Vec::with_capacity(events.len());
     for event in events {
         match event {
-            ApplyEvent::RelationChange(change) if change.operation == UniversalChangeOp::Update => {
+            ApplyEvent::RelationChange(change) if change.operation == ChangeOp::Update => {
                 relations.push(change.relation.clone());
             }
             _ => return None,
@@ -314,7 +304,7 @@ pub(crate) struct PreparedSinkBatch<P> {
 /// Library / custom-loop driver sharing the same ordered apply path as
 /// [`crate::run_source_runtime`].
 ///
-/// Accepts row [`UniversalChange`] and [`UniversalRelationChange`] into one
+/// Accepts row [`Change`] and [`RelationChange`] into one
 /// buffer / window. Identity and non-identity pipelines share one path: every
 /// batch is spawned onto the transform [`JoinSet`] (identity is an async
 /// no-op). Sink apply is ordered and may overlap with polling / transforming
@@ -468,7 +458,7 @@ where
     /// Push one row change; may start transforms and drain ordered sink.
     ///
     /// Returns the last position successfully sunk (caller should `advance_watermark`).
-    pub async fn push_change(&mut self, change: UniversalChange, position: P) -> Result<Option<P>> {
+    pub async fn push_change(&mut self, change: Change, position: P) -> Result<Option<P>> {
         self.ensure_not_poisoned()?;
         self.push_buffered_event(PositionedEvent::change(change, position));
         while self.try_start_full_batch() {}
@@ -479,7 +469,7 @@ where
     /// Push one relation change into the same window as row changes.
     pub async fn push_relation_change(
         &mut self,
-        change: UniversalRelationChange,
+        change: RelationChange,
         position: P,
     ) -> Result<Option<P>> {
         self.ensure_not_poisoned()?;
@@ -551,13 +541,13 @@ where
     }
 
     /// Transform then sink rows (same as [`write_rows_with`]).
-    pub async fn write_rows(&self, rows: Vec<UniversalRow>) -> Result<()> {
+    pub async fn write_rows(&self, rows: Vec<Row>) -> Result<()> {
         self.ensure_not_poisoned()?;
         write_rows_with(self.sink, Arc::clone(&self.transformer), rows, self.opts).await
     }
 
     /// Transform then sink relations (same as [`write_relations_with`]).
-    pub async fn write_relations(&self, relations: Vec<UniversalRelation>) -> Result<()> {
+    pub async fn write_relations(&self, relations: Vec<Relation>) -> Result<()> {
         self.ensure_not_poisoned()?;
         write_relations_with(
             self.sink,

--- a/crates/sync-transform/src/apply/source_driver.rs
+++ b/crates/sync-transform/src/apply/source_driver.rs
@@ -19,7 +19,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use surreal_sink::SurrealSink;
-use sync_core::{UniversalChange, UniversalRelation, UniversalRelationChange, UniversalRow};
+use sync_core::{Change, Relation, RelationChange, Row};
 use tracing::debug;
 
 /// Signal from [`SourceDriver::between_events`] for side work between polls.
@@ -101,17 +101,17 @@ pub enum RuntimeExit {
 /// durability bypass of the pipeline.
 #[async_trait::async_trait]
 pub trait AdhocApply: Send + Sync {
-    /// Transform + `write_universal_rows` via the runtime’s pipeline and opts.
-    async fn write_rows(&self, rows: Vec<UniversalRow>) -> Result<()>;
+    /// Transform + `write_rows` via the runtime’s pipeline and opts.
+    async fn write_rows(&self, rows: Vec<Row>) -> Result<()>;
 
-    /// Transform + `write_universal_relations`.
-    async fn write_relations(&self, relations: Vec<UniversalRelation>) -> Result<()>;
+    /// Transform + `write_relations`.
+    async fn write_relations(&self, relations: Vec<Relation>) -> Result<()>;
 
     /// Transform + apply each row change.
-    async fn apply_changes(&self, changes: Vec<UniversalChange>) -> Result<()>;
+    async fn apply_changes(&self, changes: Vec<Change>) -> Result<()>;
 
     /// Transform + apply each relation change.
-    async fn apply_relation_changes(&self, changes: Vec<UniversalRelationChange>) -> Result<()>;
+    async fn apply_relation_changes(&self, changes: Vec<RelationChange>) -> Result<()>;
 
     /// Borrow the apply options used by the incremental loop.
     fn apply_opts(&self) -> &ApplyOpts;
@@ -129,7 +129,7 @@ where
     S: SurrealSink,
     T: BatchTransformer + 'static,
 {
-    async fn write_rows(&self, rows: Vec<UniversalRow>) -> Result<()> {
+    async fn write_rows(&self, rows: Vec<Row>) -> Result<()> {
         write_rows_with(
             self.sink,
             Arc::clone(&self.transformer),
@@ -139,7 +139,7 @@ where
         .await
     }
 
-    async fn write_relations(&self, relations: Vec<UniversalRelation>) -> Result<()> {
+    async fn write_relations(&self, relations: Vec<Relation>) -> Result<()> {
         write_relations_with(
             self.sink,
             Arc::clone(&self.transformer),
@@ -149,7 +149,7 @@ where
         .await
     }
 
-    async fn apply_changes(&self, changes: Vec<UniversalChange>) -> Result<()> {
+    async fn apply_changes(&self, changes: Vec<Change>) -> Result<()> {
         apply_changes_with(
             self.sink,
             Arc::clone(&self.transformer),
@@ -159,7 +159,7 @@ where
         .await
     }
 
-    async fn apply_relation_changes(&self, changes: Vec<UniversalRelationChange>) -> Result<()> {
+    async fn apply_relation_changes(&self, changes: Vec<RelationChange>) -> Result<()> {
         apply_relation_changes_with(
             self.sink,
             Arc::clone(&self.transformer),

--- a/crates/sync-transform/src/apply/transform.rs
+++ b/crates/sync-transform/src/apply/transform.rs
@@ -4,7 +4,7 @@ use crate::apply::ApplyEvent;
 use crate::pipeline::Pipeline;
 use anyhow::{bail, Result};
 use async_trait::async_trait;
-use sync_core::{UniversalChange, UniversalRelation, UniversalRelationChange, UniversalRow};
+use sync_core::{Change, Relation, RelationChange, Row};
 
 /// Executes a transform for one numbered batch.
 ///
@@ -37,18 +37,10 @@ pub trait BatchTransformer: Send + Sync {
     fn is_identity(&self) -> bool;
 
     /// Transform an owned change batch. `batch_id` is monotonic per apply run.
-    async fn transform_changes(
-        &self,
-        batch_id: u64,
-        changes: Vec<UniversalChange>,
-    ) -> Result<Vec<UniversalChange>>;
+    async fn transform_changes(&self, batch_id: u64, changes: Vec<Change>) -> Result<Vec<Change>>;
 
     /// Transform an owned row batch.
-    async fn transform_rows(
-        &self,
-        batch_id: u64,
-        rows: Vec<UniversalRow>,
-    ) -> Result<Vec<UniversalRow>>;
+    async fn transform_rows(&self, batch_id: u64, rows: Vec<Row>) -> Result<Vec<Row>>;
 
     /// Transform an owned relation-change batch.
     ///
@@ -59,8 +51,8 @@ pub trait BatchTransformer: Send + Sync {
     async fn transform_relation_changes(
         &self,
         _batch_id: u64,
-        _changes: Vec<UniversalRelationChange>,
-    ) -> Result<Vec<UniversalRelationChange>> {
+        _changes: Vec<RelationChange>,
+    ) -> Result<Vec<RelationChange>> {
         bail!(
             "BatchTransformer::transform_relation_changes is not implemented; \
              override it (or return Ok(changes) for explicit passthrough), or use Pipeline"
@@ -73,8 +65,8 @@ pub trait BatchTransformer: Send + Sync {
     async fn transform_relations(
         &self,
         _batch_id: u64,
-        _relations: Vec<UniversalRelation>,
-    ) -> Result<Vec<UniversalRelation>> {
+        _relations: Vec<Relation>,
+    ) -> Result<Vec<Relation>> {
         bail!(
             "BatchTransformer::transform_relations is not implemented; \
              override it (or return Ok(relations) for explicit passthrough), or use Pipeline"
@@ -156,35 +148,27 @@ impl BatchTransformer for Pipeline {
         Pipeline::is_identity(self)
     }
 
-    async fn transform_changes(
-        &self,
-        batch_id: u64,
-        changes: Vec<UniversalChange>,
-    ) -> Result<Vec<UniversalChange>> {
+    async fn transform_changes(&self, batch_id: u64, changes: Vec<Change>) -> Result<Vec<Change>> {
         self.apply_changes_async(batch_id, changes).await
     }
 
-    async fn transform_rows(
-        &self,
-        batch_id: u64,
-        rows: Vec<UniversalRow>,
-    ) -> Result<Vec<UniversalRow>> {
+    async fn transform_rows(&self, batch_id: u64, rows: Vec<Row>) -> Result<Vec<Row>> {
         self.apply_rows_async(batch_id, rows).await
     }
 
     async fn transform_relation_changes(
         &self,
         batch_id: u64,
-        changes: Vec<UniversalRelationChange>,
-    ) -> Result<Vec<UniversalRelationChange>> {
+        changes: Vec<RelationChange>,
+    ) -> Result<Vec<RelationChange>> {
         self.apply_relation_changes_async(batch_id, changes).await
     }
 
     async fn transform_relations(
         &self,
         batch_id: u64,
-        relations: Vec<UniversalRelation>,
-    ) -> Result<Vec<UniversalRelation>> {
+        relations: Vec<Relation>,
+    ) -> Result<Vec<Relation>> {
         self.apply_relations_async(batch_id, relations).await
     }
 

--- a/crates/sync-transform/src/apply_tests.rs
+++ b/crates/sync-transform/src/apply_tests.rs
@@ -11,33 +11,30 @@ use anyhow::Result;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
-use sync_core::{
-    UniversalChange, UniversalRelation, UniversalRelationChange, UniversalRow, UniversalThingRef,
-    UniversalValue,
-};
+use sync_core::{Change, Relation, RelationChange, Row, ThingRef, Value};
 use tokio::time::timeout;
 
-fn change(id: i64) -> UniversalChange {
+fn change(id: i64) -> Change {
     let mut data = HashMap::new();
     data.insert(
         "name".to_string(),
-        UniversalValue::VarChar {
+        Value::VarChar {
             value: format!("row-{id}"),
             length: 64,
         },
     );
-    UniversalChange::create("users", UniversalValue::Int64(id), data)
+    Change::create("users", Value::Int64(id), data)
 }
 
 fn positioned(id: i64, pos: u64) -> PositionedChange<u64> {
     PositionedChange::new(change(id), pos)
 }
 
-fn row(id: i64) -> UniversalRow {
-    UniversalRow::builder("users", id as u64, UniversalValue::Int64(id))
+fn row(id: i64) -> Row {
+    Row::builder("users", id as u64, Value::Int64(id))
         .field(
             "name",
-            UniversalValue::VarChar {
+            Value::VarChar {
                 value: format!("row-{id}"),
                 length: 64,
             },
@@ -48,22 +45,16 @@ fn row(id: i64) -> UniversalRow {
 struct TagName;
 
 impl InPlaceTransform for TagName {
-    fn transform_row(&self, row: &mut UniversalRow) -> Result<()> {
-        row.fields.insert(
-            "name".to_string(),
-            UniversalValue::VarChar {
-                value: "tagged".to_string(),
-                length: 64,
-            },
-        );
-        Ok(())
-    }
-
-    fn transform_change(&self, change: &mut UniversalChange) -> Result<()> {
-        if let Some(data) = change.data.as_mut() {
-            data.insert(
+    fn transform(
+        &self,
+        _table: &str,
+        _id: &mut Value,
+        fields: Option<&mut HashMap<String, Value>>,
+    ) -> Result<()> {
+        if let Some(fields) = fields {
+            fields.insert(
                 "name".to_string(),
-                UniversalValue::VarChar {
+                Value::VarChar {
                     value: "tagged".to_string(),
                     length: 64,
                 },
@@ -106,11 +97,7 @@ async fn identity_pipeline_advances_track_sink() {
             .iter()
             .map(|c| c.id.clone())
             .collect::<Vec<_>>(),
-        vec![
-            UniversalValue::Int64(1),
-            UniversalValue::Int64(2),
-            UniversalValue::Int64(3),
-        ]
+        vec![Value::Int64(1), Value::Int64(2), Value::Int64(3),]
     );
 }
 
@@ -118,7 +105,7 @@ async fn identity_pipeline_advances_track_sink() {
 async fn write_rows_identity_uses_apply_context() {
     // Omit `--transforms-config` → ApplyOpts::identity() (W=1, batch_size=1).
     // Every path goes through ApplyContext; identity upserts coalesce to
-    // write_universal_rows inside the ordered sink step (not a oneshot bypass).
+    // write_rows inside the ordered sink step (not a oneshot bypass).
     let pipeline = Pipeline::new();
     assert!(pipeline.is_identity());
     let sink = RecordingSink::new();
@@ -133,11 +120,11 @@ async fn write_rows_identity_uses_apply_context() {
     assert_eq!(written.len(), 2);
     assert_eq!(written[0].len(), 1);
     assert_eq!(written[1].len(), 1);
-    assert_eq!(written[0][0].id, UniversalValue::Int64(1));
-    assert_eq!(written[1][0].id, UniversalValue::Int64(2));
+    assert_eq!(written[0][0].id, Value::Int64(1));
+    assert_eq!(written[1][0].id, Value::Int64(2));
     assert!(
         sink.applied().is_empty(),
-        "identity upserts coalesce to write_universal_rows inside the window"
+        "identity upserts coalesce to write_rows inside the window"
     );
 }
 
@@ -156,13 +143,13 @@ async fn write_rows_identity_windowed_when_max_in_flight_gt_1() {
     assert_eq!(sink.rows_written().len(), 2);
     assert!(
         sink.applied().is_empty(),
-        "identity upserts coalesce to write_universal_rows, not per-change apply"
+        "identity upserts coalesce to write_rows, not per-change apply"
     );
 }
 
 #[tokio::test]
 async fn write_rows_coalesces_homogeneous_upsert_batch() {
-    // Larger batch_size keeps a single bulk write_universal_rows inside the window.
+    // Larger batch_size keeps a single bulk write_rows inside the window.
     let pipeline = Pipeline::new();
     let sink = RecordingSink::new();
     let opts = ApplyOpts::default()
@@ -180,7 +167,7 @@ async fn write_rows_coalesces_homogeneous_upsert_batch() {
 #[tokio::test]
 async fn write_rows_honors_max_in_flight_window() {
     // Non-identity + W>1 must use ApplyContext; upserts coalesce to
-    // write_universal_rows inside the ordered sink (still windowed).
+    // write_rows inside the ordered sink (still windowed).
     let mut pipeline = Pipeline::new();
     pipeline.push_inplace(TagName);
     let sink = RecordingSink::new();
@@ -194,7 +181,7 @@ async fn write_rows_honors_max_in_flight_window() {
         assert_eq!(batch.len(), 1);
         assert_eq!(
             batch[0].fields.get("name"),
-            Some(&UniversalValue::VarChar {
+            Some(&Value::VarChar {
                 value: "tagged".to_string(),
                 length: 64,
             })
@@ -202,13 +189,13 @@ async fn write_rows_honors_max_in_flight_window() {
     }
     assert!(
         sink.applied().is_empty(),
-        "windowed write_rows upserts coalesce to write_universal_rows"
+        "windowed write_rows upserts coalesce to write_rows"
     );
 }
 
 #[tokio::test]
 async fn delete_and_mixed_batches_use_per_event_apply() {
-    // Delete (and mixed Update+Delete) must not coalesce to write_universal_rows.
+    // Delete (and mixed Update+Delete) must not coalesce to write_rows.
     let pipeline = Pipeline::new();
     let opts = ApplyOpts::default()
         .with_batch_size(10)
@@ -219,8 +206,8 @@ async fn delete_and_mixed_batches_use_per_event_apply() {
         &sink,
         &pipeline,
         vec![
-            UniversalChange::delete("users", UniversalValue::Int64(1)),
-            UniversalChange::delete("users", UniversalValue::Int64(2)),
+            Change::delete("users", Value::Int64(1)),
+            Change::delete("users", Value::Int64(2)),
         ],
         &opts,
     )
@@ -229,14 +216,14 @@ async fn delete_and_mixed_batches_use_per_event_apply() {
     assert_eq!(sink.applied().len(), 2);
     assert!(
         sink.rows_written().is_empty(),
-        "Delete batches stay on apply_universal_change, not write_universal_rows"
+        "Delete batches stay on apply_change, not write_rows"
     );
 
     let sink = RecordingSink::new();
     let mut update_data = HashMap::new();
     update_data.insert(
         "name".to_string(),
-        UniversalValue::VarChar {
+        Value::VarChar {
             value: "alice".to_string(),
             length: 64,
         },
@@ -245,8 +232,8 @@ async fn delete_and_mixed_batches_use_per_event_apply() {
         &sink,
         &pipeline,
         vec![
-            UniversalChange::update("users", UniversalValue::Int64(1), update_data),
-            UniversalChange::delete("users", UniversalValue::Int64(2)),
+            Change::update("users", Value::Int64(1), update_data),
+            Change::delete("users", Value::Int64(2)),
         ],
         &opts,
     )
@@ -255,7 +242,7 @@ async fn delete_and_mixed_batches_use_per_event_apply() {
     assert_eq!(sink.applied().len(), 2);
     assert!(
         sink.rows_written().is_empty(),
-        "mixed Update+Delete must not coalesce to write_universal_rows"
+        "mixed Update+Delete must not coalesce to write_rows"
     );
 }
 
@@ -275,8 +262,8 @@ async fn inplace_stages_mutate_before_sink() {
     let applied = sink.applied();
     assert_eq!(applied.len(), 1);
     assert_eq!(
-        applied[0].data.as_ref().unwrap().get("name"),
-        Some(&UniversalValue::VarChar {
+        applied[0].fields.as_ref().unwrap().get("name"),
+        Some(&Value::VarChar {
             value: "tagged".to_string(),
             length: 64,
         })
@@ -344,7 +331,7 @@ async fn window_former_fails_after_later_transform_succeeds() {
             .iter()
             .map(|c| c.id.clone())
             .collect::<Vec<_>>(),
-        vec![UniversalValue::Int64(1), UniversalValue::Int64(2)]
+        vec![Value::Int64(1), Value::Int64(2)]
     );
     assert_eq!(feed2.advances, vec![100, 200]);
 }
@@ -517,7 +504,7 @@ async fn failure_policy_skip_advances_past_failed_batch() {
 
     // Failed batch not written; still advanced past it; successor applied.
     assert_eq!(sink.applied().len(), 1);
-    assert_eq!(sink.applied()[0].id, UniversalValue::Int64(2));
+    assert_eq!(sink.applied()[0].id, Value::Int64(2));
     assert_eq!(feed.advances, vec![10, 20]);
 }
 
@@ -542,7 +529,7 @@ async fn crash_replay_from_last_advance() {
     );
     assert_eq!(feed.advances, vec![100]);
     assert_eq!(sink.applied().len(), 1);
-    assert_eq!(sink.applied()[0].id, UniversalValue::Int64(1));
+    assert_eq!(sink.applied()[0].id, Value::Int64(1));
 
     // Replay from last watermark advance: only unadvanced B remains.
     let mut feed2 = ScriptedChangeFeed::from_remaining(vec![positioned(2, 200)]);
@@ -555,7 +542,7 @@ async fn crash_replay_from_last_advance() {
 
     assert_eq!(feed2.advances, vec![200]);
     assert_eq!(sink2.applied().len(), 1);
-    assert_eq!(sink2.applied()[0].id, UniversalValue::Int64(2));
+    assert_eq!(sink2.applied()[0].id, Value::Int64(2));
 }
 
 #[tokio::test]
@@ -584,7 +571,7 @@ async fn ordered_sink_despite_out_of_order_transform_completion() {
             .iter()
             .map(|c| c.id.clone())
             .collect::<Vec<_>>(),
-        vec![UniversalValue::Int64(1), UniversalValue::Int64(2)]
+        vec![Value::Int64(1), Value::Int64(2)]
     );
     assert_eq!(feed.advances, vec![100, 200]);
 }
@@ -610,7 +597,7 @@ async fn apply_context_push_change_flush_watermarks() {
             .iter()
             .map(|c| c.id.clone())
             .collect::<Vec<_>>(),
-        vec![UniversalValue::Int64(1), UniversalValue::Int64(2)]
+        vec![Value::Int64(1), Value::Int64(2)]
     );
 
     // Nothing buffered → flush returns None.
@@ -663,7 +650,7 @@ async fn apply_context_flush_partial_buffer_w2() {
             .iter()
             .map(|c| c.id.clone())
             .collect::<Vec<_>>(),
-        vec![UniversalValue::Int64(1), UniversalValue::Int64(2)],
+        vec![Value::Int64(1), Value::Int64(2)],
         "sink must stay ordered A then B"
     );
 }
@@ -697,7 +684,7 @@ async fn flush_fully_drains_w1_queued_buffer() {
             .iter()
             .map(|c| c.id.clone())
             .collect::<Vec<_>>(),
-        vec![UniversalValue::Int64(1), UniversalValue::Int64(2)]
+        vec![Value::Int64(1), Value::Int64(2)]
     );
 }
 
@@ -746,17 +733,17 @@ async fn apply_context_skip_returns_watermark_without_sinking_failed() {
     // flush clears any residual in-flight; watermark already advanced on push.
     assert_eq!(ctx.flush().await.unwrap(), None);
     assert_eq!(sink.applied().len(), 1);
-    assert_eq!(sink.applied()[0].id, UniversalValue::Int64(2));
+    assert_eq!(sink.applied()[0].id, Value::Int64(2));
 }
 
 // --- Relations (first-class apply) ---
 
-fn relation(id: i64) -> UniversalRelation {
-    UniversalRelation::new(
+fn relation(id: i64) -> Relation {
+    Relation::new(
         "follows",
-        UniversalValue::Int64(id),
-        UniversalThingRef::new("users", UniversalValue::Int64(id)),
-        UniversalThingRef::new("users", UniversalValue::Int64(id + 1)),
+        Value::Int64(id),
+        ThingRef::new("users", Value::Int64(id)),
+        ThingRef::new("users", Value::Int64(id + 1)),
         HashMap::new(),
     )
 }
@@ -772,7 +759,7 @@ async fn apply_context_push_flush_relations_ordered_with_changes() {
     assert_eq!(wm, Some(10));
 
     let wm = ctx
-        .push_relation_change(UniversalRelationChange::create(relation(5)), 20u64)
+        .push_relation_change(RelationChange::create(relation(5)), 20u64)
         .await
         .unwrap();
     assert_eq!(wm, Some(20));
@@ -801,7 +788,7 @@ async fn apply_context_relation_fail_poisons_like_changes() {
     let mut ctx = ApplyContext::new(&sink, Arc::new(transformer), &opts);
 
     let err = ctx
-        .push_relation_change(UniversalRelationChange::create(relation(1)), 10u64)
+        .push_relation_change(RelationChange::create(relation(1)), 10u64)
         .await
         .unwrap_err();
     assert!(format!("{err:#}").contains("rel-fail"));
@@ -810,7 +797,7 @@ async fn apply_context_relation_fail_poisons_like_changes() {
     assert!(sink.applied().is_empty());
 
     let reuse = ctx
-        .push_relation_change(UniversalRelationChange::create(relation(2)), 20u64)
+        .push_relation_change(RelationChange::create(relation(2)), 20u64)
         .await
         .unwrap_err();
     assert!(format!("{reuse:#}").contains("poisoned"));
@@ -824,7 +811,7 @@ async fn write_relations_via_apply_context() {
     let ctx: ApplyContext<'_, _, _, ()> = ApplyContext::new(&sink, Arc::new(pipeline), &opts);
     ctx.write_relations(vec![relation(1)]).await.unwrap();
     assert_eq!(sink.relations_written().len(), 1);
-    assert_eq!(sink.relations_written()[0][0].id, UniversalValue::Int64(1));
+    assert_eq!(sink.relations_written()[0][0].id, Value::Int64(1));
 }
 
 #[tokio::test]
@@ -835,16 +822,13 @@ async fn apply_relation_changes_helper() {
     apply_relation_changes(
         &sink,
         &pipeline,
-        vec![UniversalRelationChange::create(relation(9))],
+        vec![RelationChange::create(relation(9))],
         &opts,
     )
     .await
     .unwrap();
     assert_eq!(sink.relations_applied().len(), 1);
-    assert_eq!(
-        sink.relations_applied()[0].relation.id,
-        UniversalValue::Int64(9)
-    );
+    assert_eq!(sink.relations_applied()[0].relation.id, Value::Int64(9));
 }
 
 /// W≥2 discard with a mixed relation+change batch window: A (change) fails after
@@ -864,7 +848,7 @@ async fn discard_on_failure_mixed_relation_and_change_w2() {
 
     assert!(ctx.push_change(change(1), 100u64).await.unwrap().is_none());
     assert!(ctx
-        .push_relation_change(UniversalRelationChange::create(relation(2)), 200u64)
+        .push_relation_change(RelationChange::create(relation(2)), 200u64)
         .await
         .unwrap()
         .is_none());

--- a/crates/sync-transform/src/bin/fixture_worker.rs
+++ b/crates/sync-transform/src/bin/fixture_worker.rs
@@ -77,8 +77,7 @@ fn main() {
 }
 
 fn mutate_name(item: &mut Value) {
-    // UniversalChange: data.name; UniversalRow / UniversalRelation: fields/data.name
-    // UniversalRelationChange: relation.data.name
+    // Change / Row: fields.name; Relation: data.name; RelationChange: relation.data.name
     mutate_name_in_maps(item);
     if let Some(relation) = item.get_mut("relation") {
         mutate_name_in_maps(relation);
@@ -86,9 +85,9 @@ fn mutate_name(item: &mut Value) {
 }
 
 fn mutate_name_in_maps(item: &mut Value) {
-    // UniversalValue tagged: {"type":"VarChar","value":{"value":"...","length":N}}
+    // Value tagged: {"type":"VarChar","value":{"value":"...","length":N}}
     //                    or: {"type":"Text","value":"..."}
-    for key in ["data", "fields"] {
+    for key in ["fields", "data"] {
         let Some(obj) = item.get_mut(key).and_then(|v| v.as_object_mut()) else {
             continue;
         };

--- a/crates/sync-transform/src/cow.rs
+++ b/crates/sync-transform/src/cow.rs
@@ -3,7 +3,7 @@
 use crate::inplace::InPlaceTransform;
 use anyhow::Result;
 use std::sync::Arc;
-use sync_core::{UniversalChange, UniversalRelation, UniversalRow};
+use sync_core::{Change, Relation, Row};
 
 /// Batch of `Arc`-shared items with copy-on-write mutation via [`Arc::make_mut`].
 ///
@@ -54,7 +54,7 @@ impl<T> CowBatch<T> {
     }
 }
 
-impl CowBatch<UniversalRow> {
+impl CowBatch<Row> {
     /// Apply an in-place transform with Arc COW semantics.
     ///
     /// Always calls [`Arc::make_mut`] per item. Clones when the arc is shared
@@ -68,7 +68,7 @@ impl CowBatch<UniversalRow> {
     }
 }
 
-impl CowBatch<UniversalChange> {
+impl CowBatch<Change> {
     /// Apply an in-place transform with Arc COW semantics.
     ///
     /// Always calls [`Arc::make_mut`] per item. Clones when the arc is shared
@@ -82,7 +82,7 @@ impl CowBatch<UniversalChange> {
     }
 }
 
-impl CowBatch<UniversalRelation> {
+impl CowBatch<Relation> {
     /// Apply an in-place transform with Arc COW semantics for relations.
     pub fn apply_inplace(&mut self, t: &impl InPlaceTransform) -> Result<()> {
         for item in &mut self.items {

--- a/crates/sync-transform/src/external/mod.rs
+++ b/crates/sync-transform/src/external/mod.rs
@@ -13,7 +13,7 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
-use sync_core::{UniversalChange, UniversalRelation, UniversalRelationChange, UniversalRow};
+use sync_core::{Change, Relation, RelationChange, Row};
 use tokio::sync::Mutex;
 
 use crate::framer::FramerKind;
@@ -197,41 +197,33 @@ impl ExternalTransform {
     pub async fn exchange_changes(
         &self,
         batch_id: u64,
-        changes: Vec<UniversalChange>,
-    ) -> Result<Vec<UniversalChange>> {
+        changes: Vec<Change>,
+    ) -> Result<Vec<Change>> {
         let items: Vec<Vec<u8>> = changes
             .iter()
-            .map(|c| serde_json::to_vec(c).context("serialize UniversalChange"))
+            .map(|c| serde_json::to_vec(c).context("serialize Change"))
             .collect::<Result<Vec<_>>>()?;
         let resp = self
             .exchange_raw(batch_id, &items, WireItemKind::Change)
             .await?;
         resp.items
             .into_iter()
-            .map(|bytes| {
-                serde_json::from_slice(&bytes).context("deserialize UniversalChange from worker")
-            })
+            .map(|bytes| serde_json::from_slice(&bytes).context("deserialize Change from worker"))
             .collect()
     }
 
     /// Exchange a row batch with the worker.
-    pub async fn exchange_rows(
-        &self,
-        batch_id: u64,
-        rows: Vec<UniversalRow>,
-    ) -> Result<Vec<UniversalRow>> {
+    pub async fn exchange_rows(&self, batch_id: u64, rows: Vec<Row>) -> Result<Vec<Row>> {
         let items: Vec<Vec<u8>> = rows
             .iter()
-            .map(|r| serde_json::to_vec(r).context("serialize UniversalRow"))
+            .map(|r| serde_json::to_vec(r).context("serialize Row"))
             .collect::<Result<Vec<_>>>()?;
         let resp = self
             .exchange_raw(batch_id, &items, WireItemKind::Row)
             .await?;
         resp.items
             .into_iter()
-            .map(|bytes| {
-                serde_json::from_slice(&bytes).context("deserialize UniversalRow from worker")
-            })
+            .map(|bytes| serde_json::from_slice(&bytes).context("deserialize Row from worker"))
             .collect()
     }
 
@@ -239,11 +231,11 @@ impl ExternalTransform {
     pub async fn exchange_relation_changes(
         &self,
         batch_id: u64,
-        changes: Vec<UniversalRelationChange>,
-    ) -> Result<Vec<UniversalRelationChange>> {
+        changes: Vec<RelationChange>,
+    ) -> Result<Vec<RelationChange>> {
         let items: Vec<Vec<u8>> = changes
             .iter()
-            .map(|c| serde_json::to_vec(c).context("serialize UniversalRelationChange"))
+            .map(|c| serde_json::to_vec(c).context("serialize RelationChange"))
             .collect::<Result<Vec<_>>>()?;
         let resp = self
             .exchange_raw(batch_id, &items, WireItemKind::RelationChange)
@@ -251,8 +243,7 @@ impl ExternalTransform {
         resp.items
             .into_iter()
             .map(|bytes| {
-                serde_json::from_slice(&bytes)
-                    .context("deserialize UniversalRelationChange from worker")
+                serde_json::from_slice(&bytes).context("deserialize RelationChange from worker")
             })
             .collect()
     }
@@ -261,20 +252,18 @@ impl ExternalTransform {
     pub async fn exchange_relations(
         &self,
         batch_id: u64,
-        relations: Vec<UniversalRelation>,
-    ) -> Result<Vec<UniversalRelation>> {
+        relations: Vec<Relation>,
+    ) -> Result<Vec<Relation>> {
         let items: Vec<Vec<u8>> = relations
             .iter()
-            .map(|r| serde_json::to_vec(r).context("serialize UniversalRelation"))
+            .map(|r| serde_json::to_vec(r).context("serialize Relation"))
             .collect::<Result<Vec<_>>>()?;
         let resp = self
             .exchange_raw(batch_id, &items, WireItemKind::Relation)
             .await?;
         resp.items
             .into_iter()
-            .map(|bytes| {
-                serde_json::from_slice(&bytes).context("deserialize UniversalRelation from worker")
-            })
+            .map(|bytes| serde_json::from_slice(&bytes).context("deserialize Relation from worker"))
             .collect()
     }
 

--- a/crates/sync-transform/src/external/wire.rs
+++ b/crates/sync-transform/src/external/wire.rs
@@ -10,14 +10,14 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum WireItemKind {
-    /// Incremental row [`sync_core::UniversalChange`] items.
+    /// Incremental row [`sync_core::Change`] items.
     #[default]
     Change,
-    /// Full-sync / snapshot [`sync_core::UniversalRow`] items.
+    /// Full-sync / snapshot [`sync_core::Row`] items.
     Row,
-    /// Incremental relation [`sync_core::UniversalRelationChange`] items.
+    /// Incremental relation [`sync_core::RelationChange`] items.
     RelationChange,
-    /// Full-sync [`sync_core::UniversalRelation`] items.
+    /// Full-sync [`sync_core::Relation`] items.
     Relation,
 }
 

--- a/crates/sync-transform/src/external_tests.rs
+++ b/crates/sync-transform/src/external_tests.rs
@@ -7,19 +7,19 @@ use crate::{run_change_feed, ApplyOpts, ExternalTransform, Pipeline, PositionedC
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
-use sync_core::{UniversalChange, UniversalValue};
+use sync_core::{Change, Value};
 use tokio::time::timeout;
 
-fn change(id: i64) -> UniversalChange {
+fn change(id: i64) -> Change {
     let mut data = HashMap::new();
     data.insert(
         "name".to_string(),
-        UniversalValue::VarChar {
+        Value::VarChar {
             value: format!("row-{id}"),
             length: 64,
         },
     );
-    UniversalChange::create("users", UniversalValue::Int64(id), data)
+    Change::create("users", Value::Int64(id), data)
 }
 
 fn positioned(id: i64, pos: u64) -> PositionedChange<u64> {
@@ -48,8 +48,8 @@ async fn scripted_external_echo_and_out_of_order() {
 
     let out_b = b.await.unwrap().unwrap();
     let out_a = a.await.unwrap().unwrap();
-    assert_eq!(out_a[0].id, UniversalValue::Int64(1));
-    assert_eq!(out_b[0].id, UniversalValue::Int64(2));
+    assert_eq!(out_a[0].id, Value::Int64(1));
+    assert_eq!(out_b[0].id, Value::Int64(2));
     assert_eq!(transport.write_order(), vec![1, 2]);
 }
 
@@ -179,7 +179,7 @@ async fn colliding_mismatched_batch_id_exchange_fails_closed() {
     );
     // Batch 2 keeps its own request-keyed response (correct echo), proving we
     // did not deliver batch 1's payload under id 2.
-    assert_eq!(out_b[0].id, UniversalValue::Int64(2));
+    assert_eq!(out_b[0].id, Value::Int64(2));
 }
 
 #[tokio::test]
@@ -235,23 +235,23 @@ async fn scripted_external_happy_path_sinks_and_advances() {
 
 #[tokio::test]
 async fn external_exchanges_relation_changes_over_wire() {
-    use sync_core::{UniversalRelation, UniversalRelationChange, UniversalThingRef};
+    use sync_core::{Relation, RelationChange, ThingRef};
 
     let transport = ScriptedExternalTransport::new();
     let ext = ExternalTransform::with_transport(Arc::new(transport.clone()));
-    let rel = UniversalRelation::new(
+    let rel = Relation::new(
         "follows",
-        UniversalValue::Int64(7),
-        UniversalThingRef::new("users", UniversalValue::Int64(1)),
-        UniversalThingRef::new("users", UniversalValue::Int64(2)),
+        Value::Int64(7),
+        ThingRef::new("users", Value::Int64(1)),
+        ThingRef::new("users", Value::Int64(2)),
         HashMap::new(),
     );
     let out = ext
-        .exchange_relation_changes(1, vec![UniversalRelationChange::create(rel)])
+        .exchange_relation_changes(1, vec![RelationChange::create(rel)])
         .await
         .unwrap();
     assert_eq!(out.len(), 1);
-    assert_eq!(out[0].relation.id, UniversalValue::Int64(7));
+    assert_eq!(out[0].relation.id, Value::Int64(7));
     assert_eq!(
         transport.write_kinds(),
         vec![(1, crate::WireItemKind::RelationChange)],
@@ -262,22 +262,22 @@ async fn external_exchanges_relation_changes_over_wire() {
 #[tokio::test]
 async fn external_pipeline_transforms_mixed_relation_and_change() {
     use crate::{run_source_runtime, PositionedEvent, SourceRuntimeOpts};
-    use sync_core::{UniversalRelation, UniversalRelationChange, UniversalThingRef};
+    use sync_core::{Relation, RelationChange, ThingRef};
 
     let transport = ScriptedExternalTransport::new();
     let mut pipeline = Pipeline::new();
     pipeline.push_external(ExternalTransform::with_transport(Arc::new(transport)));
 
-    let rel = UniversalRelation::new(
+    let rel = Relation::new(
         "follows",
-        UniversalValue::Int64(5),
-        UniversalThingRef::new("users", UniversalValue::Int64(5)),
-        UniversalThingRef::new("users", UniversalValue::Int64(6)),
+        Value::Int64(5),
+        ThingRef::new("users", Value::Int64(5)),
+        ThingRef::new("users", Value::Int64(6)),
         HashMap::new(),
     );
     let mut driver = crate::test_support::ScriptedSourceDriver::new(vec![
         PositionedEvent::change(change(1), 10u64),
-        PositionedEvent::relation_change(UniversalRelationChange::create(rel), 20u64),
+        PositionedEvent::relation_change(RelationChange::create(rel), 20u64),
     ]);
     let sink = RecordingSink::new();
     let opts = ApplyOpts::default()
@@ -307,7 +307,7 @@ async fn external_pipeline_transforms_mixed_relation_and_change() {
 #[tokio::test]
 async fn mixed_external_batch_uses_distinct_wire_batch_ids_and_kinds() {
     use crate::{relation_wire_batch_id, ApplyEvent, WireItemKind};
-    use sync_core::{UniversalRelation, UniversalRelationChange, UniversalThingRef};
+    use sync_core::{Relation, RelationChange, ThingRef};
 
     let transport = ScriptedExternalTransport::new();
     let mut pipeline = Pipeline::new();
@@ -315,16 +315,16 @@ async fn mixed_external_batch_uses_distinct_wire_batch_ids_and_kinds() {
         transport.clone(),
     )));
 
-    let rel = UniversalRelation::new(
+    let rel = Relation::new(
         "follows",
-        UniversalValue::Int64(9),
-        UniversalThingRef::new("users", UniversalValue::Int64(1)),
-        UniversalThingRef::new("users", UniversalValue::Int64(2)),
+        Value::Int64(9),
+        ThingRef::new("users", Value::Int64(1)),
+        ThingRef::new("users", Value::Int64(2)),
         HashMap::new(),
     );
     let events = vec![
         ApplyEvent::Change(change(1)),
-        ApplyEvent::relation_change(UniversalRelationChange::create(rel)),
+        ApplyEvent::relation_change(RelationChange::create(rel)),
     ];
     let out = pipeline.apply_events_async(42, events).await.unwrap();
     assert_eq!(out.len(), 2);

--- a/crates/sync-transform/src/flatten_id.rs
+++ b/crates/sync-transform/src/flatten_id.rs
@@ -2,14 +2,13 @@
 
 use crate::inplace::InPlaceTransform;
 use anyhow::Result;
-use sync_core::{
-    flatten_composite_id, UniversalChange, UniversalRelation, UniversalRelationChange, UniversalRow,
-};
+use std::collections::HashMap;
+use sync_core::{flatten_composite_id, Relation, RelationChange, Value};
 
 /// Default separator matching relation FK flattening and historical Snowflake IDs.
 pub const DEFAULT_FLATTEN_ID_SEPARATOR: &str = ":";
 
-/// Rewrite `UniversalValue::Array` record IDs to Text joined with [`Self::separator`].
+/// Rewrite `Value::Array` record IDs to Text joined with [`Self::separator`].
 ///
 /// Scalar IDs are left unchanged. Relation **edge** IDs are also flattened when
 /// they are Arrays (endpoint Thing refs are flattened the same way so links stay
@@ -38,39 +37,33 @@ impl FlattenId {
 }
 
 impl InPlaceTransform for FlattenId {
-    fn transform_row(&self, row: &mut UniversalRow) -> Result<()> {
-        row.id = flatten_composite_id(
-            std::mem::replace(&mut row.id, sync_core::UniversalValue::Null),
-            &self.separator,
-        );
+    fn transform(
+        &self,
+        _table: &str,
+        id: &mut Value,
+        _fields: Option<&mut HashMap<String, Value>>,
+    ) -> Result<()> {
+        *id = flatten_composite_id(std::mem::replace(id, Value::Null), &self.separator);
         Ok(())
     }
 
-    fn transform_change(&self, change: &mut UniversalChange) -> Result<()> {
-        change.id = flatten_composite_id(
-            std::mem::replace(&mut change.id, sync_core::UniversalValue::Null),
-            &self.separator,
-        );
-        Ok(())
-    }
-
-    fn transform_relation(&self, relation: &mut UniversalRelation) -> Result<()> {
+    fn transform_relation(&self, relation: &mut Relation) -> Result<()> {
         relation.id = flatten_composite_id(
-            std::mem::replace(&mut relation.id, sync_core::UniversalValue::Null),
+            std::mem::replace(&mut relation.id, Value::Null),
             &self.separator,
         );
         relation.input.id = flatten_composite_id(
-            std::mem::replace(&mut relation.input.id, sync_core::UniversalValue::Null),
+            std::mem::replace(&mut relation.input.id, Value::Null),
             &self.separator,
         );
         relation.output.id = flatten_composite_id(
-            std::mem::replace(&mut relation.output.id, sync_core::UniversalValue::Null),
+            std::mem::replace(&mut relation.output.id, Value::Null),
             &self.separator,
         );
         Ok(())
     }
 
-    fn transform_relation_change(&self, change: &mut UniversalRelationChange) -> Result<()> {
+    fn transform_relation_change(&self, change: &mut RelationChange) -> Result<()> {
         self.transform_relation(&mut change.relation)?;
         Ok(())
     }
@@ -79,30 +72,30 @@ impl InPlaceTransform for FlattenId {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sync_core::{UniversalType, UniversalValue};
+    use sync_core::{Row, Type, Value};
 
     #[test]
     fn flattens_array_row_id() {
         let t = FlattenId::default();
-        let mut row = UniversalRow::new(
+        let mut row = Row::new(
             "ledger",
             0,
-            UniversalValue::Array {
-                elements: vec![UniversalValue::Int32(1), UniversalValue::Int32(2)],
-                element_type: Box::new(UniversalType::Int32),
+            Value::Array {
+                elements: vec![Value::Int32(1), Value::Int32(2)],
+                element_type: Box::new(Type::Int32),
             },
             Default::default(),
         );
         t.transform_row(&mut row).unwrap();
-        assert_eq!(row.id, UniversalValue::Text("1:2".into()));
+        assert_eq!(row.id, Value::Text("1:2".into()));
     }
 
     #[test]
     fn leaves_scalar_unchanged() {
         let t = FlattenId::new("_");
-        let mut row = UniversalRow::new("t", 0, UniversalValue::Int64(9), Default::default());
+        let mut row = Row::new("t", 0, Value::Int64(9), Default::default());
         t.transform_row(&mut row).unwrap();
-        assert_eq!(row.id, UniversalValue::Int64(9));
+        assert_eq!(row.id, Value::Int64(9));
     }
 
     #[test]
@@ -119,19 +112,16 @@ separator = ":"
         .unwrap();
         let pipeline = Pipeline::from_config(&cfg).unwrap();
         let rows = pipeline
-            .apply_rows(vec![UniversalRow::new(
+            .apply_rows(vec![Row::new(
                 "ledger",
                 0,
-                UniversalValue::Array {
-                    elements: vec![
-                        UniversalValue::Text("a".into()),
-                        UniversalValue::Text("b".into()),
-                    ],
-                    element_type: Box::new(UniversalType::Text),
+                Value::Array {
+                    elements: vec![Value::Text("a".into()), Value::Text("b".into())],
+                    element_type: Box::new(Type::Text),
                 },
                 Default::default(),
             )])
             .unwrap();
-        assert_eq!(rows[0].id, UniversalValue::Text("a:b".into()));
+        assert_eq!(rows[0].id, Value::Text("a:b".into()));
     }
 }

--- a/crates/sync-transform/src/inplace.rs
+++ b/crates/sync-transform/src/inplace.rs
@@ -6,19 +6,25 @@
 //! a transform with a schema/catalog (e.g. wrap `postgresql::fk_transform`
 //! helpers) and [`crate::Pipeline::push_inplace`] it. The apply path runs that
 //! stage like any other in-place transform — including over
-//! [`sync_core::UniversalRelation`] / [`sync_core::UniversalRelationChange`]
+//! [`sync_core::Relation`] / [`sync_core::RelationChange`]
 //! via the relation methods below.
 //!
 //! Full join-table → relation **source** logic may remain in PostgreSQL (or
 //! other) source crates; relation **edges are first-class in the apply engine**.
 
 use anyhow::Result;
-use sync_core::{UniversalChange, UniversalRelation, UniversalRelationChange, UniversalRow};
+use std::collections::HashMap;
+use sync_core::{Change, Relation, RelationChange, Row, Value};
 
-/// Mutate-only, same-length transform over universal docs.
+/// Mutate-only, same-length transform over sync docs.
 ///
 /// This is the **only** in-process mutation primitive. Filter / fan-out belong
 /// in [`crate::ExternalTransform`] or outside this trait.
+///
+/// Implement [`transform`](Self::transform) once for the shared document surface
+/// (`table` / `id` / optional `fields`). [`transform_row`](Self::transform_row)
+/// and [`transform_change`](Self::transform_change) default to calling it.
+/// Deletes arrive with `fields == None`.
 ///
 /// # Slice defaults
 ///
@@ -28,24 +34,38 @@ use sync_core::{UniversalChange, UniversalRelation, UniversalRelationChange, Uni
 ///
 /// Relation methods default to no-op so row-only transforms stay trivial.
 pub trait InPlaceTransform: Send + Sync {
-    /// Transform a single row in place.
-    fn transform_row(&self, row: &mut UniversalRow) -> Result<()>;
+    /// Mutate the shared document surface (id + optional field map).
+    ///
+    /// `fields` is `None` for delete changes.
+    fn transform(
+        &self,
+        table: &str,
+        id: &mut Value,
+        fields: Option<&mut HashMap<String, Value>>,
+    ) -> Result<()>;
 
-    /// Transform a single change in place.
-    fn transform_change(&self, change: &mut UniversalChange) -> Result<()>;
+    /// Transform a single row in place.
+    fn transform_row(&self, row: &mut Row) -> Result<()> {
+        self.transform(&row.table, &mut row.id, Some(&mut row.fields))
+    }
+
+    /// Transform a single change in place (including deletes).
+    fn transform_change(&self, change: &mut Change) -> Result<()> {
+        self.transform(&change.table, &mut change.id, change.fields.as_mut())
+    }
 
     /// Transform a single relation in place. Default: no-op.
-    fn transform_relation(&self, _relation: &mut UniversalRelation) -> Result<()> {
+    fn transform_relation(&self, _relation: &mut Relation) -> Result<()> {
         Ok(())
     }
 
     /// Transform a single relation change in place. Default: no-op.
-    fn transform_relation_change(&self, _change: &mut UniversalRelationChange) -> Result<()> {
+    fn transform_relation_change(&self, _change: &mut RelationChange) -> Result<()> {
         Ok(())
     }
 
     /// Transform a slice of owned rows in place (true zero-copy path).
-    fn transform_rows_inplace(&self, rows: &mut [UniversalRow]) -> Result<()> {
+    fn transform_rows_inplace(&self, rows: &mut [Row]) -> Result<()> {
         for row in rows {
             self.transform_row(row)?;
         }
@@ -53,7 +73,7 @@ pub trait InPlaceTransform: Send + Sync {
     }
 
     /// Transform a slice of owned changes in place (true zero-copy path).
-    fn transform_changes_inplace(&self, changes: &mut [UniversalChange]) -> Result<()> {
+    fn transform_changes_inplace(&self, changes: &mut [Change]) -> Result<()> {
         for change in changes {
             self.transform_change(change)?;
         }
@@ -61,7 +81,7 @@ pub trait InPlaceTransform: Send + Sync {
     }
 
     /// Transform a slice of owned relations in place. Default: loop.
-    fn transform_relations_inplace(&self, relations: &mut [UniversalRelation]) -> Result<()> {
+    fn transform_relations_inplace(&self, relations: &mut [Relation]) -> Result<()> {
         for relation in relations {
             self.transform_relation(relation)?;
         }
@@ -69,10 +89,7 @@ pub trait InPlaceTransform: Send + Sync {
     }
 
     /// Transform a slice of owned relation changes in place. Default: loop.
-    fn transform_relation_changes_inplace(
-        &self,
-        changes: &mut [UniversalRelationChange],
-    ) -> Result<()> {
+    fn transform_relation_changes_inplace(&self, changes: &mut [RelationChange]) -> Result<()> {
         for change in changes {
             self.transform_relation_change(change)?;
         }
@@ -92,11 +109,12 @@ pub trait InPlaceTransform: Send + Sync {
 pub struct Passthrough;
 
 impl InPlaceTransform for Passthrough {
-    fn transform_row(&self, _row: &mut UniversalRow) -> Result<()> {
-        Ok(())
-    }
-
-    fn transform_change(&self, _change: &mut UniversalChange) -> Result<()> {
+    fn transform(
+        &self,
+        _table: &str,
+        _id: &mut Value,
+        _fields: Option<&mut HashMap<String, Value>>,
+    ) -> Result<()> {
         Ok(())
     }
 }

--- a/crates/sync-transform/src/lib.rs
+++ b/crates/sync-transform/src/lib.rs
@@ -92,9 +92,9 @@ const _: () = {
 
     fn check() {
         assert_send_sync::<Pipeline>();
-        assert_send_sync::<CowBatch<sync_core::UniversalRow>>();
-        assert_send_sync::<CowBatch<sync_core::UniversalChange>>();
-        assert_send_sync::<CowBatch<sync_core::UniversalRelation>>();
+        assert_send_sync::<CowBatch<sync_core::Row>>();
+        assert_send_sync::<CowBatch<sync_core::Change>>();
+        assert_send_sync::<CowBatch<sync_core::Relation>>();
         assert_send_sync::<ApplyOpts>();
         assert_send_sync::<ExternalTransform>();
         assert_send_sync::<NdjsonFramer>();

--- a/crates/sync-transform/src/pipeline.rs
+++ b/crates/sync-transform/src/pipeline.rs
@@ -5,7 +5,7 @@ use crate::external::ExternalTransform;
 use crate::inplace::InPlaceTransform;
 use anyhow::{bail, Result};
 use std::sync::Arc;
-use sync_core::{UniversalChange, UniversalRelation, UniversalRelationChange, UniversalRow};
+use sync_core::{Change, Relation, RelationChange, Row};
 
 /// A single pipeline stage.
 #[derive(Clone)]
@@ -128,7 +128,7 @@ impl Pipeline {
     ///
     /// Empty pipeline: no-op with no stage dispatch. External stages are not
     /// supported here; use [`crate::BatchTransformer::transform_rows`] (async).
-    pub fn transform_rows_inplace(&self, rows: &mut [UniversalRow]) -> Result<()> {
+    pub fn transform_rows_inplace(&self, rows: &mut [Row]) -> Result<()> {
         if self.is_identity() {
             return Ok(());
         }
@@ -150,7 +150,7 @@ impl Pipeline {
     ///
     /// Empty pipeline: no-op with no stage dispatch. External stages are not
     /// supported here; use [`crate::BatchTransformer::transform_changes`] (async).
-    pub fn transform_changes_inplace(&self, changes: &mut [UniversalChange]) -> Result<()> {
+    pub fn transform_changes_inplace(&self, changes: &mut [Change]) -> Result<()> {
         if self.is_identity() {
             return Ok(());
         }
@@ -172,13 +172,13 @@ impl Pipeline {
     ///
     /// Preferred path for **in-place-only** pipelines: empty
     /// pipeline is a pure move with no transform dispatch.
-    pub fn apply_rows(&self, mut rows: Vec<UniversalRow>) -> Result<Vec<UniversalRow>> {
+    pub fn apply_rows(&self, mut rows: Vec<Row>) -> Result<Vec<Row>> {
         self.transform_rows_inplace(&mut rows)?;
         Ok(rows)
     }
 
     /// Consume an owned change batch, transform in place, and return it.
-    pub fn apply_changes(&self, mut changes: Vec<UniversalChange>) -> Result<Vec<UniversalChange>> {
+    pub fn apply_changes(&self, mut changes: Vec<Change>) -> Result<Vec<Change>> {
         self.transform_changes_inplace(&mut changes)?;
         Ok(changes)
     }
@@ -188,8 +188,8 @@ impl Pipeline {
     pub(crate) async fn apply_changes_async(
         &self,
         batch_id: u64,
-        mut changes: Vec<UniversalChange>,
-    ) -> Result<Vec<UniversalChange>> {
+        mut changes: Vec<Change>,
+    ) -> Result<Vec<Change>> {
         if self.is_identity() {
             return Ok(changes);
         }
@@ -208,8 +208,8 @@ impl Pipeline {
     pub(crate) async fn apply_rows_async(
         &self,
         batch_id: u64,
-        mut rows: Vec<UniversalRow>,
-    ) -> Result<Vec<UniversalRow>> {
+        mut rows: Vec<Row>,
+    ) -> Result<Vec<Row>> {
         if self.is_identity() {
             return Ok(rows);
         }
@@ -225,10 +225,7 @@ impl Pipeline {
     }
 
     /// Transform owned relation changes in place (sync — **in-place stages only**).
-    pub fn transform_relation_changes_inplace(
-        &self,
-        changes: &mut [UniversalRelationChange],
-    ) -> Result<()> {
+    pub fn transform_relation_changes_inplace(&self, changes: &mut [RelationChange]) -> Result<()> {
         if self.is_identity() {
             return Ok(());
         }
@@ -247,7 +244,7 @@ impl Pipeline {
     }
 
     /// Transform owned relations in place (sync — **in-place stages only**).
-    pub fn transform_relations_inplace(&self, relations: &mut [UniversalRelation]) -> Result<()> {
+    pub fn transform_relations_inplace(&self, relations: &mut [Relation]) -> Result<()> {
         if self.is_identity() {
             return Ok(());
         }
@@ -268,17 +265,14 @@ impl Pipeline {
     /// Consume owned relation changes, transform in place, return them.
     pub fn apply_relation_changes(
         &self,
-        mut changes: Vec<UniversalRelationChange>,
-    ) -> Result<Vec<UniversalRelationChange>> {
+        mut changes: Vec<RelationChange>,
+    ) -> Result<Vec<RelationChange>> {
         self.transform_relation_changes_inplace(&mut changes)?;
         Ok(changes)
     }
 
     /// Consume owned relations, transform in place, return them.
-    pub fn apply_relations(
-        &self,
-        mut relations: Vec<UniversalRelation>,
-    ) -> Result<Vec<UniversalRelation>> {
+    pub fn apply_relations(&self, mut relations: Vec<Relation>) -> Result<Vec<Relation>> {
         self.transform_relations_inplace(&mut relations)?;
         Ok(relations)
     }
@@ -286,8 +280,8 @@ impl Pipeline {
     pub(crate) async fn apply_relation_changes_async(
         &self,
         batch_id: u64,
-        mut changes: Vec<UniversalRelationChange>,
-    ) -> Result<Vec<UniversalRelationChange>> {
+        mut changes: Vec<RelationChange>,
+    ) -> Result<Vec<RelationChange>> {
         if self.is_identity() {
             return Ok(changes);
         }
@@ -305,8 +299,8 @@ impl Pipeline {
     pub(crate) async fn apply_relations_async(
         &self,
         batch_id: u64,
-        mut relations: Vec<UniversalRelation>,
-    ) -> Result<Vec<UniversalRelation>> {
+        mut relations: Vec<Relation>,
+    ) -> Result<Vec<Relation>> {
         if self.is_identity() {
             return Ok(relations);
         }
@@ -352,7 +346,7 @@ impl Pipeline {
                     let all_changes = events.iter().all(|e| e.is_change());
                     let all_rels = events.iter().all(|e| e.is_relation_change());
                     if all_changes {
-                        let changes: Vec<UniversalChange> = events
+                        let changes: Vec<Change> = events
                             .into_iter()
                             .map(|e| match e {
                                 ApplyEvent::Change(c) => c,
@@ -362,7 +356,7 @@ impl Pipeline {
                         let transformed = ext.exchange_changes(batch_id, changes).await?;
                         events = transformed.into_iter().map(ApplyEvent::Change).collect();
                     } else if all_rels {
-                        let rels: Vec<UniversalRelationChange> = events
+                        let rels: Vec<RelationChange> = events
                             .into_iter()
                             .map(|e| match e {
                                 ApplyEvent::RelationChange(r) => *r,

--- a/crates/sync-transform/src/source_driver_tests.rs
+++ b/crates/sync-transform/src/source_driver_tests.rs
@@ -8,28 +8,26 @@ use crate::{
 };
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
-use sync_core::{
-    UniversalChange, UniversalRelation, UniversalRelationChange, UniversalThingRef, UniversalValue,
-};
+use sync_core::{Change, Relation, RelationChange, ThingRef, Value};
 
-fn change(id: i64) -> UniversalChange {
+fn change(id: i64) -> Change {
     let mut data = HashMap::new();
     data.insert(
         "name".to_string(),
-        UniversalValue::VarChar {
+        Value::VarChar {
             value: format!("row-{id}"),
             length: 64,
         },
     );
-    UniversalChange::create("users", UniversalValue::Int64(id), data)
+    Change::create("users", Value::Int64(id), data)
 }
 
-fn relation(id: i64) -> UniversalRelation {
-    UniversalRelation::new(
+fn relation(id: i64) -> Relation {
+    Relation::new(
         "follows",
-        UniversalValue::Int64(id),
-        UniversalThingRef::new("users", UniversalValue::Int64(id)),
-        UniversalThingRef::new("users", UniversalValue::Int64(id + 1)),
+        Value::Int64(id),
+        ThingRef::new("users", Value::Int64(id)),
+        ThingRef::new("users", Value::Int64(id + 1)),
         HashMap::new(),
     )
 }
@@ -192,7 +190,7 @@ async fn mixed_relation_and_change_events_ordered() {
     let mut driver = ScriptedSourceDriver::new(vec![
         PositionedEvent::change(change(1), 10u64),
         PositionedEvent::new(
-            ApplyEvent::relation_change(UniversalRelationChange::create(relation(5))),
+            ApplyEvent::relation_change(RelationChange::create(relation(5))),
             20u64,
         ),
         PositionedEvent::change(change(2), 30u64),
@@ -334,7 +332,7 @@ async fn interval_when_drained_persists_sunk_promptly_when_already_drained() {
 
 #[tokio::test]
 async fn adhoc_snapshot_receives_apply_helpers_and_can_write() {
-    use sync_core::UniversalRow;
+    use sync_core::Row;
 
     struct AdhocWriter {
         remaining: Vec<PositionedEvent<u64>>,
@@ -380,12 +378,12 @@ async fn adhoc_snapshot_receives_apply_helpers_and_can_write() {
             let mut data = HashMap::new();
             data.insert(
                 "name".to_string(),
-                UniversalValue::VarChar {
+                Value::VarChar {
                     value: "adhoc".into(),
                     length: 64,
                 },
             );
-            let row = UniversalRow::new("users", 0, UniversalValue::Int64(99), data);
+            let row = Row::new("users", 0, Value::Int64(99), data);
             apply.write_rows(vec![row]).await?;
             self.wrote_via_adhoc = true;
             Ok(())
@@ -414,7 +412,7 @@ async fn adhoc_snapshot_receives_apply_helpers_and_can_write() {
     assert!(driver.wrote_via_adhoc);
     assert_eq!(sink.applied().len(), 1);
     assert_eq!(sink.rows_written().len(), 1);
-    assert_eq!(sink.rows_written()[0][0].id, UniversalValue::Int64(99));
+    assert_eq!(sink.rows_written()[0][0].id, Value::Int64(99));
 }
 
 #[tokio::test]
@@ -723,11 +721,7 @@ async fn identity_polls_while_slow_sink_in_flight() {
             .iter()
             .map(|c| c.id.clone())
             .collect::<Vec<_>>(),
-        vec![
-            UniversalValue::Int64(1),
-            UniversalValue::Int64(2),
-            UniversalValue::Int64(3)
-        ]
+        vec![Value::Int64(1), Value::Int64(2), Value::Int64(3)]
     );
 }
 
@@ -841,7 +835,7 @@ async fn non_identity_transforms_overlap_sink_ordered_advance_after_sink() {
             .iter()
             .map(|c| c.id.clone())
             .collect::<Vec<_>>(),
-        vec![UniversalValue::Int64(1), UniversalValue::Int64(2)],
+        vec![Value::Int64(1), Value::Int64(2)],
         "sink must stay ordered"
     );
     assert_eq!(
@@ -1152,11 +1146,7 @@ async fn multi_event_sink_not_reapplied_when_transform_completes() {
     let ids: Vec<_> = applied.iter().map(|c| c.id.clone()).collect();
     assert_eq!(
         ids,
-        vec![
-            UniversalValue::Int64(1),
-            UniversalValue::Int64(2),
-            UniversalValue::Int64(3)
-        ],
+        vec![Value::Int64(1), Value::Int64(2), Value::Int64(3)],
         "sink order must stay correct"
     );
     assert_eq!(
@@ -1175,7 +1165,7 @@ async fn filter_transform_notes_input_count_for_kafka_and_wal2json() {
     use anyhow::bail;
     use async_trait::async_trait;
     use std::sync::Arc;
-    use sync_core::UniversalChange;
+    use sync_core::Change;
 
     /// Drops every other change (keeps odd ids) — length shrinks.
     struct FilterOddIds;
@@ -1189,12 +1179,12 @@ async fn filter_transform_notes_input_count_for_kafka_and_wal2json() {
         async fn transform_changes(
             &self,
             _batch_id: u64,
-            changes: Vec<UniversalChange>,
-        ) -> anyhow::Result<Vec<UniversalChange>> {
+            changes: Vec<Change>,
+        ) -> anyhow::Result<Vec<Change>> {
             Ok(changes
                 .into_iter()
                 .filter(|c| match &c.id {
-                    UniversalValue::Int64(id) => id % 2 == 1,
+                    Value::Int64(id) => id % 2 == 1,
                     _ => true,
                 })
                 .collect())
@@ -1203,8 +1193,8 @@ async fn filter_transform_notes_input_count_for_kafka_and_wal2json() {
         async fn transform_rows(
             &self,
             _batch_id: u64,
-            rows: Vec<sync_core::UniversalRow>,
-        ) -> anyhow::Result<Vec<sync_core::UniversalRow>> {
+            rows: Vec<sync_core::Row>,
+        ) -> anyhow::Result<Vec<sync_core::Row>> {
             Ok(rows)
         }
 
@@ -1401,7 +1391,7 @@ async fn fan_out_transform_notes_input_count_not_output_length() {
     use anyhow::bail;
     use async_trait::async_trait;
     use std::sync::Arc;
-    use sync_core::UniversalChange;
+    use sync_core::Change;
 
     /// Duplicates each change — length grows.
     struct FanOutTwice;
@@ -1415,8 +1405,8 @@ async fn fan_out_transform_notes_input_count_not_output_length() {
         async fn transform_changes(
             &self,
             _batch_id: u64,
-            changes: Vec<UniversalChange>,
-        ) -> anyhow::Result<Vec<UniversalChange>> {
+            changes: Vec<Change>,
+        ) -> anyhow::Result<Vec<Change>> {
             let mut out = Vec::with_capacity(changes.len() * 2);
             for c in changes {
                 out.push(c.clone());
@@ -1428,8 +1418,8 @@ async fn fan_out_transform_notes_input_count_not_output_length() {
         async fn transform_rows(
             &self,
             _batch_id: u64,
-            rows: Vec<sync_core::UniversalRow>,
-        ) -> anyhow::Result<Vec<sync_core::UniversalRow>> {
+            rows: Vec<sync_core::Row>,
+        ) -> anyhow::Result<Vec<sync_core::Row>> {
             Ok(rows)
         }
 
@@ -1651,7 +1641,7 @@ async fn fan_out_transform_notes_input_count_not_output_length() {
 async fn row_chunk_driver_streams_chunks_through_runtime() {
     use crate::{RowChunkDriver, RowChunkSource};
     use async_trait::async_trait;
-    use sync_core::UniversalRow;
+    use sync_core::Row;
 
     struct TwoChunks {
         n: usize,
@@ -1659,18 +1649,18 @@ async fn row_chunk_driver_streams_chunks_through_runtime() {
 
     #[async_trait]
     impl RowChunkSource for TwoChunks {
-        async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<UniversalRow>>> {
+        async fn next_chunk(&mut self) -> anyhow::Result<Option<Vec<Row>>> {
             self.n += 1;
             if self.n > 2 {
                 return Ok(None);
             }
             let id = self.n as i64;
             let mut fields = HashMap::new();
-            fields.insert("v".to_string(), UniversalValue::Int64(id));
-            Ok(Some(vec![UniversalRow::new(
+            fields.insert("v".to_string(), Value::Int64(id));
+            Ok(Some(vec![Row::new(
                 "t",
                 id as u64,
-                UniversalValue::Int64(id),
+                Value::Int64(id),
                 fields,
             )]))
         }

--- a/crates/sync-transform/src/test_support.rs
+++ b/crates/sync-transform/src/test_support.rs
@@ -13,7 +13,7 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use surreal_sink::SurrealSink;
-use sync_core::{UniversalChange, UniversalRelation, UniversalRelationChange, UniversalRow};
+use sync_core::{Change, Relation, RelationChange, Row};
 use tokio::sync::Notify;
 
 /// Per-batch script for [`ScriptedTransformer`].
@@ -126,11 +126,7 @@ impl BatchTransformer for ScriptedTransformer {
         false
     }
 
-    async fn transform_changes(
-        &self,
-        batch_id: u64,
-        changes: Vec<UniversalChange>,
-    ) -> Result<Vec<UniversalChange>> {
+    async fn transform_changes(&self, batch_id: u64, changes: Vec<Change>) -> Result<Vec<Change>> {
         let script = {
             let mut st = self.state.lock().expect("scripted transformer lock");
             st.transform_calls += 1;
@@ -157,11 +153,7 @@ impl BatchTransformer for ScriptedTransformer {
         Ok(out)
     }
 
-    async fn transform_rows(
-        &self,
-        batch_id: u64,
-        rows: Vec<UniversalRow>,
-    ) -> Result<Vec<UniversalRow>> {
+    async fn transform_rows(&self, batch_id: u64, rows: Vec<Row>) -> Result<Vec<Row>> {
         let script = {
             let mut st = self.state.lock().expect("scripted transformer lock");
             st.transform_calls += 1;
@@ -191,8 +183,8 @@ impl BatchTransformer for ScriptedTransformer {
     async fn transform_relation_changes(
         &self,
         batch_id: u64,
-        changes: Vec<UniversalRelationChange>,
-    ) -> Result<Vec<UniversalRelationChange>> {
+        changes: Vec<RelationChange>,
+    ) -> Result<Vec<RelationChange>> {
         // Prefer transform_events for scripted delay/fail; this path is for
         // homogeneous relation-only helpers.
         let script = {
@@ -224,8 +216,8 @@ impl BatchTransformer for ScriptedTransformer {
     async fn transform_relations(
         &self,
         batch_id: u64,
-        relations: Vec<UniversalRelation>,
-    ) -> Result<Vec<UniversalRelation>> {
+        relations: Vec<Relation>,
+    ) -> Result<Vec<Relation>> {
         let script = {
             let mut st = self.state.lock().expect("scripted transformer lock");
             st.transform_calls += 1;
@@ -505,17 +497,12 @@ impl ScriptedInPlace {
 }
 
 impl crate::InPlaceTransform for ScriptedInPlace {
-    fn transform_row(&self, _row: &mut UniversalRow) -> Result<()> {
-        let mut c = self.calls.lock().expect("scripted inplace lock");
-        let idx = *c;
-        *c += 1;
-        if self.fail_on_calls.contains(&idx) {
-            return Err(anyhow!("ScriptedInPlace fail on call {idx}"));
-        }
-        Ok(())
-    }
-
-    fn transform_change(&self, _change: &mut UniversalChange) -> Result<()> {
+    fn transform(
+        &self,
+        _table: &str,
+        _id: &mut sync_core::Value,
+        _fields: Option<&mut std::collections::HashMap<String, sync_core::Value>>,
+    ) -> Result<()> {
         let mut c = self.calls.lock().expect("scripted inplace lock");
         let idx = *c;
         *c += 1;
@@ -589,7 +576,7 @@ where
 /// Sink failure script.
 #[derive(Debug, Clone)]
 pub enum SinkFailWhen {
-    /// Fail on the Nth `apply_universal_change` call (0-based).
+    /// Fail on the Nth `apply_change` call (0-based).
     ApplyIndex(usize),
     /// Fail when the change id (as display) matches.
     ChangeId(String),
@@ -597,10 +584,10 @@ pub enum SinkFailWhen {
 
 #[derive(Default)]
 struct RecordingSinkState {
-    applied: Vec<UniversalChange>,
-    relations_applied: Vec<UniversalRelationChange>,
-    rows_written: Vec<Vec<UniversalRow>>,
-    relations_written: Vec<Vec<UniversalRelation>>,
+    applied: Vec<Change>,
+    relations_applied: Vec<RelationChange>,
+    rows_written: Vec<Vec<Row>>,
+    relations_written: Vec<Vec<Relation>>,
     /// Sink apply order tags: `change:{id}` or `relation:{id}`.
     event_order: Vec<String>,
     apply_count: usize,
@@ -609,7 +596,7 @@ struct RecordingSinkState {
     /// If true, fail only once per scripted condition then succeed on retry.
     fail_once: bool,
     fired: Vec<bool>,
-    /// Artificial delay before each successful `apply_universal_change`.
+    /// Artificial delay before each successful `apply_change`.
     apply_delay: Duration,
     /// Notified when an apply begins (before delay/gate).
     apply_started: Option<Arc<Notify>>,
@@ -661,7 +648,7 @@ impl RecordingSink {
     }
 
     /// Applied changes in sink order.
-    pub fn applied(&self) -> Vec<UniversalChange> {
+    pub fn applied(&self) -> Vec<Change> {
         self.state
             .lock()
             .expect("recording sink lock")
@@ -669,7 +656,7 @@ impl RecordingSink {
             .clone()
     }
 
-    /// Ids of applied changes (Debug of `UniversalValue`).
+    /// Ids of applied changes (Debug of `Value`).
     pub fn applied_ids(&self) -> Vec<String> {
         self.applied()
             .iter()
@@ -677,8 +664,8 @@ impl RecordingSink {
             .collect()
     }
 
-    /// Row batches passed to `write_universal_rows`.
-    pub fn rows_written(&self) -> Vec<Vec<UniversalRow>> {
+    /// Row batches passed to `write_rows`.
+    pub fn rows_written(&self) -> Vec<Vec<Row>> {
         self.state
             .lock()
             .expect("recording sink lock")
@@ -686,13 +673,13 @@ impl RecordingSink {
             .clone()
     }
 
-    /// Number of `apply_universal_change` attempts (including failures).
+    /// Number of `apply_change` attempts (including failures).
     pub fn apply_attempts(&self) -> usize {
         self.state.lock().expect("recording sink lock").apply_count
     }
 
     /// Applied relation changes in sink order.
-    pub fn relations_applied(&self) -> Vec<UniversalRelationChange> {
+    pub fn relations_applied(&self) -> Vec<RelationChange> {
         self.state
             .lock()
             .expect("recording sink lock")
@@ -700,8 +687,8 @@ impl RecordingSink {
             .clone()
     }
 
-    /// Relation batches passed to `write_universal_relations`.
-    pub fn relations_written(&self) -> Vec<Vec<UniversalRelation>> {
+    /// Relation batches passed to `write_relations`.
+    pub fn relations_written(&self) -> Vec<Vec<Relation>> {
         self.state
             .lock()
             .expect("recording sink lock")
@@ -719,21 +706,21 @@ impl RecordingSink {
     }
 }
 
-fn id_matches(change: &UniversalChange, want: &str) -> bool {
+fn id_matches(change: &Change, want: &str) -> bool {
     format!("{:?}", change.id) == want || change_id_display(change) == want
 }
 
-fn change_id_display(change: &UniversalChange) -> String {
+fn change_id_display(change: &Change) -> String {
     match &change.id {
-        sync_core::UniversalValue::Int64(n) => n.to_string(),
-        sync_core::UniversalValue::Int32(n) => n.to_string(),
+        sync_core::Value::Int64(n) => n.to_string(),
+        sync_core::Value::Int32(n) => n.to_string(),
         other => format!("{other:?}"),
     }
 }
 
 #[async_trait]
 impl SurrealSink for RecordingSink {
-    async fn write_universal_rows(&self, rows: &[UniversalRow]) -> Result<()> {
+    async fn write_rows(&self, rows: &[Row]) -> Result<()> {
         self.state
             .lock()
             .expect("recording sink lock")
@@ -742,7 +729,7 @@ impl SurrealSink for RecordingSink {
         Ok(())
     }
 
-    async fn write_universal_relations(&self, relations: &[UniversalRelation]) -> Result<()> {
+    async fn write_relations(&self, relations: &[Relation]) -> Result<()> {
         self.state
             .lock()
             .expect("recording sink lock")
@@ -751,7 +738,7 @@ impl SurrealSink for RecordingSink {
         Ok(())
     }
 
-    async fn apply_universal_change(&self, change: &UniversalChange) -> Result<()> {
+    async fn apply_change(&self, change: &Change) -> Result<()> {
         let (delay, started, gate, should_fail) = {
             let mut st = self.state.lock().expect("recording sink lock");
             let idx = st.apply_count;
@@ -805,10 +792,7 @@ impl SurrealSink for RecordingSink {
         Ok(())
     }
 
-    async fn apply_universal_relation_change(
-        &self,
-        change: &UniversalRelationChange,
-    ) -> Result<()> {
+    async fn apply_relation_change(&self, change: &RelationChange) -> Result<()> {
         let mut st = self.state.lock().expect("recording sink lock");
         st.relation_apply_count += 1;
         st.event_order.push(format!(
@@ -820,10 +804,10 @@ impl SurrealSink for RecordingSink {
     }
 }
 
-fn relation_id_display(id: &sync_core::UniversalValue) -> String {
+fn relation_id_display(id: &sync_core::Value) -> String {
     match id {
-        sync_core::UniversalValue::Int64(n) => n.to_string(),
-        sync_core::UniversalValue::Int32(n) => n.to_string(),
+        sync_core::Value::Int64(n) => n.to_string(),
+        sync_core::Value::Int32(n) => n.to_string(),
         other => format!("{other:?}"),
     }
 }

--- a/crates/sync-transform/src/tests.rs
+++ b/crates/sync-transform/src/tests.rs
@@ -5,13 +5,13 @@ use anyhow::{bail, Result};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use sync_core::{UniversalChange, UniversalChangeOp, UniversalRow, UniversalValue};
+use sync_core::{Change, ChangeOp, Row, Value};
 
-fn sample_row(name: &str) -> UniversalRow {
-    UniversalRow::builder("users", 0, UniversalValue::Int64(1))
+fn sample_row(name: &str) -> Row {
+    Row::builder("users", 0, Value::Int64(1))
         .field(
             "name",
-            UniversalValue::VarChar {
+            Value::VarChar {
                 value: name.to_string(),
                 length: 64,
             },
@@ -19,16 +19,16 @@ fn sample_row(name: &str) -> UniversalRow {
         .build()
 }
 
-fn sample_change(name: &str) -> UniversalChange {
+fn sample_change(name: &str) -> Change {
     let mut data = HashMap::new();
     data.insert(
         "name".to_string(),
-        UniversalValue::VarChar {
+        Value::VarChar {
             value: name.to_string(),
             length: 64,
         },
     );
-    UniversalChange::create("users", UniversalValue::Int64(1), data)
+    Change::create("users", Value::Int64(1), data)
 }
 
 /// Mutating transform used to prove make_mut / stage dispatch.
@@ -37,22 +37,16 @@ struct Rename {
 }
 
 impl InPlaceTransform for Rename {
-    fn transform_row(&self, row: &mut UniversalRow) -> Result<()> {
-        row.fields.insert(
-            "name".to_string(),
-            UniversalValue::VarChar {
-                value: self.to.clone(),
-                length: 64,
-            },
-        );
-        Ok(())
-    }
-
-    fn transform_change(&self, change: &mut UniversalChange) -> Result<()> {
-        if let Some(data) = change.data.as_mut() {
-            data.insert(
+    fn transform(
+        &self,
+        _table: &str,
+        _id: &mut Value,
+        fields: Option<&mut HashMap<String, Value>>,
+    ) -> Result<()> {
+        if let Some(fields) = fields {
+            fields.insert(
                 "name".to_string(),
-                UniversalValue::VarChar {
+                Value::VarChar {
                     value: self.to.clone(),
                     length: 64,
                 },
@@ -70,12 +64,22 @@ struct Counting<T> {
 }
 
 impl<T: InPlaceTransform> InPlaceTransform for Counting<T> {
-    fn transform_row(&self, row: &mut UniversalRow) -> Result<()> {
+    fn transform(
+        &self,
+        table: &str,
+        id: &mut Value,
+        fields: Option<&mut HashMap<String, Value>>,
+    ) -> Result<()> {
+        // Count via the concrete path that will run (row vs change) in slice helpers.
+        self.inner.transform(table, id, fields)
+    }
+
+    fn transform_row(&self, row: &mut Row) -> Result<()> {
         self.rows.fetch_add(1, Ordering::SeqCst);
         self.inner.transform_row(row)
     }
 
-    fn transform_change(&self, change: &mut UniversalChange) -> Result<()> {
+    fn transform_change(&self, change: &mut Change) -> Result<()> {
         self.changes.fetch_add(1, Ordering::SeqCst);
         self.inner.transform_change(change)
     }
@@ -85,12 +89,13 @@ impl<T: InPlaceTransform> InPlaceTransform for Counting<T> {
 struct AlwaysFail;
 
 impl InPlaceTransform for AlwaysFail {
-    fn transform_row(&self, _row: &mut UniversalRow) -> Result<()> {
-        bail!("stage failed (rows)")
-    }
-
-    fn transform_change(&self, _change: &mut UniversalChange) -> Result<()> {
-        bail!("stage failed (changes)")
+    fn transform(
+        &self,
+        _table: &str,
+        _id: &mut Value,
+        _fields: Option<&mut HashMap<String, Value>>,
+    ) -> Result<()> {
+        bail!("stage failed")
     }
 }
 
@@ -106,7 +111,7 @@ fn empty_pipeline_is_identity() {
     assert_eq!(out.len(), 1);
     assert_eq!(
         out[0].get_field("name"),
-        Some(&UniversalValue::VarChar {
+        Some(&Value::VarChar {
             value: "alice".to_string(),
             length: 64,
         })
@@ -114,7 +119,7 @@ fn empty_pipeline_is_identity() {
 
     let changes = vec![sample_change("bob")];
     let out = pipeline.apply_changes(changes).unwrap();
-    assert_eq!(out[0].operation, UniversalChangeOp::Create);
+    assert_eq!(out[0].operation, ChangeOp::Create);
 }
 
 /// Empty pipeline short-circuits before any stage dispatch.
@@ -132,7 +137,7 @@ fn empty_pipeline_is_identity_short_circuit() {
     let out = pipeline.apply_rows(rows).unwrap();
     assert_eq!(
         out[0].get_field("name"),
-        Some(&UniversalValue::VarChar {
+        Some(&Value::VarChar {
             value: "x".to_string(),
             length: 64,
         })
@@ -141,8 +146,8 @@ fn empty_pipeline_is_identity_short_circuit() {
     let changes = vec![sample_change("y")];
     let out = pipeline.apply_changes(changes).unwrap();
     assert_eq!(
-        out[0].data.as_ref().unwrap().get("name"),
-        Some(&UniversalValue::VarChar {
+        out[0].fields.as_ref().unwrap().get("name"),
+        Some(&Value::VarChar {
             value: "y".to_string(),
             length: 64,
         })
@@ -171,7 +176,7 @@ fn lone_passthrough_is_not_identity() {
     let out = pipeline.apply_rows(vec![sample_row("alice")]).unwrap();
     assert_eq!(
         out[0].get_field("name"),
-        Some(&UniversalValue::VarChar {
+        Some(&Value::VarChar {
             value: "alice".to_string(),
             length: 64,
         })
@@ -189,7 +194,7 @@ fn passthrough_on_owned_vec_mutates_in_place_without_realloc() {
     assert_eq!(rows.as_ptr(), ptr_before);
     assert_eq!(
         rows[0].get_field("name"),
-        Some(&UniversalValue::VarChar {
+        Some(&Value::VarChar {
             value: "alice".to_string(),
             length: 64,
         })
@@ -236,14 +241,14 @@ fn cowbatch_shared_passthrough_still_clones() {
     // Original holder unchanged; batch item is a distinct clone of the same data.
     assert_eq!(
         held.get_field("name"),
-        Some(&UniversalValue::VarChar {
+        Some(&Value::VarChar {
             value: "alice".to_string(),
             length: 64,
         })
     );
     assert_eq!(
         batch.items[0].get_field("name"),
-        Some(&UniversalValue::VarChar {
+        Some(&Value::VarChar {
             value: "alice".to_string(),
             length: 64,
         })
@@ -274,15 +279,15 @@ fn cowbatch_make_mut_clones_only_when_shared() {
     );
     // Original holder still sees the old value (COW).
     assert_eq!(
-        held.data.as_ref().unwrap().get("name"),
-        Some(&UniversalValue::VarChar {
+        held.fields.as_ref().unwrap().get("name"),
+        Some(&Value::VarChar {
             value: "alice".to_string(),
             length: 64,
         })
     );
     assert_eq!(
-        batch.items[0].data.as_ref().unwrap().get("name"),
-        Some(&UniversalValue::VarChar {
+        batch.items[0].fields.as_ref().unwrap().get("name"),
+        Some(&Value::VarChar {
             value: "carol".to_string(),
             length: 64,
         })
@@ -310,8 +315,8 @@ fn cowbatch_unique_arc_mutating_transform_no_clone() {
         "unique Arc should mutate in place without clone"
     );
     assert_eq!(
-        batch.items[0].data.as_ref().unwrap().get("name"),
-        Some(&UniversalValue::VarChar {
+        batch.items[0].fields.as_ref().unwrap().get("name"),
+        Some(&Value::VarChar {
             value: "dave".to_string(),
             length: 64,
         })
@@ -338,7 +343,7 @@ fn pipeline_applies_inplace_stages_in_order() {
     assert_eq!(counter.rows.load(Ordering::SeqCst), 1);
     assert_eq!(
         out[0].get_field("name"),
-        Some(&UniversalValue::VarChar {
+        Some(&Value::VarChar {
             value: "step2".to_string(),
             length: 64,
         })
@@ -372,8 +377,8 @@ fn pipeline_applies_changes_stages_in_order() {
     assert_eq!(step1.changes.load(Ordering::SeqCst), 1);
     assert_eq!(step2.changes.load(Ordering::SeqCst), 1);
     assert_eq!(
-        out[0].data.as_ref().unwrap().get("name"),
-        Some(&UniversalValue::VarChar {
+        out[0].fields.as_ref().unwrap().get("name"),
+        Some(&Value::VarChar {
             value: "step2".to_string(),
             length: 64,
         })
@@ -385,8 +390,8 @@ fn pipeline_applies_changes_stages_in_order() {
     assert_eq!(step1.changes.load(Ordering::SeqCst), 2);
     assert_eq!(step2.changes.load(Ordering::SeqCst), 2);
     assert_eq!(
-        changes[0].data.as_ref().unwrap().get("name"),
-        Some(&UniversalValue::VarChar {
+        changes[0].fields.as_ref().unwrap().get("name"),
+        Some(&Value::VarChar {
             value: "step2".to_string(),
             length: 64,
         })
@@ -463,7 +468,7 @@ fn pipeline_external_sync_inplace_errors() {
 
 #[test]
 fn pipeline_external_sync_relation_inplace_errors() {
-    use sync_core::{UniversalRelation, UniversalRelationChange, UniversalThingRef};
+    use sync_core::{Relation, RelationChange, ThingRef};
 
     let transport = crate::test_support::ScriptedExternalTransport::new();
     let mut pipeline = Pipeline::new();
@@ -471,16 +476,16 @@ fn pipeline_external_sync_relation_inplace_errors() {
         transport,
     )));
 
-    let rel = UniversalRelation::new(
+    let rel = Relation::new(
         "follows",
-        UniversalValue::Int64(1),
-        UniversalThingRef::new("users", UniversalValue::Int64(1)),
-        UniversalThingRef::new("users", UniversalValue::Int64(2)),
+        Value::Int64(1),
+        ThingRef::new("users", Value::Int64(1)),
+        ThingRef::new("users", Value::Int64(2)),
         HashMap::new(),
     );
 
     let err_changes = pipeline
-        .apply_relation_changes(vec![UniversalRelationChange::create(rel.clone())])
+        .apply_relation_changes(vec![RelationChange::create(rel.clone())])
         .unwrap_err();
     assert!(
         err_changes.to_string().contains("BatchTransformer")
@@ -504,7 +509,7 @@ fn pipeline_external_sync_relation_inplace_errors() {
 async fn batch_transformer_default_relation_methods_fail_closed() {
     use crate::BatchTransformer;
     use async_trait::async_trait;
-    use sync_core::{UniversalRelation, UniversalRelationChange, UniversalThingRef};
+    use sync_core::{Relation, RelationChange, ThingRef};
 
     struct ChangesOnly;
 
@@ -517,31 +522,27 @@ async fn batch_transformer_default_relation_methods_fail_closed() {
         async fn transform_changes(
             &self,
             _batch_id: u64,
-            changes: Vec<UniversalChange>,
-        ) -> Result<Vec<UniversalChange>> {
+            changes: Vec<Change>,
+        ) -> Result<Vec<Change>> {
             Ok(changes)
         }
 
-        async fn transform_rows(
-            &self,
-            _batch_id: u64,
-            rows: Vec<UniversalRow>,
-        ) -> Result<Vec<UniversalRow>> {
+        async fn transform_rows(&self, _batch_id: u64, rows: Vec<Row>) -> Result<Vec<Row>> {
             Ok(rows)
         }
     }
 
     let t = ChangesOnly;
-    let rel = UniversalRelation::new(
+    let rel = Relation::new(
         "follows",
-        UniversalValue::Int64(1),
-        UniversalThingRef::new("users", UniversalValue::Int64(1)),
-        UniversalThingRef::new("users", UniversalValue::Int64(2)),
+        Value::Int64(1),
+        ThingRef::new("users", Value::Int64(1)),
+        ThingRef::new("users", Value::Int64(2)),
         HashMap::new(),
     );
 
     let err = t
-        .transform_relation_changes(1, vec![UniversalRelationChange::create(rel.clone())])
+        .transform_relation_changes(1, vec![RelationChange::create(rel.clone())])
         .await
         .unwrap_err();
     assert!(
@@ -563,15 +564,13 @@ async fn batch_transformer_default_relation_methods_fail_closed() {
             1,
             vec![
                 crate::ApplyEvent::Change(sample_change("a")),
-                crate::ApplyEvent::relation_change(UniversalRelationChange::create(
-                    UniversalRelation::new(
-                        "follows",
-                        UniversalValue::Int64(2),
-                        UniversalThingRef::new("users", UniversalValue::Int64(3)),
-                        UniversalThingRef::new("users", UniversalValue::Int64(4)),
-                        HashMap::new(),
-                    ),
-                )),
+                crate::ApplyEvent::relation_change(RelationChange::create(Relation::new(
+                    "follows",
+                    Value::Int64(2),
+                    ThingRef::new("users", Value::Int64(3)),
+                    ThingRef::new("users", Value::Int64(4)),
+                    HashMap::new(),
+                ))),
             ],
         )
         .await
@@ -595,7 +594,7 @@ fn cowbatch_from_owned_and_row_apply() {
     let items = batch.into_items();
     assert_eq!(
         items[0].get_field("name"),
-        Some(&UniversalValue::VarChar {
+        Some(&Value::VarChar {
             value: "zoe".to_string(),
             length: 64,
         })

--- a/crates/sync-transform/tests/external_stdio.rs
+++ b/crates/sync-transform/tests/external_stdio.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
-use sync_core::{UniversalChange, UniversalValue};
+use sync_core::{Change, Value};
 use sync_transform::test_support::{RecordingSink, ScriptedChangeFeed};
 use sync_transform::{
     run_change_feed, write_rows, ApplyOpts, ChildStdioMode, ConfiguredStage, ExternalTransform,
@@ -15,16 +15,16 @@ fn fixture_cmd(mode: &str) -> Vec<String> {
     vec![bin.to_string(), mode.to_string()]
 }
 
-fn change(id: i64, name: &str) -> UniversalChange {
+fn change(id: i64, name: &str) -> Change {
     let mut data = HashMap::new();
     data.insert(
         "name".to_string(),
-        UniversalValue::VarChar {
+        Value::VarChar {
             value: name.to_string(),
             length: 64,
         },
     );
-    UniversalChange::create("users", UniversalValue::Int64(id), data)
+    Change::create("users", Value::Int64(id), data)
 }
 
 fn positioned(id: i64, pos: u64) -> PositionedChange<u64> {
@@ -44,7 +44,7 @@ async fn persistent_echo_and_mutate() {
         .await
         .unwrap();
     assert_eq!(out.len(), 1);
-    assert_eq!(out[0].id, UniversalValue::Int64(1));
+    assert_eq!(out[0].id, Value::Int64(1));
 
     let ext_m = ExternalTransform::child_stdio(
         ChildStdioMode::Persistent,
@@ -57,13 +57,13 @@ async fn persistent_echo_and_mutate() {
         .await
         .unwrap();
     let name = out[0]
-        .data
+        .fields
         .as_ref()
         .unwrap()
         .get("name")
         .expect("name field");
     match name {
-        UniversalValue::VarChar { value, .. } => assert_eq!(value, "mutated"),
+        Value::VarChar { value, .. } => assert_eq!(value, "mutated"),
         other => panic!("expected VarChar, got {other:?}"),
     }
 }
@@ -86,8 +86,8 @@ async fn persistent_multiplex_batch_ids() {
     };
     let out_a = a.await.unwrap().unwrap();
     let out_b = b.await.unwrap().unwrap();
-    assert_eq!(out_a[0].id, UniversalValue::Int64(1));
-    assert_eq!(out_b[0].id, UniversalValue::Int64(2));
+    assert_eq!(out_a[0].id, Value::Int64(1));
+    assert_eq!(out_b[0].id, Value::Int64(2));
 }
 
 #[tokio::test]
@@ -99,14 +99,14 @@ async fn transient_smoke() {
     )
     .expect("transient");
     let out = ext.exchange_changes(1, vec![change(9, "x")]).await.unwrap();
-    assert_eq!(out[0].id, UniversalValue::Int64(9));
+    assert_eq!(out[0].id, Value::Int64(9));
 
     // Second batch respawns.
     let out2 = ext
         .exchange_changes(2, vec![change(10, "y")])
         .await
         .unwrap();
-    assert_eq!(out2[0].id, UniversalValue::Int64(10));
+    assert_eq!(out2[0].id, Value::Int64(10));
 }
 
 #[tokio::test]
@@ -245,10 +245,10 @@ async fn write_rows_through_external_mutate() {
     );
     let sink = RecordingSink::new();
     let opts = ApplyOpts::default();
-    let row = sync_core::UniversalRow::builder("users", 0, UniversalValue::Int64(1))
+    let row = sync_core::Row::builder("users", 0, Value::Int64(1))
         .field(
             "name",
-            UniversalValue::VarChar {
+            Value::VarChar {
                 value: "alice".into(),
                 length: 64,
             },
@@ -257,13 +257,13 @@ async fn write_rows_through_external_mutate() {
     write_rows(&sink, &pipeline, vec![row], &opts)
         .await
         .unwrap();
-    // write_rows → Update upserts coalesce to write_universal_rows inside the window.
+    // write_rows → Update upserts coalesce to write_rows inside the window.
     let written = sink.rows_written();
     assert_eq!(written.len(), 1);
     assert_eq!(written[0].len(), 1);
     let name = written[0][0].fields.get("name").expect("name field");
     match name {
-        UniversalValue::VarChar { value, .. } => assert_eq!(value, "mutated"),
+        Value::VarChar { value, .. } => assert_eq!(value, "mutated"),
         other => panic!("unexpected: {other:?}"),
     }
 }
@@ -333,13 +333,13 @@ stdio.framer = "ndjson"
     assert_eq!(sink.applied().len(), 1);
     let applied = sink.applied();
     let name = applied[0]
-        .data
+        .fields
         .as_ref()
         .unwrap()
         .get("name")
         .expect("name field");
     match name {
-        UniversalValue::VarChar { value, .. } => assert_eq!(value, "mutated"),
+        Value::VarChar { value, .. } => assert_eq!(value, "mutated"),
         other => panic!("expected mutated name, got {other:?}"),
     }
     assert_eq!(feed.advances, vec![10]);

--- a/docs/mysql-data-types.md
+++ b/docs/mysql-data-types.md
@@ -93,8 +93,8 @@ Note: Complex spatial operations specific to MySQL are not preserved.
 
 ### Data Integrity Notes
 
-- **NULL handling**: MySQL NULL values become SurrealDB `NONE` (via `UniversalValue::Null`)
-- **Zero dates**: MySQL/MariaDB zero dates (`0000-00-00`, `0000-00-00 00:00:00`) become `UniversalValue::ZeroTemporal` with the intended column type preserved for transforms. The SurrealDB sink maps them according to `[sink.surrealdb] zero_temporal`:
+- **NULL handling**: MySQL NULL values become SurrealDB `NONE` (via `Value::Null`)
+- **Zero dates**: MySQL/MariaDB zero dates (`0000-00-00`, `0000-00-00 00:00:00`) become `Value::ZeroTemporal` with the intended column type preserved for transforms. The SurrealDB sink maps them according to `[sink.surrealdb] zero_temporal`:
   - `none` (default) → SurrealDB `NONE`
   - `null` → SurrealDB `NULL`
   - `string` → literal string such as `"0000-00-00"` / `"0000-00-00 00:00:00"`

--- a/docs/sync-pipeline.md
+++ b/docs/sync-pipeline.md
@@ -427,7 +427,7 @@ if __name__ == "__main__":
     main()
 ```
 
-Make it executable and point `command` at it. Item JSON is the serde shape of surreal-sync’s universal row/change documents (typed values under `fields` / `data`, etc.). Start by echoing; then mutate fields your enrichment needs — including rewriting `id` when you need a custom composite-key shape (see [Record IDs and composite primary keys](#record-ids-and-composite-primary-keys)).
+Make it executable and point `command` at it. Item JSON is the serde shape of surreal-sync’s row/change documents (typed values under `fields`, etc.). Start by echoing; then mutate fields your enrichment needs — including rewriting `id` when you need a custom composite-key shape (see [Record IDs and composite primary keys](#record-ids-and-composite-primary-keys)).
 
 #### Tips for enrichment tools
 
@@ -498,6 +498,11 @@ as the stock binary for that source.
 
 Filter-out or fan-out of events is out of scope for `InPlaceTransform` — use a
 `command` worker or a custom `BatchTransformer` for those.
+
+Implement one `transform(table, id, fields)` method; the trait defaults
+`transform_row` / `transform_change` by calling it (`fields` is `None` on
+deletes). Re-exported embedder types are `Row`, `Change`, `Value`, and `ChangeOp`
+(no `Universal*` prefix).
 
 **Composition rules**
 

--- a/examples/mysql_binlog_custom_transform.rs
+++ b/examples/mysql_binlog_custom_transform.rs
@@ -14,31 +14,26 @@
 use anyhow::Result;
 use std::collections::HashMap;
 use surreal_sync::mysql_binlog;
-use surreal_sync::{FlattenId, InPlaceTransform, UniversalChange, UniversalRow, UniversalValue};
+use surreal_sync::{FlattenId, InPlaceTransform, Value};
 
 /// Drop columns that must not leave the source VPC (CDC often mirrors more than the target needs).
 struct RedactPii;
 
 impl RedactPii {
     const DROP: &'static [&'static str] = &["password_hash", "ssn", "credit_card"];
-
-    fn scrub(fields: &mut HashMap<String, UniversalValue>) {
-        for key in Self::DROP {
-            fields.remove(*key);
-        }
-    }
 }
 
 impl InPlaceTransform for RedactPii {
-    fn transform_row(&self, row: &mut UniversalRow) -> Result<()> {
-        Self::scrub(&mut row.fields);
-        Ok(())
-    }
-
-    fn transform_change(&self, change: &mut UniversalChange) -> Result<()> {
-        // Create/Update carry `data`; Delete does not — leave id/table alone.
-        if let Some(data) = change.data.as_mut() {
-            Self::scrub(data);
+    fn transform(
+        &self,
+        _table: &str,
+        _id: &mut Value,
+        fields: Option<&mut HashMap<String, Value>>,
+    ) -> Result<()> {
+        if let Some(fields) = fields {
+            for key in Self::DROP {
+                fields.remove(*key);
+            }
         }
         Ok(())
     }
@@ -47,23 +42,17 @@ impl InPlaceTransform for RedactPii {
 /// Rename / reshape fields toward the SurrealDB document shape.
 struct RenameFields;
 
-impl RenameFields {
-    fn rename(fields: &mut HashMap<String, UniversalValue>) {
-        if let Some(name) = fields.remove("name") {
-            fields.insert("full_name".into(), name);
-        }
-    }
-}
-
 impl InPlaceTransform for RenameFields {
-    fn transform_row(&self, row: &mut UniversalRow) -> Result<()> {
-        Self::rename(&mut row.fields);
-        Ok(())
-    }
-
-    fn transform_change(&self, change: &mut UniversalChange) -> Result<()> {
-        if let Some(data) = change.data.as_mut() {
-            Self::rename(data);
+    fn transform(
+        &self,
+        _table: &str,
+        _id: &mut Value,
+        fields: Option<&mut HashMap<String, Value>>,
+    ) -> Result<()> {
+        if let Some(fields) = fields {
+            if let Some(name) = fields.remove("name") {
+                fields.insert("full_name".into(), name);
+            }
         }
         Ok(())
     }
@@ -75,35 +64,30 @@ struct FkToRecordLink {
     table: &'static str,
 }
 
-impl FkToRecordLink {
-    fn linkify(&self, fields: &mut HashMap<String, UniversalValue>) {
-        let Some(id) = fields.remove(self.field) else {
-            return;
+impl InPlaceTransform for FkToRecordLink {
+    fn transform(
+        &self,
+        _table: &str,
+        _id: &mut Value,
+        fields: Option<&mut HashMap<String, Value>>,
+    ) -> Result<()> {
+        let Some(fields) = fields else {
+            return Ok(());
         };
-        if matches!(id, UniversalValue::Null) {
-            fields.insert(self.field.into(), UniversalValue::Null);
-            return;
+        let Some(id) = fields.remove(self.field) else {
+            return Ok(());
+        };
+        if matches!(id, Value::Null) {
+            fields.insert(self.field.into(), Value::Null);
+            return Ok(());
         }
         fields.insert(
             self.field.into(),
-            UniversalValue::Thing {
+            Value::Thing {
                 table: self.table.into(),
                 id: Box::new(id),
             },
         );
-    }
-}
-
-impl InPlaceTransform for FkToRecordLink {
-    fn transform_row(&self, row: &mut UniversalRow) -> Result<()> {
-        self.linkify(&mut row.fields);
-        Ok(())
-    }
-
-    fn transform_change(&self, change: &mut UniversalChange) -> Result<()> {
-        if let Some(data) = change.data.as_mut() {
-            self.linkify(data);
-        }
         Ok(())
     }
 }

--- a/examples/snowflake_custom_transform.rs
+++ b/examples/snowflake_custom_transform.rs
@@ -17,7 +17,7 @@
 use anyhow::Result;
 use std::collections::HashMap;
 use surreal_sync::snowflake;
-use surreal_sync::{FlattenId, InPlaceTransform, UniversalChange, UniversalRow, UniversalValue};
+use surreal_sync::{FlattenId, InPlaceTransform, Value};
 
 /// Drop columns that must not leave the source VPC (imports often mirror more
 /// than the target needs).
@@ -25,24 +25,19 @@ struct RedactPii;
 
 impl RedactPii {
     const DROP: &'static [&'static str] = &["password_hash", "ssn", "credit_card"];
-
-    fn scrub(fields: &mut HashMap<String, UniversalValue>) {
-        for key in Self::DROP {
-            fields.remove(*key);
-        }
-    }
 }
 
 impl InPlaceTransform for RedactPii {
-    fn transform_row(&self, row: &mut UniversalRow) -> Result<()> {
-        Self::scrub(&mut row.fields);
-        Ok(())
-    }
-
-    fn transform_change(&self, change: &mut UniversalChange) -> Result<()> {
-        // Snowflake imports rows only; keep the change path for trait completeness.
-        if let Some(data) = change.data.as_mut() {
-            Self::scrub(data);
+    fn transform(
+        &self,
+        _table: &str,
+        _id: &mut Value,
+        fields: Option<&mut HashMap<String, Value>>,
+    ) -> Result<()> {
+        if let Some(fields) = fields {
+            for key in Self::DROP {
+                fields.remove(*key);
+            }
         }
         Ok(())
     }
@@ -51,23 +46,17 @@ impl InPlaceTransform for RedactPii {
 /// Rename / reshape fields toward the SurrealDB document shape.
 struct RenameFields;
 
-impl RenameFields {
-    fn rename(fields: &mut HashMap<String, UniversalValue>) {
-        if let Some(name) = fields.remove("name") {
-            fields.insert("full_name".into(), name);
-        }
-    }
-}
-
 impl InPlaceTransform for RenameFields {
-    fn transform_row(&self, row: &mut UniversalRow) -> Result<()> {
-        Self::rename(&mut row.fields);
-        Ok(())
-    }
-
-    fn transform_change(&self, change: &mut UniversalChange) -> Result<()> {
-        if let Some(data) = change.data.as_mut() {
-            Self::rename(data);
+    fn transform(
+        &self,
+        _table: &str,
+        _id: &mut Value,
+        fields: Option<&mut HashMap<String, Value>>,
+    ) -> Result<()> {
+        if let Some(fields) = fields {
+            if let Some(name) = fields.remove("name") {
+                fields.insert("full_name".into(), name);
+            }
         }
         Ok(())
     }
@@ -79,35 +68,30 @@ struct FkToRecordLink {
     table: &'static str,
 }
 
-impl FkToRecordLink {
-    fn linkify(&self, fields: &mut HashMap<String, UniversalValue>) {
-        let Some(id) = fields.remove(self.field) else {
-            return;
+impl InPlaceTransform for FkToRecordLink {
+    fn transform(
+        &self,
+        _table: &str,
+        _id: &mut Value,
+        fields: Option<&mut HashMap<String, Value>>,
+    ) -> Result<()> {
+        let Some(fields) = fields else {
+            return Ok(());
         };
-        if matches!(id, UniversalValue::Null) {
-            fields.insert(self.field.into(), UniversalValue::Null);
-            return;
+        let Some(id) = fields.remove(self.field) else {
+            return Ok(());
+        };
+        if matches!(id, Value::Null) {
+            fields.insert(self.field.into(), Value::Null);
+            return Ok(());
         }
         fields.insert(
             self.field.into(),
-            UniversalValue::Thing {
+            Value::Thing {
                 table: self.table.into(),
                 id: Box::new(id),
             },
         );
-    }
-}
-
-impl InPlaceTransform for FkToRecordLink {
-    fn transform_row(&self, row: &mut UniversalRow) -> Result<()> {
-        self.linkify(&mut row.fields);
-        Ok(())
-    }
-
-    fn transform_change(&self, change: &mut UniversalChange) -> Result<()> {
-        if let Some(data) = change.data.as_mut() {
-            self.linkify(data);
-        }
         Ok(())
     }
 }

--- a/src/from/common/schema.rs
+++ b/src/from/common/schema.rs
@@ -18,12 +18,12 @@ pub fn load_schema_if_provided(schema_file: &Option<PathBuf>) -> anyhow::Result<
 /// Extract JSON field paths from a schema (e.g., ["users.profile_data", "products.metadata"]).
 /// This is used to auto-populate Neo4j JSON properties from the schema file.
 pub fn extract_json_fields_from_schema(schema: &Schema) -> Vec<String> {
-    use sync_core::UniversalType;
+    use sync_core::Type;
 
     let mut json_fields = Vec::new();
     for table in &schema.tables {
         for field in &table.fields {
-            if matches!(field.field_type, UniversalType::Json | UniversalType::Jsonb) {
+            if matches!(field.field_type, Type::Json | Type::Jsonb) {
                 json_fields.push(format!("{}.{}", table.name, field.name));
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ pub use surreal_sync_csv_source as csv;
 pub use surreal_sync_jsonl_source as jsonl;
 
 // Transform + core types for embedders (one dependency: surreal-sync)
-pub use sync_core::{UniversalChange, UniversalChangeOp, UniversalRow, UniversalValue};
+pub use sync_core::{Change, ChangeOp, Row, Value};
 pub use sync_transform::{ApplyOpts, FlattenId, InPlaceTransform, Pipeline};
 
 #[derive(Parser, Clone)]

--- a/src/transforms.rs
+++ b/src/transforms.rs
@@ -115,7 +115,6 @@ pub fn merge_inplace_boxed(
 mod tests {
     use super::*;
     use std::io::Write;
-    use sync_core::{UniversalChange, UniversalRow};
     use sync_transform::FlattenId;
 
     #[test]
@@ -199,15 +198,14 @@ command = ["/nonexistent/surreal-sync-transform-worker-cli-xyz"]
     struct Tag;
 
     impl InPlaceTransform for Tag {
-        fn transform_row(&self, row: &mut UniversalRow) -> anyhow::Result<()> {
-            row.fields
-                .insert("tagged".into(), sync_core::UniversalValue::Bool(true));
-            Ok(())
-        }
-
-        fn transform_change(&self, change: &mut UniversalChange) -> anyhow::Result<()> {
-            if let Some(data) = change.data.as_mut() {
-                data.insert("tagged".into(), sync_core::UniversalValue::Bool(true));
+        fn transform(
+            &self,
+            _table: &str,
+            _id: &mut sync_core::Value,
+            fields: Option<&mut std::collections::HashMap<String, sync_core::Value>>,
+        ) -> anyhow::Result<()> {
+            if let Some(fields) = fields {
+                fields.insert("tagged".into(), sync_core::Value::Bool(true));
             }
             Ok(())
         }

--- a/tests/kafka/transforms_lib.rs
+++ b/tests/kafka/transforms_lib.rs
@@ -12,12 +12,12 @@ use surreal_sync::testing::generate_test_id;
 use surreal_sync_kafka_producer::container::KafkaContainer;
 use surreal_sync_kafka_producer::{publish_test_users, KafkaTestProducer};
 use surreal_sync_kafka_source::Config as KafkaConfig;
-use sync_core::{UniversalChange, UniversalRelation, UniversalRow, UniversalValue};
+use sync_core::{Change, Relation, Row, Value};
 use sync_transform::{ApplyOpts, ChildStdioMode, ExternalTransform, FramerKind, Pipeline};
 use tokio::time::sleep;
 
 struct CaptureSink {
-    changes: Mutex<Vec<UniversalChange>>,
+    changes: Mutex<Vec<Change>>,
 }
 
 impl CaptureSink {
@@ -30,12 +30,12 @@ impl CaptureSink {
 
 #[async_trait::async_trait]
 impl SurrealSink for CaptureSink {
-    async fn write_universal_rows(&self, rows: &[UniversalRow]) -> anyhow::Result<()> {
-        // Homogeneous Update upserts coalesce to write_universal_rows; record the
-        // same observations tests assert via apply_universal_change.
+    async fn write_rows(&self, rows: &[Row]) -> anyhow::Result<()> {
+        // Homogeneous Update upserts coalesce to write_rows; record the
+        // same observations tests assert via apply_change.
         let mut changes = self.changes.lock().expect("lock");
         for row in rows {
-            changes.push(UniversalChange::update(
+            changes.push(Change::update(
                 row.table.clone(),
                 row.id.clone(),
                 row.fields.clone(),
@@ -44,21 +44,18 @@ impl SurrealSink for CaptureSink {
         Ok(())
     }
 
-    async fn write_universal_relations(
-        &self,
-        _relations: &[UniversalRelation],
-    ) -> anyhow::Result<()> {
+    async fn write_relations(&self, _relations: &[Relation]) -> anyhow::Result<()> {
         Ok(())
     }
 
-    async fn apply_universal_change(&self, change: &UniversalChange) -> anyhow::Result<()> {
+    async fn apply_change(&self, change: &Change) -> anyhow::Result<()> {
         self.changes.lock().expect("lock").push(change.clone());
         Ok(())
     }
 
-    async fn apply_universal_relation_change(
+    async fn apply_relation_change(
         &self,
-        _change: &sync_core::UniversalRelationChange,
+        _change: &sync_core::RelationChange,
     ) -> anyhow::Result<()> {
         Ok(())
     }
@@ -89,11 +86,11 @@ fn ensure_fixture_worker() -> PathBuf {
     path
 }
 
-fn change_name(change: &UniversalChange) -> Option<String> {
-    let data = change.data.as_ref()?;
+fn change_name(change: &Change) -> Option<String> {
+    let data = change.fields.as_ref()?;
     match data.get("name")? {
-        UniversalValue::Text(value) => Some(value.clone()),
-        UniversalValue::VarChar { value, .. } => Some(value.clone()),
+        Value::Text(value) => Some(value.clone()),
+        Value::VarChar { value, .. } => Some(value.clone()),
         other => panic!("unexpected name: {other:?}"),
     }
 }

--- a/tests/mongodb/mongodb_transforms_lib.rs
+++ b/tests/mongodb/mongodb_transforms_lib.rs
@@ -11,12 +11,12 @@ use surreal_sync_mongodb_changestream_source::{
     run_full_sync_with_transforms, run_incremental_sync_with_transforms, MongoDBCheckpoint,
     ReplicationTailOptions, SourceOpts, SyncOpts,
 };
-use sync_core::{UniversalChange, UniversalRow, UniversalValue};
+use sync_core::{Change, Row, Value};
 use sync_transform::{ApplyOpts, ChildStdioMode, ExternalTransform, FramerKind, Pipeline};
 
 struct CaptureSink {
-    changes: Mutex<Vec<UniversalChange>>,
-    rows: Mutex<Vec<UniversalRow>>,
+    changes: Mutex<Vec<Change>>,
+    rows: Mutex<Vec<Row>>,
 }
 
 impl CaptureSink {
@@ -30,13 +30,13 @@ impl CaptureSink {
 
 #[async_trait::async_trait]
 impl SurrealSink for CaptureSink {
-    async fn write_universal_rows(&self, rows: &[UniversalRow]) -> anyhow::Result<()> {
+    async fn write_rows(&self, rows: &[Row]) -> anyhow::Result<()> {
         // Homogeneous Update upserts coalesce here; mirror into `changes` for
         // incremental assertions (full sync still reads `rows`).
         self.rows.lock().expect("lock").extend(rows.iter().cloned());
         let mut changes = self.changes.lock().expect("lock");
         for row in rows {
-            changes.push(UniversalChange::update(
+            changes.push(Change::update(
                 row.table.clone(),
                 row.id.clone(),
                 row.fields.clone(),
@@ -45,21 +45,18 @@ impl SurrealSink for CaptureSink {
         Ok(())
     }
 
-    async fn write_universal_relations(
-        &self,
-        _relations: &[sync_core::UniversalRelation],
-    ) -> anyhow::Result<()> {
+    async fn write_relations(&self, _relations: &[sync_core::Relation]) -> anyhow::Result<()> {
         Ok(())
     }
 
-    async fn apply_universal_change(&self, change: &UniversalChange) -> anyhow::Result<()> {
+    async fn apply_change(&self, change: &Change) -> anyhow::Result<()> {
         self.changes.lock().expect("lock").push(change.clone());
         Ok(())
     }
 
-    async fn apply_universal_relation_change(
+    async fn apply_relation_change(
         &self,
-        _change: &sync_core::UniversalRelationChange,
+        _change: &sync_core::RelationChange,
     ) -> anyhow::Result<()> {
         Ok(())
     }
@@ -90,17 +87,17 @@ fn ensure_fixture_worker() -> PathBuf {
     path
 }
 
-fn name_field(change: &UniversalChange) -> Option<String> {
-    let data = change.data.as_ref()?;
+fn name_field(change: &Change) -> Option<String> {
+    let data = change.fields.as_ref()?;
     match data.get("name")? {
-        UniversalValue::Text(value) => Some(value.clone()),
+        Value::Text(value) => Some(value.clone()),
         other => panic!("unexpected name: {other:?}"),
     }
 }
 
-fn row_name_field(row: &UniversalRow) -> Option<String> {
+fn row_name_field(row: &Row) -> Option<String> {
     match row.fields.get("name")? {
-        UniversalValue::Text(value) => Some(value.clone()),
+        Value::Text(value) => Some(value.clone()),
         other => panic!("unexpected name: {other:?}"),
     }
 }


### PR DESCRIPTION
Shorten the public sync types and let one transform method cover both rows and changes, so embedders write less boilerplate when running MySQL binlog or Snowflake sync from their own Rust binary.

Follow-up to #133 #134