### PR TITLE
Fix static musl Linux release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,18 @@ on:
     tags:
       - 'v*.*.*'
   workflow_dispatch:
+    inputs:
+      only_target:
+        description: 'Build only this target (empty = all)'
+        required: false
+        type: choice
+        options:
+          - ''
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+          - aarch64-apple-darwin
+        default: ''
 
 env:
   CARGO_TERM_COLOR: always
@@ -15,6 +27,7 @@ jobs:
   build:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.only_target == '' || inputs.only_target == matrix.target }}
     continue-on-error: ${{ matrix.continue-on-error || false }}
     permissions:
       contents: read
@@ -32,7 +45,6 @@ jobs:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             binary_name: surreal-sync
-            continue-on-error: true
           # - target: aarch64-unknown-linux-musl
           #   os: ubuntu-latest
           #   binary_name: surreal-sync
@@ -79,11 +91,24 @@ jobs:
           FEATURES=""
           case "${{ matrix.target }}" in
             *-musl)
-              FEATURES="--features vendored-openssl"
+              FEATURES="--features static-musl"
               export CC=musl-gcc
               ;;
           esac
           cargo build --release --target ${{ matrix.target }} $FEATURES
+
+      - name: Verify static linking (musl)
+        if: contains(matrix.target, 'musl')
+        run: |
+          BIN="target/${{ matrix.target }}/release/${{ matrix.binary_name }}"
+          file "$BIN"
+          if readelf -d "$BIN" | grep -q 'NEEDED'; then
+            echo "Error: musl binary has dynamic library dependencies:"
+            readelf -d "$BIN" | grep 'NEEDED' || true
+            ldd "$BIN" || true
+            exit 1
+          fi
+          echo "OK: no dynamic NEEDED entries (fully static)"
 
       - name: Create archive
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,16 +9,16 @@ on:
   workflow_dispatch:
     inputs:
       only_target:
-        description: 'Build only this target (empty = all)'
+        description: 'Build only this target (all = full matrix)'
         required: false
         type: choice
         options:
-          - ''
+          - all
           - x86_64-unknown-linux-gnu
           - aarch64-unknown-linux-gnu
           - x86_64-unknown-linux-musl
           - aarch64-apple-darwin
-        default: ''
+        default: all
 
 env:
   CARGO_TERM_COLOR: always
@@ -27,7 +27,6 @@ jobs:
   build:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.only_target == '' || inputs.only_target == matrix.target }}
     continue-on-error: ${{ matrix.continue-on-error || false }}
     permissions:
       contents: read
@@ -56,23 +55,37 @@ jobs:
             continue-on-error: true
 
     steps:
+      - name: Decide whether to build this target
+        id: gate
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" \
+            && "${{ inputs.only_target }}" != "all" \
+            && "${{ inputs.only_target }}" != "${{ matrix.target }}" ]]; then
+            echo "build=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping ${{ matrix.target }} (only_target=${{ inputs.only_target }})"
+          else
+            echo "build=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout repository
+        if: steps.gate.outputs.build == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust toolchain
+        if: steps.gate.outputs.build == 'true'
         run: |
           rustup toolchain install
           rustup target add ${{ matrix.target }}
 
       - name: Install system build dependencies
-        if: contains(matrix.target, 'linux')
+        if: steps.gate.outputs.build == 'true' && contains(matrix.target, 'linux')
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             build-essential cmake libssl-dev libsasl2-dev pkg-config protobuf-compiler
 
       - name: Install cross-compilation tools
-        if: matrix.os == 'ubuntu-latest'
+        if: steps.gate.outputs.build == 'true' && matrix.os == 'ubuntu-latest'
         run: |
           case "${{ matrix.target }}" in
             x86_64-unknown-linux-musl)
@@ -87,6 +100,7 @@ jobs:
           esac
 
       - name: Build binary
+        if: steps.gate.outputs.build == 'true'
         run: |
           FEATURES=""
           case "${{ matrix.target }}" in
@@ -98,7 +112,7 @@ jobs:
           cargo build --release --target ${{ matrix.target }} $FEATURES
 
       - name: Verify static linking (musl)
-        if: contains(matrix.target, 'musl')
+        if: steps.gate.outputs.build == 'true' && contains(matrix.target, 'musl')
         run: |
           BIN="target/${{ matrix.target }}/release/${{ matrix.binary_name }}"
           file "$BIN"
@@ -111,6 +125,7 @@ jobs:
           echo "OK: no dynamic NEEDED entries (fully static)"
 
       - name: Create archive
+        if: steps.gate.outputs.build == 'true'
         shell: bash
         run: |
           mkdir -p dist
@@ -129,6 +144,7 @@ jobs:
           fi
 
       - name: Upload artifacts
+        if: steps.gate.outputs.build == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: surreal-sync-${{ matrix.target }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2387,7 +2387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4771,7 +4771,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5039,7 +5039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5791,7 +5791,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6513,7 +6513,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6593,7 +6593,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6663,6 +6663,7 @@ dependencies = [
  "cc",
  "duct",
  "libc",
+ "openssl-sys",
  "pkg-config",
 ]
 
@@ -6783,7 +6784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7562,6 +7563,7 @@ dependencies = [
  "protobuf-codegen",
  "protobuf-parse",
  "rdkafka",
+ "sasl2-sys",
  "serde",
  "serde_json",
  "surreal-sync-core",
@@ -8312,10 +8314,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9408,7 +9410,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ publish = false
 [features]
 default = []
 vendored-openssl = ["dep:openssl"]
+# Fully static musl builds: vendored OpenSSL + Kafka static-native (SASL PLAIN/SCRAM, zlib).
+static-musl = ["vendored-openssl", "surreal-sync-kafka/static-native"]
 
 [dependencies]
 # CLI framework

--- a/crates/kafka/Cargo.toml
+++ b/crates/kafka/Cargo.toml
@@ -43,6 +43,12 @@ producer = [
     "dep:tempfile",
     "dep:tracing-subscriber",
 ]
+# Static/vendored native deps for musl (and similar) builds: OpenSSL, zlib, Cyrus SASL PLAIN+SCRAM.
+static-native = [
+    "rdkafka/ssl-vendored",
+    "rdkafka/libz-static",
+    "dep:sasl2-sys",
+]
 
 [dependencies]
 # types
@@ -69,6 +75,9 @@ clap = { version = "4.5", features = ["derive", "env"], optional = true }
 rdkafka = { version = "0.39", features = ["tokio", "sasl"], optional = true }
 tokio = { version = "1.49", features = ["full"], optional = true }
 tempfile = { version = "3.27", optional = true }
+# Feature-unified with rdkafka-sys's sasl2-sys when static-native is enabled.
+# plain/scram imply vendored and enable the plugins Kafka SASL auth needs.
+sasl2-sys = { version = "0.1.22", features = ["plain", "scram"], optional = true }
 
 # producer
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }

--- a/docs/kafka.md
+++ b/docs/kafka.md
@@ -82,6 +82,8 @@ For secured Kafka clusters, set `--security-protocol` to `SASL_PLAINTEXT` or `SA
 | `--sasl-password <PASS>` | `KAFKA_SASL_PASSWORD` | SASL password |
 | `--sasl-mechanism <MECH>` | — | `SCRAM-SHA-256`, `SCRAM-SHA-512`, or `PLAIN` |
 
+Kerberos (GSSAPI) is intentionally not supported.
+
 ### TLS / mTLS
 
 When `--security-protocol` is `SSL` or `SASL_SSL`, you can configure TLS trust and optional mutual TLS (mTLS) client authentication. These flags map to librdkafka `ssl.*` settings and are ignored for `PLAINTEXT` and `SASL_PLAINTEXT`.

--- a/docs/kafka.md
+++ b/docs/kafka.md
@@ -82,7 +82,7 @@ For secured Kafka clusters, set `--security-protocol` to `SASL_PLAINTEXT` or `SA
 | `--sasl-password <PASS>` | `KAFKA_SASL_PASSWORD` | SASL password |
 | `--sasl-mechanism <MECH>` | — | `SCRAM-SHA-256`, `SCRAM-SHA-512`, or `PLAIN` |
 
-Kerberos (GSSAPI) is intentionally not supported.
+Kerberos (GSSAPI) is not supported. If you need it, please open a feature request.
 
 ### TLS / mTLS
 


### PR DESCRIPTION
The x86_64 musl release job was failing because Kafka’s SASL support expected a system libsasl2 that isn’t usable for a static musl binary.

This change vendors Cyrus SASL with PLAIN and SCRAM, plus OpenSSL and zlib, behind a `static-musl` feature so that target builds a fully static binary with no glibc or other shared-library dependencies.