### PR TITLE
Add SQL Server as a sync source (`from mssql sync`)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -83,3 +83,13 @@ retries = 0
 filter = 'binary(snowflake)'
 slow-timeout = { period = "120s", terminate-after = 30 }
 retries = 0
+
+# SQL Server e2e (tests/mssql/) uses a ~2GB official image with Agent + CDC.
+# High threads-required serializes these tests so two containers do not overlap.
+[[profile.default.overrides]]
+filter = 'test(mssql)'
+threads-required = 8
+
+[[profile.ci.overrides]]
+filter = 'test(mssql)'
+threads-required = 8

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -135,6 +135,9 @@ jobs:
     - name: Pre-pull MySQL/MariaDB binlog test images
       run: make prepull-binlog-images
 
+    - name: Pre-pull SQL Server test image
+      run: make prepull-mssql-image
+
     - name: Export binlog test image tags
       run: make print-test-images >> $GITHUB_ENV
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,6 +135,9 @@ jobs:
     - name: Pre-pull MySQL/MariaDB binlog test images
       run: make prepull-binlog-images
 
+    - name: Pre-pull SQL Server test image
+      run: make prepull-mssql-image
+
     - name: Export binlog test image tags
       run: make print-test-images >> $GITHUB_ENV
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,6 +432,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "asynchronous-codec"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4057f2c32adbb2fc158e22fb38433c8e9bbf76b75a4732c7c0cbaf695fb65568"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "asynk-strim"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,7 +800,7 @@ dependencies = [
  "pin-project-lite",
  "rustls 0.21.12",
  "rustls 0.23.43",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.4",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -1633,6 +1646,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "connection-string"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "510ca239cf13b7f8d16a2b48f263de7b4f8c566f0af58d901031473c76afb1e3"
+
+[[package]]
 name = "console"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2411,6 +2430,26 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "equivalent"
@@ -3354,7 +3393,7 @@ dependencies = [
  "hyper 1.11.0",
  "hyper-util",
  "rustls 0.23.43",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.4",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
@@ -4745,7 +4784,7 @@ dependencies = [
  "pastey",
  "pin-project-lite",
  "rustls 0.23.43",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.4",
  "rustls-pki-types",
  "serde",
  "socket2 0.5.10",
@@ -5095,6 +5134,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-probe"
@@ -5647,6 +5692,12 @@ dependencies = [
  "ipnet",
  "num-traits",
 ]
+
+[[package]]
+name = "pretty-hex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
 
 [[package]]
 name = "primeorder"
@@ -6650,14 +6701,35 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe 0.1.6",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -6691,10 +6763,10 @@ dependencies = [
  "log",
  "once_cell",
  "rustls 0.23.43",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.4",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.13",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -6856,6 +6928,19 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
 ]
 
 [[package]]
@@ -7503,6 +7588,7 @@ dependencies = [
  "surreal-sync-json",
  "surreal-sync-kafka",
  "surreal-sync-mongodb-changestream-source",
+ "surreal-sync-mssql",
  "surreal-sync-mysql",
  "surreal-sync-neo4j-source",
  "surreal-sync-postgresql",
@@ -7587,6 +7673,16 @@ version = "0.6.1"
 dependencies = [
  "anyhow",
  "surreal-sync-kafka",
+ "surreal-sync-surreal",
+ "tokio",
+]
+
+[[package]]
+name = "surreal-sync-example-from-mssql"
+version = "0.6.1"
+dependencies = [
+ "anyhow",
+ "surreal-sync-mssql",
  "surreal-sync-surreal",
  "tokio",
 ]
@@ -7708,6 +7804,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "surreal-sync-mssql"
+version = "0.6.1"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "clap",
+ "hex",
+ "rustls 0.23.43",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "surreal-sync-core",
+ "surreal-sync-runtime",
+ "thiserror 2.0.19",
+ "tiberius",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "surreal-sync-mysql"
 version = "0.6.1"
 dependencies = [
@@ -7730,7 +7849,7 @@ dependencies = [
  "rsa",
  "rust_decimal",
  "rustls 0.23.43",
- "rustls-pemfile",
+ "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
  "sha1 0.10.7",
@@ -8515,6 +8634,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiberius"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1446cb4198848d1562301a3340424b4f425ef79f35ef9ee034769a9dd92c10d"
+dependencies = [
+ "async-trait",
+ "asynchronous-codec",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "connection-string",
+ "encoding_rs",
+ "enumflags2",
+ "futures-util",
+ "num-traits",
+ "once_cell",
+ "pin-project-lite",
+ "pretty-hex",
+ "rustls-native-certs 0.6.3",
+ "rustls-pemfile 1.0.4",
+ "thiserror 1.0.69",
+ "tokio-rustls 0.24.1",
+ "tokio-util",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,12 @@ members = [
     "crates/json",
     "crates/csv",
     "crates/kafka",
+    "crates/mssql",
     "examples/from-mysql-binlog",
     "examples/from-snowflake",
     "examples/from-jsonl",
     "examples/from-kafka",
+    "examples/from-mssql",
 ]
 resolver = "2"
 
@@ -112,6 +114,7 @@ surreal-sync-postgresql = { path = "crates/postgresql", features = ["from_wal2js
 surreal-sync-csv = { path = "crates/csv", features = ["from_csv"] }
 surreal-sync-json = { path = "crates/json", features = ["from_jsonl"] }
 surreal-sync-mysql = { path = "crates/mysql", features = ["from_binlog", "from_trigger"] }
+surreal-sync-mssql = { path = "crates/mssql", features = ["from_mssql"] }
 surreal-sync-snowflake = { path = "crates/snowflake", features = ["from_snowflake"] }
 
 # Load testing populators

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test check fmt clippy build build-debug compile-embedder-examples embed-dependency-tree-gates clean clean-logs help install-tools install-hooks system-deps prebuild-test-images prepull-binlog-images print-test-images services-info
+.PHONY: test check fmt clippy build build-debug compile-embedder-examples embed-dependency-tree-gates clean clean-logs help install-tools install-hooks system-deps prebuild-test-images prepull-binlog-images prepull-mssql-image print-test-images services-info
 
 include scripts/test-images.mk
 
@@ -122,7 +122,7 @@ embed-dependency-tree-gates:
 
 # Pre-pull binlog images and pre-build the custom PostgreSQL (wal2json) test image
 # so parallel test processes find them in Docker's layer cache instead of racing.
-prebuild-test-images: prepull-binlog-images
+prebuild-test-images: prepull-binlog-images prepull-mssql-image
 	@echo "🐳 Pre-building PostgreSQL wal2json test image..."
 	docker build -t postgres-wal2json-test \
 		-f crates/postgresql/Dockerfile.postgres16.wal2json \

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ See source-specific guides for more details:
 - **[JSONL](docs/jsonl.md)**: Bulk import from JSON Lines files
 - **[Kafka](docs/kafka.md)**: Kafka consumer that subscribes to a topic, importing Kafka message payloads into SurrealDB with optional deduplication
 - **[Snowflake](docs/snowflake.md)**: Full one-shot snapshot ingestion via the SQL REST API v2 using key-pair (JWT) auth
+- **[SQL Server](docs/mssql.md)**: Snapshot and CDC using native SQL Server change data capture
 - **[How sync works](docs/sync-pipeline.md)**: End-to-end pipeline (source → apply/transforms → sink → watermark), including optional `--transforms-config`
 
 ## Development

--- a/crates/loadtest-distributed/src/generator/databases/postgresql_logical.rs
+++ b/crates/loadtest-distributed/src/generator/databases/postgresql_logical.rs
@@ -60,6 +60,8 @@ pub fn generate_postgresql_logical_docker_service(config: &DatabaseConfig) -> Va
         "-c",
         "max_replication_slots=10",
         "-c",
+        "output_plugin_libraries=wal2json",
+        "-c",
         "synchronous_commit=off",
     ];
     service.insert(
@@ -172,6 +174,8 @@ spec:
         - "-c"
         - "max_replication_slots=10"
         - "-c"
+        - "output_plugin_libraries=wal2json"
+        - "-c"
         - "synchronous_commit=off"
         ports:
         - containerPort: 5432
@@ -265,6 +269,7 @@ mod tests {
         assert!(yaml.contains("wal_level=logical"));
         assert!(yaml.contains("max_wal_senders=10"));
         assert!(yaml.contains("max_replication_slots=10"));
+        assert!(yaml.contains("output_plugin_libraries=wal2json"));
     }
 
     #[test]
@@ -279,5 +284,6 @@ mod tests {
         assert!(statefulset.contains("wal_level=logical"));
         assert!(statefulset.contains("max_wal_senders=10"));
         assert!(statefulset.contains("max_replication_slots=10"));
+        assert!(statefulset.contains("output_plugin_libraries=wal2json"));
     }
 }

--- a/crates/mssql/Cargo.toml
+++ b/crates/mssql/Cargo.toml
@@ -1,0 +1,74 @@
+[package]
+name = "surreal-sync-mssql"
+version = "0.6.1"
+edition = "2021"
+description = "Sync SQL Server tables into SurrealDB using CDC and watermark snapshots"
+license = "Apache-2.0"
+readme = "README.md"
+publish = true
+repository = "https://github.com/surrealdb/surreal-sync"
+homepage = "https://github.com/surrealdb/surreal-sync"
+documentation = "https://docs.rs/surreal-sync-mssql"
+
+[features]
+default = ["types"]
+types = []
+from_mssql = [
+    "types",
+    "dep:surreal-sync-runtime",
+    "dep:clap",
+    "dep:async-trait",
+    "dep:tokio",
+    "dep:tokio-util",
+    "dep:tracing",
+    "dep:tiberius",
+    "dep:rustls",
+    "dep:sha2",
+    "dep:hex",
+    "dep:thiserror",
+]
+
+[dependencies]
+surreal-sync-core = { path = "../sync-core", version = "0.6.1" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+chrono = { version = "0.4", features = ["serde"] }
+anyhow = "1.0"
+uuid = { version = "1.10", features = ["v4", "serde"] }
+
+surreal-sync-runtime = { path = "../runtime", version = "0.6.1", features = ["cli"], optional = true }
+clap = { version = "4.5", features = ["derive", "env"], optional = true }
+async-trait = { version = "0.1", optional = true }
+tokio = { version = "1.49", features = ["net", "io-util", "time", "rt", "macros", "sync", "signal"], optional = true }
+tokio-util = { version = "0.7", features = ["compat"], optional = true }
+tracing = { version = "0.1", optional = true }
+tiberius = { version = "0.12", default-features = false, features = ["rustls", "chrono", "tds73"], optional = true }
+rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs", "std", "tls12"], optional = true }
+sha2 = { version = "0.10", optional = true }
+hex = { version = "0.4", optional = true }
+thiserror = { version = "2.0", optional = true }
+
+[dev-dependencies]
+tokio = { version = "1.49", features = ["full"] }
+async-trait = "0.1"
+serde_json = "1.0"
+surreal-sync-runtime = { path = "../runtime", version = "0.6.1" }
+surreal-sync-core = { path = "../sync-core", version = "0.6.1" }
+tiberius = { version = "0.12", default-features = false, features = ["rustls", "chrono", "tds73"] }
+sha2 = "0.10"
+hex = "0.4"
+thiserror = "2.0"
+
+[lib]
+name = "surreal_sync_mssql"
+path = "src/lib.rs"
+
+[[test]]
+name = "transforms"
+path = "tests/transforms.rs"
+required-features = ["from_mssql"]
+
+[[test]]
+name = "types"
+path = "tests/types.rs"
+required-features = ["from_mssql"]

--- a/crates/mssql/README.md
+++ b/crates/mssql/README.md
@@ -1,0 +1,60 @@
+# surreal-sync-mssql
+
+Sync SQL Server tables into SurrealDB using CDC and watermark snapshots.
+
+## Depend
+
+```toml
+surreal-sync-mssql = { version = "0.6", features = ["from_mssql"] }
+surreal-sync-surreal = "0.6" # SurrealDB 3 by default; use features = ["v2"] for v2
+```
+
+## Embed
+
+Define optional transforms, then call `run` with a SurrealDB sink. Pass the same flags as `surreal-sync from mssql sync`.
+
+```rust
+use anyhow::Result;
+use std::collections::HashMap;
+use surreal_sync_mssql::{run, FlattenId, InPlaceTransform, Value};
+use surreal_sync_surreal::Surreal3Sink;
+
+struct RedactPii;
+
+impl InPlaceTransform for RedactPii {
+    fn transform(
+        &self,
+        _table: &str,
+        _id: &mut Value,
+        fields: Option<&mut HashMap<String, Value>>,
+    ) -> Result<()> {
+        if let Some(fields) = fields {
+            fields.remove("password_hash");
+        }
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    run::<Surreal3Sink>([
+        Box::new(FlattenId::default()) as Box<dyn InPlaceTransform>,
+        Box::new(RedactPii),
+    ])
+    .await
+}
+```
+
+Example argv (same flags as the stock CLI):
+
+```text
+sync \
+  --connection-string 'Server=tcp:localhost,1433;User=sa;Password=...;Database=App;TrustServerCertificate=true;Encrypt=true' \
+  --tables dbo.Article,sales.Order \
+  --to-namespace prod --to-database app \
+  --checkpoints-surreal-table sync_checkpoints
+```
+
+Default `--strategy interleaved-snapshot` copies tables while SQL Server CDC runs, then stays in the replication tail. Pass `--strategy sequential-snapshot` for a SNAPSHOT-isolation dump (writers are not locked). Pass `--schemafull` to emit `DEFINE TABLE` / `FIELD` / `INDEX`; the default is schemaless.
+
+SQL Server must have CDC enabled (`EXEC sys.sp_cdc_enable_db;`) and SQL Server Agent running (Linux containers: `MSSQL_AGENT_ENABLED=true`). Windows Integrated Auth (`IntegratedSecurity=true`) is Windows-only.

--- a/crates/mssql/src/from_mssql/catalog.rs
+++ b/crates/mssql/src/from_mssql/catalog.rs
@@ -410,10 +410,11 @@ async fn load_raw(client: &MssqlClient) -> Result<RawCatalog> {
              INNER JOIN sys.foreign_key_columns fkc ON fkc.constraint_object_id = fk.object_id \
              INNER JOIN sys.tables parent_t ON parent_t.object_id = fk.parent_object_id \
              INNER JOIN sys.tables ref_t ON ref_t.object_id = fk.referenced_object_id \
-             ORDER BY fk.object_id, fkc.constraint_column_id",
+             ORDER BY fk.parent_object_id, fkc.parent_column_id, fk.object_id, fkc.constraint_column_id",
             &[],
         )
         .await?;
+    let mut fk_order: Vec<(i32, String)> = Vec::new();
     let mut fk_acc: HashMap<(i32, String), ForeignKeyDefinition> = HashMap::new();
     for row in fk_rows {
         let parent_id: i32 = row.try_get(0)?.unwrap_or(0);
@@ -422,20 +423,25 @@ async fn load_raw(client: &MssqlClient) -> Result<RawCatalog> {
         let ref_table: &str = row.try_get(6)?.unwrap_or("");
         let parent_col: &str = row.try_get(4)?.unwrap_or("");
         let ref_col: &str = row.try_get(7)?.unwrap_or("");
-        let entry = fk_acc
-            .entry((parent_id, cname.to_string()))
-            .or_insert(ForeignKeyDefinition {
+        let key = (parent_id, cname.to_string());
+        if let std::collections::hash_map::Entry::Vacant(e) = fk_acc.entry(key.clone()) {
+            fk_order.push(key.clone());
+            e.insert(ForeignKeyDefinition {
                 constraint_name: cname.to_string(),
                 columns: Vec::new(),
                 referenced_table: QualifiedName::new(ref_schema, ref_table).dotted(),
                 referenced_columns: Vec::new(),
             });
+        }
+        let entry = fk_acc.get_mut(&key).expect("FK just inserted");
         entry.columns.push(parent_col.to_string());
         entry.referenced_columns.push(ref_col.to_string());
     }
     let mut fks: HashMap<i32, Vec<ForeignKeyDefinition>> = HashMap::new();
-    for ((parent_id, _), fk) in fk_acc {
-        fks.entry(parent_id).or_default().push(fk);
+    for key in fk_order {
+        if let Some(fk) = fk_acc.remove(&key) {
+            fks.entry(key.0).or_default().push(fk);
+        }
     }
 
     let period_rows = client

--- a/crates/mssql/src/from_mssql/catalog.rs
+++ b/crates/mssql/src/from_mssql/catalog.rs
@@ -1,0 +1,555 @@
+//! SQL Server catalog: tables, PKs, FKs, indexes, temporal kind.
+
+use anyhow::{anyhow, Result};
+use std::collections::{HashMap, HashSet};
+use surreal_sync_core::{ColumnDefinition, ForeignKeyDefinition, Type};
+use tracing::warn;
+
+use crate::from_mssql::client::MssqlClient;
+use crate::from_mssql::naming::{
+    detect_collisions, parse_table_ref, target_table_name, QualifiedName,
+};
+use crate::from_mssql::signal::SIGNAL_TABLE;
+use crate::types::mssql_column_to_universal_type;
+
+/// How a selected table is copied (from `sys.tables.temporal_type`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TableSyncKind {
+    /// Ordinary table: PK record ids and record-link FKs.
+    Regular,
+    /// System-versioned current table: one Surreal table for all versions.
+    Temporal,
+}
+
+/// One SQL Server column after type mapping.
+#[derive(Debug, Clone)]
+pub struct MssqlColumnMeta {
+    pub name: String,
+    pub type_name: String,
+    pub nullable: bool,
+    pub ordinal: i32,
+    pub universal_type: Type,
+}
+
+/// A translatable btree index (or a skipped one, which is not stored).
+#[derive(Debug, Clone)]
+pub struct MssqlIndexMeta {
+    pub name: String,
+    pub columns: Vec<String>,
+    pub unique: bool,
+    pub is_primary: bool,
+}
+
+/// Catalog row for one selected source table (history is nested, not a second target).
+#[derive(Debug, Clone)]
+pub struct MssqlTableMeta {
+    pub source: QualifiedName,
+    pub target: String,
+    pub kind: TableSyncKind,
+    pub object_id: i32,
+    pub pk_columns: Vec<String>,
+    pub columns: Vec<MssqlColumnMeta>,
+    pub indexes: Vec<MssqlIndexMeta>,
+    pub foreign_keys: Vec<ForeignKeyDefinition>,
+    /// Period start column (temporal tables only).
+    pub period_start: Option<String>,
+    /// Period end column (temporal tables only).
+    pub period_end: Option<String>,
+    pub history: Option<QualifiedName>,
+    /// `sys.tables.temporal_type`: 0 none, 1 history, 2 current.
+    pub temporal_type: u8,
+}
+
+impl MssqlTableMeta {
+    pub fn column(&self, name: &str) -> Option<&MssqlColumnMeta> {
+        self.columns.iter().find(|c| c.name == name)
+    }
+
+    pub fn pk_types(&self) -> Vec<Type> {
+        self.pk_columns
+            .iter()
+            .filter_map(|n| self.column(n).map(|c| c.universal_type.clone()))
+            .collect()
+    }
+}
+
+#[derive(Clone)]
+struct RawTable {
+    schema: String,
+    name: String,
+    object_id: i32,
+    temporal_type: u8,
+    history_table_id: Option<i32>,
+}
+
+/// User tables in the current database (excludes CDC, history, and the signal table).
+pub async fn list_user_tables(client: &MssqlClient) -> Result<Vec<QualifiedName>> {
+    let catalog = load_raw(client).await?;
+    let mut out = Vec::new();
+    for t in &catalog.tables {
+        if t.temporal_type == 1 {
+            continue;
+        }
+        if t.name.eq_ignore_ascii_case(SIGNAL_TABLE) {
+            continue;
+        }
+        if t.schema.eq_ignore_ascii_case("cdc") {
+            continue;
+        }
+        out.push(QualifiedName::new(&t.schema, &t.name));
+    }
+    Ok(out)
+}
+
+/// Load selected tables (or all user tables). History-only selection is an error.
+pub async fn collect_database_schema(
+    client: &MssqlClient,
+    selected: &[String],
+) -> Result<Vec<MssqlTableMeta>> {
+    let raw = load_raw(client).await?;
+    let requested: Vec<QualifiedName> = if selected.is_empty() {
+        list_user_tables(client).await?
+    } else {
+        selected
+            .iter()
+            .map(|s| parse_table_ref(s))
+            .collect::<Result<Vec<_>>>()?
+    };
+
+    detect_collisions(&requested)?;
+
+    let mut by_id: HashMap<i32, &RawTable> = HashMap::new();
+    let mut by_name: HashMap<(String, String), &RawTable> = HashMap::new();
+    for t in &raw.tables {
+        by_id.insert(t.object_id, t);
+        by_name.insert(
+            (t.schema.to_ascii_lowercase(), t.name.to_ascii_lowercase()),
+            t,
+        );
+    }
+
+    let mut metas = Vec::new();
+    for name in &requested {
+        let key = (
+            name.schema.to_ascii_lowercase(),
+            name.table.to_ascii_lowercase(),
+        );
+        let table = by_name.get(&key).ok_or_else(|| {
+            anyhow!(
+                "table `{}` was not found in the current database",
+                name.dotted()
+            )
+        })?;
+        if table.temporal_type == 1 {
+            let current = raw
+                .tables
+                .iter()
+                .find(|t| t.history_table_id == Some(table.object_id))
+                .map(|t| QualifiedName::new(&t.schema, &t.name).dotted())
+                .unwrap_or_else(|| "dbo.<current>".into());
+            anyhow::bail!(
+                "sync the current table `{current}`, not the history table `{}`",
+                name.dotted()
+            );
+        }
+        let kind = if table.temporal_type == 2 {
+            TableSyncKind::Temporal
+        } else {
+            TableSyncKind::Regular
+        };
+        let history = table.history_table_id.and_then(|id| {
+            by_id
+                .get(&id)
+                .map(|h| QualifiedName::new(&h.schema, &h.name))
+        });
+        let pk_columns = raw.pks.get(&table.object_id).cloned().unwrap_or_default();
+        if pk_columns.is_empty() {
+            anyhow::bail!(
+                "table `{}` has no primary key; every synced table needs a primary key",
+                name.dotted()
+            );
+        }
+        let columns = raw
+            .columns
+            .get(&table.object_id)
+            .cloned()
+            .unwrap_or_default();
+        let period = raw.periods.get(&table.object_id).cloned();
+        let indexes = filter_indexes(
+            name,
+            raw.indexes.get(&table.object_id).unwrap_or(&Vec::new()),
+            &columns,
+        );
+        let fks = raw
+            .fks
+            .get(&table.object_id)
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|mut fk| {
+                fk.referenced_table = target_for_source(&fk.referenced_table, &by_name);
+                fk
+            })
+            .collect();
+
+        metas.push(MssqlTableMeta {
+            source: name.clone(),
+            target: target_table_name(name),
+            kind,
+            object_id: table.object_id,
+            pk_columns,
+            columns,
+            indexes,
+            foreign_keys: fks,
+            period_start: period.as_ref().map(|p| p.0.clone()),
+            period_end: period.as_ref().map(|p| p.1.clone()),
+            history,
+            temporal_type: table.temporal_type,
+        });
+    }
+    Ok(metas)
+}
+
+fn target_for_source(
+    dotted_or_name: &str,
+    by_name: &HashMap<(String, String), &RawTable>,
+) -> String {
+    if let Ok(q) = parse_table_ref(dotted_or_name) {
+        if by_name.contains_key(&(q.schema.to_ascii_lowercase(), q.table.to_ascii_lowercase())) {
+            return target_table_name(&q);
+        }
+    }
+    dotted_or_name.to_string()
+}
+
+struct RawCatalog {
+    tables: Vec<RawTable>,
+    columns: HashMap<i32, Vec<MssqlColumnMeta>>,
+    pks: HashMap<i32, Vec<String>>,
+    indexes: HashMap<i32, Vec<RawIndex>>,
+    fks: HashMap<i32, Vec<ForeignKeyDefinition>>,
+    periods: HashMap<i32, (String, String)>,
+}
+
+#[derive(Clone)]
+struct RawIndex {
+    name: String,
+    unique: bool,
+    is_primary: bool,
+    has_filter: bool,
+    is_disabled: bool,
+    is_hypothetical: bool,
+    type_desc: String,
+    columns: Vec<String>,
+    include_columns: Vec<String>,
+}
+
+async fn load_raw(client: &MssqlClient) -> Result<RawCatalog> {
+    let table_rows = client
+        .query(
+            "SELECT SCHEMA_NAME(t.schema_id), t.name, t.object_id, t.temporal_type, t.history_table_id \
+             FROM sys.tables t \
+             WHERE t.is_ms_shipped = 0 AND SCHEMA_NAME(t.schema_id) NOT IN (N'sys', N'cdc')",
+            &[],
+        )
+        .await?;
+    let mut tables = Vec::new();
+    for row in table_rows {
+        let schema: &str = row.try_get(0)?.unwrap_or("dbo");
+        let name: &str = row.try_get(1)?.unwrap_or("");
+        let object_id: i32 = row.try_get(2)?.unwrap_or(0);
+        let temporal_type: u8 = row
+            .try_get::<u8, _>(3)
+            .ok()
+            .flatten()
+            .or_else(|| row.try_get::<i32, _>(3).ok().flatten().map(|v| v as u8))
+            .unwrap_or(0);
+        let history_table_id: Option<i32> = row.try_get(4).ok().flatten();
+        tables.push(RawTable {
+            schema: schema.to_string(),
+            name: name.to_string(),
+            object_id,
+            temporal_type,
+            history_table_id,
+        });
+    }
+
+    let col_rows = client
+        .query(
+            "SELECT c.object_id, c.name, ty.name, c.max_length, c.precision, c.scale, \
+                    c.is_nullable, c.column_id, \
+                    CASE WHEN ty.name IN (N'nchar', N'nvarchar') AND c.max_length > 0 \
+                         THEN c.max_length / 2 ELSE CASE WHEN c.max_length < 0 THEN NULL ELSE c.max_length END END \
+             FROM sys.columns c \
+             INNER JOIN sys.types ty ON ty.user_type_id = c.user_type_id \
+             INNER JOIN sys.tables t ON t.object_id = c.object_id \
+             WHERE t.is_ms_shipped = 0 \
+             ORDER BY c.object_id, c.column_id",
+            &[],
+        )
+        .await?;
+    let mut columns: HashMap<i32, Vec<MssqlColumnMeta>> = HashMap::new();
+    for row in col_rows {
+        let object_id: i32 = row.try_get(0)?.unwrap_or(0);
+        let name: &str = row.try_get(1)?.unwrap_or("");
+        let type_name: &str = row.try_get(2)?.unwrap_or("");
+        let max_length: i16 = row.try_get(3)?.unwrap_or(0);
+        let precision: u8 = row.try_get(4)?.unwrap_or(0);
+        let scale: u8 = row.try_get(5)?.unwrap_or(0);
+        let nullable: bool = row.try_get(6)?.unwrap_or(false);
+        let ordinal: i32 = row.try_get(7)?.unwrap_or(0);
+        let char_len: Option<i32> = row.try_get(8).ok().flatten();
+        let max_i32 = max_length as i32;
+        let length = char_len.and_then(|n| u16::try_from(n).ok());
+        let universal_type = mssql_column_to_universal_type(
+            type_name,
+            Some(precision),
+            Some(scale),
+            length,
+            Some(max_i32),
+        )
+        .map_err(|e| anyhow!("table object_id {object_id} column `{name}`: {e}"))?;
+        columns.entry(object_id).or_default().push(MssqlColumnMeta {
+            name: name.to_string(),
+            type_name: type_name.to_string(),
+            nullable,
+            ordinal,
+            universal_type,
+        });
+    }
+
+    let pk_rows = client
+        .query(
+            "SELECT ic.object_id, COL_NAME(ic.object_id, ic.column_id), ic.key_ordinal \
+             FROM sys.indexes i \
+             INNER JOIN sys.index_columns ic \
+               ON ic.object_id = i.object_id AND ic.index_id = i.index_id \
+             WHERE i.is_primary_key = 1 AND ic.is_included_column = 0 \
+             ORDER BY ic.object_id, ic.key_ordinal",
+            &[],
+        )
+        .await?;
+    let mut pks: HashMap<i32, Vec<String>> = HashMap::new();
+    for row in pk_rows {
+        let object_id: i32 = row.try_get(0)?.unwrap_or(0);
+        let col: &str = row.try_get(1)?.unwrap_or("");
+        pks.entry(object_id).or_default().push(col.to_string());
+    }
+
+    let idx_rows = client
+        .query(
+            "SELECT i.object_id, i.name, i.is_unique, i.is_primary_key, i.has_filter, \
+                    i.is_disabled, i.is_hypothetical, i.type_desc, i.index_id \
+             FROM sys.indexes i \
+             INNER JOIN sys.tables t ON t.object_id = i.object_id \
+             WHERE i.type > 0 AND t.is_ms_shipped = 0",
+            &[],
+        )
+        .await?;
+    let ic_rows = client
+        .query(
+            "SELECT ic.object_id, ic.index_id, COL_NAME(ic.object_id, ic.column_id), \
+                    ic.is_included_column, ic.key_ordinal \
+             FROM sys.index_columns ic \
+             INNER JOIN sys.tables t ON t.object_id = ic.object_id \
+             WHERE t.is_ms_shipped = 0 \
+             ORDER BY ic.object_id, ic.index_id, ic.key_ordinal",
+            &[],
+        )
+        .await?;
+    let mut ic_map: HashMap<(i32, i32), (Vec<String>, Vec<String>)> = HashMap::new();
+    for row in ic_rows {
+        let object_id: i32 = row.try_get(0)?.unwrap_or(0);
+        let index_id: i32 = row.try_get(1)?.unwrap_or(0);
+        let col: &str = row.try_get(2)?.unwrap_or("");
+        let included: bool = row.try_get(3)?.unwrap_or(false);
+        let entry = ic_map.entry((object_id, index_id)).or_default();
+        if included {
+            entry.1.push(col.to_string());
+        } else {
+            entry.0.push(col.to_string());
+        }
+    }
+    let mut indexes: HashMap<i32, Vec<RawIndex>> = HashMap::new();
+    for row in idx_rows {
+        let object_id: i32 = row.try_get(0)?.unwrap_or(0);
+        let name: &str = row.try_get(1)?.unwrap_or("");
+        let unique: bool = row.try_get(2)?.unwrap_or(false);
+        let is_primary: bool = row.try_get(3)?.unwrap_or(false);
+        let has_filter: bool = row.try_get(4)?.unwrap_or(false);
+        let is_disabled: bool = row.try_get(5)?.unwrap_or(false);
+        let is_hypothetical: bool = row.try_get(6)?.unwrap_or(false);
+        let type_desc: &str = row.try_get(7)?.unwrap_or("");
+        let index_id: i32 = row.try_get(8)?.unwrap_or(0);
+        let (cols, includes) = ic_map
+            .get(&(object_id, index_id))
+            .cloned()
+            .unwrap_or_default();
+        indexes.entry(object_id).or_default().push(RawIndex {
+            name: name.to_string(),
+            unique,
+            is_primary,
+            has_filter,
+            is_disabled,
+            is_hypothetical,
+            type_desc: type_desc.to_string(),
+            columns: cols,
+            include_columns: includes,
+        });
+    }
+
+    let fk_rows = client
+        .query(
+            "SELECT fk.parent_object_id, fk.name, \
+                    SCHEMA_NAME(parent_t.schema_id), OBJECT_NAME(fk.parent_object_id), \
+                    COL_NAME(fkc.parent_object_id, fkc.parent_column_id), \
+                    SCHEMA_NAME(ref_t.schema_id), OBJECT_NAME(fk.referenced_object_id), \
+                    COL_NAME(fkc.referenced_object_id, fkc.referenced_column_id), \
+                    fkc.constraint_column_id \
+             FROM sys.foreign_keys fk \
+             INNER JOIN sys.foreign_key_columns fkc ON fkc.constraint_object_id = fk.object_id \
+             INNER JOIN sys.tables parent_t ON parent_t.object_id = fk.parent_object_id \
+             INNER JOIN sys.tables ref_t ON ref_t.object_id = fk.referenced_object_id \
+             ORDER BY fk.object_id, fkc.constraint_column_id",
+            &[],
+        )
+        .await?;
+    let mut fk_acc: HashMap<(i32, String), ForeignKeyDefinition> = HashMap::new();
+    for row in fk_rows {
+        let parent_id: i32 = row.try_get(0)?.unwrap_or(0);
+        let cname: &str = row.try_get(1)?.unwrap_or("");
+        let ref_schema: &str = row.try_get(5)?.unwrap_or("dbo");
+        let ref_table: &str = row.try_get(6)?.unwrap_or("");
+        let parent_col: &str = row.try_get(4)?.unwrap_or("");
+        let ref_col: &str = row.try_get(7)?.unwrap_or("");
+        let entry = fk_acc
+            .entry((parent_id, cname.to_string()))
+            .or_insert(ForeignKeyDefinition {
+                constraint_name: cname.to_string(),
+                columns: Vec::new(),
+                referenced_table: QualifiedName::new(ref_schema, ref_table).dotted(),
+                referenced_columns: Vec::new(),
+            });
+        entry.columns.push(parent_col.to_string());
+        entry.referenced_columns.push(ref_col.to_string());
+    }
+    let mut fks: HashMap<i32, Vec<ForeignKeyDefinition>> = HashMap::new();
+    for ((parent_id, _), fk) in fk_acc {
+        fks.entry(parent_id).or_default().push(fk);
+    }
+
+    let period_rows = client
+        .query(
+            "SELECT p.object_id, COL_NAME(p.object_id, p.start_column_id), \
+                    COL_NAME(p.object_id, p.end_column_id) \
+             FROM sys.periods p",
+            &[],
+        )
+        .await
+        .unwrap_or_default();
+    let mut periods = HashMap::new();
+    for row in period_rows {
+        let object_id: i32 = row.try_get(0)?.unwrap_or(0);
+        let start: &str = row.try_get(1)?.unwrap_or("");
+        let end: &str = row.try_get(2)?.unwrap_or("");
+        periods.insert(object_id, (start.to_string(), end.to_string()));
+    }
+
+    Ok(RawCatalog {
+        tables,
+        columns,
+        pks,
+        indexes,
+        fks,
+        periods,
+    })
+}
+
+fn filter_indexes(
+    table: &QualifiedName,
+    indexes: &[RawIndex],
+    columns: &[MssqlColumnMeta],
+) -> Vec<MssqlIndexMeta> {
+    let known: HashSet<&str> = columns.iter().map(|c| c.name.as_str()).collect();
+    let mut out = Vec::new();
+    for idx in indexes {
+        let reason = if idx.is_disabled {
+            Some("disabled")
+        } else if idx.is_hypothetical {
+            Some("hypothetical")
+        } else if idx.has_filter {
+            Some("filtered (WHERE)")
+        } else if !idx.include_columns.is_empty() {
+            Some("INCLUDE columns")
+        } else if idx_type_untranslatable(&idx.type_desc) {
+            Some(idx.type_desc.as_str())
+        } else if idx.columns.iter().any(|c| !known.contains(c.as_str())) {
+            Some("column was not copied")
+        } else {
+            None
+        };
+        if let Some(reason) = reason {
+            warn!(
+                "Skipping index `{}` on `{}`: {reason}",
+                idx.name,
+                table.dotted()
+            );
+            continue;
+        }
+        out.push(MssqlIndexMeta {
+            name: idx.name.clone(),
+            columns: idx.columns.clone(),
+            unique: idx.unique,
+            is_primary: idx.is_primary,
+        });
+    }
+    out
+}
+
+fn idx_type_untranslatable(type_desc: &str) -> bool {
+    let u = type_desc.to_ascii_uppercase();
+    u.contains("XML")
+        || u.contains("SPATIAL")
+        || u.contains("COLUMNSTORE")
+        || u.contains("FULLTEXT")
+        || u.contains("HASH")
+}
+
+/// Column definitions for SCHEMAFULL / FK mapping (PK first, then the rest).
+pub fn column_definitions(meta: &MssqlTableMeta) -> (ColumnDefinition, Vec<ColumnDefinition>) {
+    let pk_name = meta
+        .pk_columns
+        .first()
+        .cloned()
+        .unwrap_or_else(|| "id".into());
+    let pk_col = meta.column(&pk_name);
+    let primary_key = match pk_col {
+        Some(c) => {
+            let mut d = ColumnDefinition::new(&c.name, c.universal_type.clone());
+            d.nullable = c.nullable;
+            d
+        }
+        None => ColumnDefinition::new(pk_name, Type::Text),
+    };
+    let rest = meta
+        .columns
+        .iter()
+        .filter(|c| Some(c.name.as_str()) != meta.pk_columns.first().map(|s| s.as_str()))
+        .map(|c| {
+            let mut d = ColumnDefinition::new(&c.name, c.universal_type.clone());
+            d.nullable = c.nullable;
+            d
+        })
+        .collect();
+    (primary_key, rest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn table_sync_kind_is_regular_or_temporal() {
+        assert_ne!(TableSyncKind::Regular, TableSyncKind::Temporal);
+    }
+}

--- a/crates/mssql/src/from_mssql/cdc.rs
+++ b/crates/mssql/src/from_mssql/cdc.rs
@@ -1,0 +1,362 @@
+//! SQL Server CDC enablement and LSN polling.
+
+use anyhow::{anyhow, Context, Result};
+use std::collections::HashMap;
+use tracing::warn;
+
+use crate::from_mssql::catalog::MssqlTableMeta;
+use crate::from_mssql::checkpoint::MssqlLsn;
+use crate::from_mssql::client::{MssqlClient, SqlArg};
+use crate::from_mssql::naming::QualifiedName;
+use crate::types::tiberius_to_value;
+use surreal_sync_core::{Type, Value};
+
+/// CDC `__$operation` values from `fn_cdc_get_all_changes_*`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CdcOperation {
+    /// 1 — delete
+    Delete,
+    /// 2 — insert
+    Insert,
+    /// 3 — update before-image
+    UpdateBefore,
+    /// 4 — update after-image
+    UpdateAfter,
+}
+
+impl CdcOperation {
+    fn from_i32(v: i32) -> Result<Self> {
+        match v {
+            1 => Ok(Self::Delete),
+            2 => Ok(Self::Insert),
+            3 => Ok(Self::UpdateBefore),
+            4 => Ok(Self::UpdateAfter),
+            other => anyhow::bail!("unknown CDC __$operation {other}"),
+        }
+    }
+}
+
+/// One row from `cdc.fn_cdc_get_all_changes_<capture>`.
+#[derive(Debug, Clone)]
+pub struct CdcChange {
+    pub start_lsn: MssqlLsn,
+    pub operation: CdcOperation,
+    #[allow(dead_code)]
+    pub source: QualifiedName,
+    pub fields: HashMap<String, Value>,
+}
+
+fn agent_hint() -> &'static str {
+    "SQL Server Agent must be running for CDC capture jobs \
+     (Linux containers: MSSQL_AGENT_ENABLED=true). To enable Agent XPs:\n\
+     EXEC sp_configure 'show advanced options', 1; RECONFIGURE;\n\
+     EXEC sp_configure 'Agent XPs', 1; RECONFIGURE;"
+}
+
+fn map_cdc_error(err: anyhow::Error) -> anyhow::Error {
+    let msg = err.to_string();
+    if msg.contains("Agent") || msg.contains("cdc.") || msg.to_ascii_lowercase().contains("capture")
+    {
+        anyhow!("{msg}\n{}", agent_hint())
+    } else {
+        err
+    }
+}
+
+/// SQL Server error 313: the LSN is not in the capture instance's range yet (Agent lag).
+fn is_lsn_range_not_ready(err: &anyhow::Error) -> bool {
+    let msg = err.to_string();
+    msg.contains("insufficient number of arguments") || msg.contains("(code: 313")
+}
+
+/// Fail with copy-paste T-SQL when CDC is off for the database.
+pub async fn ensure_cdc_enabled(client: &MssqlClient) -> Result<()> {
+    let rows = client
+        .query(
+            "SELECT is_cdc_enabled FROM sys.databases WHERE database_id = DB_ID()",
+            &[],
+        )
+        .await?;
+    let enabled: bool = rows
+        .first()
+        .and_then(|r| r.try_get::<bool, _>(0).ok().flatten())
+        .or_else(|| {
+            rows.first()
+                .and_then(|r| r.try_get::<u8, _>(0).ok().flatten())
+                .map(|v| v != 0)
+        })
+        .unwrap_or(false);
+    if enabled {
+        return Ok(());
+    }
+    match client.execute("EXEC sys.sp_cdc_enable_db;", &[]).await {
+        Ok(_) => Ok(()),
+        Err(e) => Err(anyhow!(
+            "CDC is not enabled for this database ({e}). A DBA must run:\n\
+             EXEC sys.sp_cdc_enable_db;"
+        )),
+    }
+}
+
+/// Enable CDC on one table, or return the T-SQL a DBA must run.
+pub async fn ensure_table_cdc(client: &MssqlClient, table: &QualifiedName) -> Result<()> {
+    let rows = client
+        .query(
+            "SELECT 1 FROM cdc.change_tables ct \
+             INNER JOIN sys.tables t ON t.object_id = ct.source_object_id \
+             INNER JOIN sys.schemas s ON s.schema_id = t.schema_id \
+             WHERE s.name = @P1 AND t.name = @P2",
+            &[
+                SqlArg::String(table.schema.clone()),
+                SqlArg::String(table.table.clone()),
+            ],
+        )
+        .await;
+    if let Ok(rows) = &rows {
+        if !rows.is_empty() {
+            return Ok(());
+        }
+    }
+    let sql = format!(
+        "EXEC sys.sp_cdc_enable_table @source_schema=N'{}', @source_name=N'{}', @role_name=NULL;",
+        table.schema.replace('\'', "''"),
+        table.table.replace('\'', "''"),
+    );
+    match client.execute(&sql, &[]).await {
+        Ok(_) => Ok(()),
+        Err(e) => Err(anyhow!(
+            "CDC is not enabled for table `{}` ({e}). A DBA must run:\n{sql}",
+            table.dotted()
+        )),
+    }
+}
+
+/// Current maximum captured LSN, or `None` if CDC has not captured anything yet.
+pub async fn max_lsn(client: &MssqlClient) -> Result<Option<MssqlLsn>> {
+    let rows = client
+        .query("SELECT sys.fn_cdc_get_max_lsn()", &[])
+        .await
+        .map_err(map_cdc_error)?;
+    lsn_from_first(&rows)
+}
+
+/// Exclusive start LSN (`sys.fn_cdc_increment_lsn`).
+pub async fn increment_lsn(client: &MssqlClient, from: &MssqlLsn) -> Result<MssqlLsn> {
+    let rows = client
+        .query(
+            "SELECT sys.fn_cdc_increment_lsn(@P1)",
+            &[SqlArg::Bytes(from.0.clone())],
+        )
+        .await
+        .map_err(map_cdc_error)?;
+    lsn_from_first(&rows)?.ok_or_else(|| anyhow!("fn_cdc_increment_lsn returned NULL"))
+}
+
+fn lsn_from_first(rows: &[tiberius::Row]) -> Result<Option<MssqlLsn>> {
+    let Some(row) = rows.first() else {
+        return Ok(None);
+    };
+    let bytes: Option<&[u8]> = row.try_get(0).ok().flatten();
+    match bytes {
+        Some(b) if !b.is_empty() => Ok(Some(MssqlLsn::from_bytes(b.to_vec())?)),
+        _ => Ok(None),
+    }
+}
+
+/// Capture instance name from `cdc.change_tables` (usually `schema_table`).
+pub async fn capture_instance(client: &MssqlClient, table: &QualifiedName) -> Result<String> {
+    let rows = client
+        .query(
+            "SELECT ct.capture_instance FROM cdc.change_tables ct \
+             INNER JOIN sys.tables t ON t.object_id = ct.source_object_id \
+             INNER JOIN sys.schemas s ON s.schema_id = t.schema_id \
+             WHERE s.name = @P1 AND t.name = @P2",
+            &[
+                SqlArg::String(table.schema.clone()),
+                SqlArg::String(table.table.clone()),
+            ],
+        )
+        .await
+        .map_err(map_cdc_error)?;
+    let name: Option<&str> = rows.first().and_then(|r| r.try_get(0).ok().flatten());
+    name.map(str::to_string).ok_or_else(|| {
+        anyhow!(
+            "no CDC capture instance for `{}`. Enable CDC with:\n\
+             EXEC sys.sp_cdc_enable_table @source_schema=N'{}', @source_name=N'{}', @role_name=NULL;",
+            table.dotted(),
+            table.schema,
+            table.table
+        )
+    })
+}
+
+/// Poll `cdc.fn_cdc_get_all_changes_<capture>` for `(from_lsn, to_lsn]`.
+///
+/// `from_lsn` is exclusive (incremented). If `max_lsn <= from`, returns no rows.
+/// Update before-images (`__$operation` = 3) are skipped; after-images (4) are kept.
+pub async fn poll_changes(
+    client: &MssqlClient,
+    table: &MssqlTableMeta,
+    from_lsn: Option<&MssqlLsn>,
+    to_lsn: &MssqlLsn,
+) -> Result<Vec<CdcChange>> {
+    if let Some(from) = from_lsn {
+        if to_lsn <= from {
+            return Ok(Vec::new());
+        }
+    }
+    let start = match from_lsn {
+        Some(from) => increment_lsn(client, from).await?,
+        None => to_lsn.clone(),
+    };
+    if from_lsn.is_none() || start > *to_lsn {
+        return Ok(Vec::new());
+    }
+
+    let instance = capture_instance(client, &table.source).await?;
+    let fn_name = format!("cdc.fn_cdc_get_all_changes_{}", instance.replace(']', "]]"));
+    // `all update old` includes update before-images (`__$operation` 3) so temporal
+    // CDC can clear `is_current` on the previous version.
+    let sql = format!("SELECT * FROM {fn_name}(@P1, @P2, N'all update old')");
+    let rows = match client
+        .query(
+            &sql,
+            &[
+                SqlArg::Bytes(start.0.clone()),
+                SqlArg::Bytes(to_lsn.0.clone()),
+            ],
+        )
+        .await
+    {
+        Ok(r) => r,
+        Err(e) if is_lsn_range_not_ready(&e) => return Ok(Vec::new()),
+        Err(e) => {
+            return Err(map_cdc_error(e))
+                .with_context(|| format!("polling CDC for {}", table.source))
+        }
+    };
+
+    let mut out = Vec::new();
+    for row in rows {
+        let start_lsn = row
+            .try_get::<&[u8], _>(0)
+            .ok()
+            .flatten()
+            .ok_or_else(|| anyhow!("CDC row missing __$start_lsn"))?;
+        let op: i32 = row.try_get(2).ok().flatten().unwrap_or(0);
+        let operation = CdcOperation::from_i32(op)?;
+        let mut fields = HashMap::new();
+        for col in &table.columns {
+            let idx = row
+                .columns()
+                .iter()
+                .position(|c| c.name() == col.name)
+                .ok_or_else(|| {
+                    anyhow!(
+                        "CDC capture for `{}` is missing column `{}`",
+                        table.source,
+                        col.name
+                    )
+                })?;
+            let value = tiberius_to_value(&row, idx, &col.universal_type)?;
+            fields.insert(col.name.clone(), value);
+        }
+        out.push(CdcChange {
+            start_lsn: MssqlLsn::from_bytes(start_lsn.to_vec())?,
+            operation,
+            source: table.source.clone(),
+            fields,
+        });
+    }
+    Ok(out)
+}
+
+/// Poll the signal table capture instance (columns: id, kind, tables, consumed).
+pub async fn poll_signal_changes(
+    client: &MssqlClient,
+    signal: &QualifiedName,
+    from_lsn: Option<&MssqlLsn>,
+    to_lsn: &MssqlLsn,
+) -> Result<Vec<CdcChange>> {
+    if let Some(from) = from_lsn {
+        if to_lsn <= from {
+            return Ok(Vec::new());
+        }
+    }
+    let start = match from_lsn {
+        Some(from) => increment_lsn(client, from).await?,
+        None => return Ok(Vec::new()),
+    };
+    if start > *to_lsn {
+        return Ok(Vec::new());
+    }
+    let instance = match capture_instance(client, signal).await {
+        Ok(i) => i,
+        Err(e) => {
+            warn!("signal table CDC not ready: {e}");
+            return Ok(Vec::new());
+        }
+    };
+    let fn_name = format!("cdc.fn_cdc_get_all_changes_{instance}");
+    let sql = format!("SELECT * FROM {fn_name}(@P1, @P2, N'all')");
+    let rows = match client
+        .query(
+            &sql,
+            &[
+                SqlArg::Bytes(start.0.clone()),
+                SqlArg::Bytes(to_lsn.0.clone()),
+            ],
+        )
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            warn!("signal CDC poll failed: {e}");
+            return Ok(Vec::new());
+        }
+    };
+
+    let mut out = Vec::new();
+    for row in rows {
+        let start_lsn = row
+            .try_get::<&[u8], _>(0)
+            .ok()
+            .flatten()
+            .ok_or_else(|| anyhow!("signal CDC row missing __$start_lsn"))?;
+        let op: i32 = row.try_get(2).ok().flatten().unwrap_or(0);
+        let operation = CdcOperation::from_i32(op)?;
+        if operation == CdcOperation::UpdateBefore {
+            continue;
+        }
+        let cols = row.columns();
+        let id_idx = cols
+            .iter()
+            .position(|c| c.name().eq_ignore_ascii_case("id"));
+        let kind_idx = cols
+            .iter()
+            .position(|c| c.name().eq_ignore_ascii_case("kind"));
+        let tables_idx = cols
+            .iter()
+            .position(|c| c.name().eq_ignore_ascii_case("tables"));
+        let mut fields = HashMap::new();
+        if let Some(idx) = id_idx {
+            fields.insert("id".into(), tiberius_to_value(&row, idx, &Type::Uuid)?);
+        }
+        if let Some(idx) = kind_idx {
+            fields.insert(
+                "kind".into(),
+                tiberius_to_value(&row, idx, &Type::VarChar { length: 32 })?,
+            );
+        }
+        if let Some(idx) = tables_idx {
+            fields.insert("tables".into(), tiberius_to_value(&row, idx, &Type::Text)?);
+        }
+        out.push(CdcChange {
+            start_lsn: MssqlLsn::from_bytes(start_lsn.to_vec())?,
+            operation,
+            source: signal.clone(),
+            fields,
+        });
+    }
+    Ok(out)
+}

--- a/crates/mssql/src/from_mssql/checkpoint.rs
+++ b/crates/mssql/src/from_mssql/checkpoint.rs
@@ -1,0 +1,99 @@
+//! SQL Server CDC log sequence number checkpoint.
+
+use anyhow::{anyhow, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// 10-byte CDC LSN. Ordered by binary compare.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct MssqlLsn(pub Vec<u8>);
+
+impl MssqlLsn {
+    /// CDC LSNs are 10 bytes.
+    pub fn from_bytes(bytes: Vec<u8>) -> Result<Self> {
+        if bytes.len() != 10 && !bytes.is_empty() {
+            anyhow::bail!("SQL Server LSN must be 10 bytes, got {}", bytes.len());
+        }
+        Ok(Self(bytes))
+    }
+
+    /// Hex of the LSN bytes (no prefix).
+    pub fn to_hex(&self) -> String {
+        hex::encode(&self.0)
+    }
+
+    /// Parse hex (optional `0x` / `mssql:` prefix).
+    pub fn from_hex(s: &str) -> Result<Self> {
+        let s = s
+            .strip_prefix("mssql:")
+            .or_else(|| s.strip_prefix("0x"))
+            .or_else(|| s.strip_prefix("0X"))
+            .unwrap_or(s)
+            .trim();
+        let bytes = hex::decode(s).map_err(|e| anyhow!("invalid LSN hex `{s}`: {e}"))?;
+        Self::from_bytes(bytes)
+    }
+}
+
+impl std::fmt::Display for MssqlLsn {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_hex())
+    }
+}
+
+/// Persisted SQL Server CDC checkpoint (LSN + timestamp).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MssqlCheckpoint {
+    pub lsn: MssqlLsn,
+    pub timestamp: DateTime<Utc>,
+}
+
+impl MssqlCheckpoint {
+    /// Checkpoint at `lsn` with the current time.
+    pub fn new(lsn: MssqlLsn) -> Self {
+        Self {
+            lsn,
+            timestamp: Utc::now(),
+        }
+    }
+}
+
+impl surreal_sync_core::Checkpoint for MssqlCheckpoint {
+    const DATABASE_TYPE: &'static str = "mssql";
+
+    fn to_cli_string(&self) -> String {
+        self.lsn.to_hex()
+    }
+
+    fn from_cli_string(s: &str) -> Result<Self> {
+        let s = s.strip_prefix("mssql:").unwrap_or(s);
+        Ok(Self {
+            lsn: MssqlLsn::from_hex(s)?,
+            timestamp: Utc::now(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use surreal_sync_core::Checkpoint;
+
+    #[test]
+    fn lsn_orders_binary() {
+        let a = MssqlLsn::from_bytes(vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 1]).unwrap();
+        let b = MssqlLsn::from_bytes(vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 2]).unwrap();
+        assert!(a < b);
+    }
+
+    #[test]
+    fn checkpoint_cli_roundtrip() {
+        let original =
+            MssqlCheckpoint::new(MssqlLsn::from_bytes(vec![0, 0, 0, 0, 0, 0, 0, 1, 2, 3]).unwrap());
+        let cli = original.to_cli_string();
+        let decoded = MssqlCheckpoint::from_cli_string(&cli).unwrap();
+        assert_eq!(decoded.lsn, original.lsn);
+        let prefixed = MssqlCheckpoint::from_cli_string(&format!("mssql:{cli}")).unwrap();
+        assert_eq!(prefixed.lsn, original.lsn);
+    }
+}

--- a/crates/mssql/src/from_mssql/client.rs
+++ b/crates/mssql/src/from_mssql/client.rs
@@ -1,0 +1,229 @@
+//! SQL Server connection over Tiberius (rustls).
+
+use anyhow::{anyhow, Context, Result};
+use std::sync::Arc;
+use tiberius::{Client, Config, Query};
+use tokio::net::TcpStream;
+use tokio::sync::Mutex;
+use tokio_util::compat::{Compat, TokioAsyncWriteCompatExt};
+
+/// Tiberius client wrapped for shared async use (the client is not `Sync`).
+pub type RawClient = Client<Compat<TcpStream>>;
+
+/// Shared SQL Server client.
+#[derive(Clone)]
+pub struct MssqlClient {
+    inner: Arc<Mutex<RawClient>>,
+}
+
+/// Owned query parameter.
+#[derive(Debug, Clone)]
+pub enum SqlArg {
+    I16(i16),
+    I32(i32),
+    I64(i64),
+    F64(f64),
+    Bool(bool),
+    String(String),
+    Bytes(Vec<u8>),
+    Uuid(uuid::Uuid),
+    Null,
+}
+
+impl SqlArg {
+    /// Bind a universal value for keyset pagination.
+    pub fn from_value(value: &surreal_sync_core::Value) -> Result<Self> {
+        use surreal_sync_core::Value;
+        Ok(match value {
+            Value::Int16(v) => SqlArg::I16(*v),
+            Value::Int32(v) => SqlArg::I32(*v),
+            Value::Int64(v) => SqlArg::I64(*v),
+            Value::Int8 { value, .. } => SqlArg::I16(*value as i16),
+            Value::Bool(v) => SqlArg::Bool(*v),
+            Value::Float64(v) => SqlArg::F64(*v),
+            Value::Float32(v) => SqlArg::F64(*v as f64),
+            Value::Text(s) | Value::VarChar { value: s, .. } | Value::Char { value: s, .. } => {
+                SqlArg::String(s.clone())
+            }
+            Value::Uuid(u) => SqlArg::Uuid(*u),
+            Value::Bytes(b) | Value::Blob(b) => SqlArg::Bytes(b.clone()),
+            Value::Null => SqlArg::Null,
+            other => anyhow::bail!("cannot bind SQL Server parameter from {other:?}"),
+        })
+    }
+}
+
+/// True when the ADO.NET string asks for Windows Integrated Auth.
+pub fn integrated_security_requested(ado: &str) -> bool {
+    ado.split(';').any(|part| {
+        let part = part.trim();
+        let Some((key, value)) = part.split_once('=') else {
+            return false;
+        };
+        key.trim().eq_ignore_ascii_case("IntegratedSecurity")
+            && matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "true" | "yes" | "1"
+            )
+    })
+}
+
+/// Parse an ADO.NET connection string without connecting.
+pub fn parse_ado_config(ado: &str) -> Result<Config> {
+    Config::from_ado_string(ado).map_err(|e| anyhow!("invalid SQL Server connection string: {e}"))
+}
+
+fn reject_integrated_on_non_windows(ado: &str) -> Result<()> {
+    if integrated_security_requested(ado) {
+        #[cfg(not(windows))]
+        {
+            anyhow::bail!(
+                "Windows Integrated Auth (IntegratedSecurity=true) is Windows-only. \
+                 Use SQL authentication (User ID / Password) on this platform."
+            );
+        }
+        #[cfg(windows)]
+        {
+            let _ = ado;
+        }
+    }
+    Ok(())
+}
+
+fn install_rustls_provider() {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+}
+
+/// Connect with rustls. `IntegratedSecurity=true` is Windows-only.
+pub async fn connect(ado: &str) -> Result<MssqlClient> {
+    reject_integrated_on_non_windows(ado)?;
+    install_rustls_provider();
+    let config = parse_ado_config(ado)?;
+    let tcp = TcpStream::connect(config.get_addr())
+        .await
+        .with_context(|| format!("connecting to SQL Server at {}", config.get_addr()))?;
+    tcp.set_nodelay(true)?;
+    let raw = Client::connect(config, tcp.compat_write())
+        .await
+        .map_err(|e| anyhow!("SQL Server login failed: {e}"))?;
+    Ok(MssqlClient {
+        inner: Arc::new(Mutex::new(raw)),
+    })
+}
+
+impl MssqlClient {
+    /// Run a parameterized query and return the first result set.
+    pub async fn query(&self, sql: &str, args: &[SqlArg]) -> Result<Vec<tiberius::Row>> {
+        let mut client = self.inner.lock().await;
+        let mut q = Query::new(sql);
+        bind_args(&mut q, args);
+        let stream = q
+            .query(&mut *client)
+            .await
+            .map_err(|e| anyhow!("SQL Server query failed: {e}"))?;
+        stream
+            .into_first_result()
+            .await
+            .map_err(|e| anyhow!("SQL Server query failed: {e}"))
+    }
+
+    /// Run a statement (INSERT/EXEC/…) and return rows affected when known.
+    pub async fn execute(&self, sql: &str, args: &[SqlArg]) -> Result<u64> {
+        let mut client = self.inner.lock().await;
+        let mut q = Query::new(sql);
+        bind_args(&mut q, args);
+        let result = q
+            .execute(&mut *client)
+            .await
+            .map_err(|e| anyhow!("SQL Server execute failed: {e}"))?;
+        Ok(result.rows_affected().first().copied().unwrap_or(0))
+    }
+
+    /// Run T-SQL with no parameters (session settings, DDL).
+    pub async fn simple_query(&self, sql: &str) -> Result<()> {
+        let mut client = self.inner.lock().await;
+        client
+            .simple_query(sql)
+            .await
+            .map_err(|e| anyhow!("SQL Server query failed: {e}"))?
+            .into_results()
+            .await
+            .map_err(|e| anyhow!("SQL Server query failed: {e}"))?;
+        Ok(())
+    }
+}
+
+fn bind_args(q: &mut Query<'_>, args: &[SqlArg]) {
+    for arg in args {
+        match arg {
+            SqlArg::I16(v) => {
+                q.bind(*v);
+            }
+            SqlArg::I32(v) => {
+                q.bind(*v);
+            }
+            SqlArg::I64(v) => {
+                q.bind(*v);
+            }
+            SqlArg::F64(v) => {
+                q.bind(*v);
+            }
+            SqlArg::Bool(v) => {
+                q.bind(*v);
+            }
+            SqlArg::String(v) => {
+                q.bind(v.clone());
+            }
+            SqlArg::Bytes(v) => {
+                q.bind(v.clone());
+            }
+            SqlArg::Uuid(v) => {
+                q.bind(*v);
+            }
+            SqlArg::Null => {
+                q.bind(Option::<i32>::None);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_sql_auth() {
+        let cfg = parse_ado_config(
+            "Server=tcp:localhost,1433;User=sa;Password=Surreal_Sync1;Database=App;\
+             TrustServerCertificate=true;Encrypt=true",
+        )
+        .unwrap();
+        assert!(cfg.get_addr().contains("localhost"));
+        assert!(cfg.get_addr().contains("1433"));
+    }
+
+    #[test]
+    fn parse_integrated_security() {
+        let cfg = parse_ado_config(
+            "Server=tcp:localhost,1433;IntegratedSecurity=true;Database=App;\
+             TrustServerCertificate=true;Encrypt=true",
+        )
+        .unwrap();
+        assert!(cfg.get_addr().contains("1433"));
+        assert!(integrated_security_requested(
+            "Server=localhost;IntegratedSecurity=true"
+        ));
+        assert!(!integrated_security_requested(
+            "Server=localhost;User=sa;Password=x"
+        ));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn integrated_security_rejected_on_unix() {
+        let err = reject_integrated_on_non_windows("Server=localhost;IntegratedSecurity=true")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Windows-only"), "{err}");
+    }
+}

--- a/crates/mssql/src/from_mssql/embed/args.rs
+++ b/crates/mssql/src/from_mssql/embed/args.rs
@@ -1,0 +1,99 @@
+//! Clap argument types for SQL Server CDC (`sync` only).
+
+use clap::{Args, Subcommand, ValueEnum};
+use std::path::PathBuf;
+
+use surreal_sync_runtime::SurrealCliOpts as SurrealOpts;
+
+/// Full-sync strategy. Interleaved CDC + watermarks is the default.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, ValueEnum)]
+pub enum SyncStrategy {
+    /// Copy PK-ordered chunks while SQL Server CDC runs (signal-table watermarks).
+    /// Requires CDC, SQL Server Agent, and a primary key on every table.
+    #[default]
+    InterleavedSnapshot,
+    /// One SNAPSHOT-isolation read of each table, then CDC from that LSN.
+    /// Writers are not locked. Requires `ALLOW_SNAPSHOT_ISOLATION`.
+    SequentialSnapshot,
+}
+
+/// Default rows per keyset chunk.
+pub const DEFAULT_CHUNK_SIZE: usize = 1024;
+
+/// Whether `sync` runs an initial snapshot, streams only, or snapshots only.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub enum SnapshotModeArg {
+    /// Snapshot then continuous CDC (default).
+    #[default]
+    Initial,
+    /// CDC only from the checkpoint store (no snapshot).
+    Never,
+    /// Snapshot only, then exit (no CDC tail).
+    Only,
+}
+
+/// Source-shaped mssql commands (`sync` + flags).
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Snapshot and/or stream sync from SQL Server CDC
+    Sync(Box<SyncArgs>),
+}
+
+/// Combined snapshot+stream sync for SQL Server.
+#[derive(Args)]
+pub struct SyncArgs {
+    /// ADO.NET connection string (SQL auth, or IntegratedSecurity=true on Windows)
+    #[arg(long, env = "MSSQL_CONNECTION_STRING")]
+    pub connection_string: String,
+
+    /// Tables to sync (`schema.table` or bare name for dbo). Empty means all user tables.
+    #[arg(long, value_delimiter = ',')]
+    pub tables: Vec<String>,
+
+    /// Tables to treat as SurrealDB relations (comma-separated Surreal table names)
+    #[arg(long, value_delimiter = ',')]
+    pub relation_tables: Vec<String>,
+
+    /// Target SurrealDB namespace
+    #[arg(long)]
+    pub to_namespace: String,
+
+    /// Target SurrealDB database
+    #[arg(long)]
+    pub to_database: String,
+
+    /// Snapshot phase: initial (snapshot then stream), never (stream only), only (snapshot then exit)
+    #[arg(long, value_enum, default_value_t = SnapshotModeArg::default())]
+    pub snapshot_mode: SnapshotModeArg,
+
+    /// Stop the CDC tail after this duration (for example 3600s, 30m)
+    #[arg(long, value_name = "DURATION")]
+    pub timeout: Option<String>,
+
+    /// Full-sync strategy (interleaved-snapshot is the default)
+    #[arg(long, value_enum, default_value_t = SyncStrategy::default())]
+    pub strategy: SyncStrategy,
+
+    /// Rows read per keyset chunk during snapshot
+    #[arg(long, default_value_t = DEFAULT_CHUNK_SIZE)]
+    pub chunk_size: usize,
+
+    /// Directory to persist snapshot and stream checkpoints
+    #[arg(long, value_name = "DIR", conflicts_with = "checkpoints_surreal_table")]
+    pub checkpoint_dir: Option<String>,
+
+    /// SurrealDB table for persisting snapshot and stream checkpoints
+    #[arg(long, value_name = "TABLE", conflicts_with = "checkpoint_dir")]
+    pub checkpoints_surreal_table: Option<String>,
+
+    /// TOML file describing the transform pipeline (`[[transforms]]`)
+    #[arg(long, value_name = "PATH")]
+    pub transforms_config: Option<PathBuf>,
+
+    /// Emit DEFINE TABLE / FIELD / INDEX before copying (default is schemaless)
+    #[arg(long)]
+    pub schemafull: bool,
+
+    #[command(flatten)]
+    pub surreal: SurrealOpts,
+}

--- a/crates/mssql/src/from_mssql/embed/mod.rs
+++ b/crates/mssql/src/from_mssql/embed/mod.rs
@@ -1,0 +1,386 @@
+//! SQL Server CDC — library entrypoint for stock CLI and embedders.
+//!
+//! Pick `surreal-sync-surreal` with feature `v3` (or `v2`), define transforms,
+//! and call [`run`]:
+//!
+//! ```ignore
+//! use surreal_sync_mssql::{run, FlattenId, InPlaceTransform, Value};
+//! use surreal_sync_surreal::Surreal3Sink;
+//!
+//! #[tokio::main]
+//! async fn main() -> anyhow::Result<()> {
+//!     run::<Surreal3Sink>([
+//!         Box::new(FlattenId::default()) as Box<dyn InPlaceTransform>,
+//!     ]).await
+//! }
+//! ```
+//!
+//! `run` parses source-shaped argv (`sync` + the same flags as
+//! `surreal-sync from mssql`).
+
+mod args;
+
+pub use args::{Commands, SnapshotModeArg, SyncArgs, SyncStrategy, DEFAULT_CHUNK_SIZE};
+
+use anyhow::Context;
+use clap::Parser;
+use surreal_sync_core::{Checkpoint, CheckpointStore, NullStore, SurrealSink, SyncManager};
+use surreal_sync_runtime::checkpoint_fs::FilesystemStore;
+use surreal_sync_runtime::{init, merge_inplace_boxed, parse_duration_to_secs};
+use surreal_sync_runtime::{ApplyOpts, SnapshotTransforms};
+use tokio_util::sync::CancellationToken;
+
+use crate::from_mssql::{
+    run_initial_interleaved_snapshot_with_transforms,
+    run_interleaved_snapshot_full_sync_with_transforms, run_replication_tail_with_transforms,
+    run_sequential_snapshot_with_transforms, InterleavedFullSyncOptions, MssqlCheckpoint,
+    ReplicationTailOptions, SourceOpts, SyncOpts,
+};
+
+pub use surreal_sync_core::Value;
+pub use surreal_sync_runtime::SinkWithCheckpoints;
+pub use surreal_sync_runtime::{FlattenId, InPlaceTransform, Pipeline};
+
+/// Create a cancellation token that fires on SIGINT/SIGTERM.
+pub fn install_shutdown_token() -> CancellationToken {
+    let token = CancellationToken::new();
+    let child = token.clone();
+    tokio::spawn(async move {
+        shutdown_signal().await;
+        tracing::info!("Shutdown signal received; requesting graceful stop");
+        child.cancel();
+    });
+    token
+}
+
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        let mut sigterm =
+            match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+                Ok(s) => s,
+                Err(_) => {
+                    let _ = tokio::signal::ctrl_c().await;
+                    return;
+                }
+            };
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = sigterm.recv() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
+}
+
+fn source_opts(args: &SyncArgs) -> SourceOpts {
+    SourceOpts {
+        connection_string: args.connection_string.clone(),
+        tables: args.tables.clone(),
+        relation_tables: args.relation_tables.clone(),
+        schemafull: args.schemafull,
+        dry_run: args.surreal.dry_run,
+    }
+}
+
+fn sync_opts(args: &SyncArgs) -> SyncOpts {
+    SyncOpts {
+        batch_size: args.surreal.batch_size,
+        dry_run: args.surreal.dry_run,
+        schemafull: args.schemafull,
+    }
+}
+
+fn parse_timeout(raw: Option<&str>) -> anyhow::Result<Option<chrono::DateTime<chrono::Utc>>> {
+    Ok(match raw {
+        Some(raw) => {
+            let seconds = parse_duration_to_secs(raw)?;
+            Some(chrono::Utc::now() + chrono::Duration::seconds(seconds))
+        }
+        None => None,
+    })
+}
+
+fn tail_options(
+    args: &SyncArgs,
+    cancel: CancellationToken,
+) -> anyhow::Result<ReplicationTailOptions> {
+    let deadline = parse_timeout(args.timeout.as_deref())?;
+    Ok(ReplicationTailOptions::stream(deadline, None).with_cancel(cancel))
+}
+
+async fn read_latest_replication_checkpoint<St: CheckpointStore>(
+    manager: &SyncManager<St>,
+) -> anyhow::Result<MssqlCheckpoint> {
+    use surreal_sync_core::SyncPhase;
+    if let Ok(end) = manager
+        .read_checkpoint::<MssqlCheckpoint>(SyncPhase::FullSyncEnd)
+        .await
+    {
+        return Ok(end);
+    }
+    manager
+        .read_checkpoint(SyncPhase::FullSyncStart)
+        .await
+        .with_context(|| "No FullSyncEnd or FullSyncStart checkpoint found")
+}
+
+/// Run sync with a pre-built sink; checkpoint backend is selected from args.
+pub async fn run_sync<S: SinkWithCheckpoints>(
+    args: SyncArgs,
+    sink: &S,
+    pipeline: Pipeline,
+    apply_opts: ApplyOpts,
+) -> anyhow::Result<()> {
+    if args.checkpoint_dir.is_some() && args.checkpoints_surreal_table.is_some() {
+        anyhow::bail!("Cannot specify both --checkpoint-dir and --checkpoints-surreal-table");
+    }
+
+    let cancel = install_shutdown_token();
+
+    if let Some(dir) = args.checkpoint_dir.clone() {
+        let manager = SyncManager::new(FilesystemStore::new(&dir));
+        orchestrate(sink, args, cancel, Some(&manager), pipeline, apply_opts).await
+    } else if let Some(table) = args.checkpoints_surreal_table.clone() {
+        let store = sink.table_checkpoints(table);
+        let manager = SyncManager::new(store);
+        orchestrate(sink, args, cancel, Some(&manager), pipeline, apply_opts).await
+    } else {
+        orchestrate::<_, NullStore>(sink, args, cancel, None, pipeline, apply_opts).await
+    }
+}
+
+/// Load `--transforms-config` (if any), append Rust [`InPlaceTransform`] stages,
+/// connect `S`, then [`run_sync`].
+pub async fn run_sync_with_extra_transforms<S: SinkWithCheckpoints>(
+    args: SyncArgs,
+    extra: impl IntoIterator<Item = Box<dyn InPlaceTransform>>,
+) -> anyhow::Result<()> {
+    let (pipeline, apply_opts) = merge_inplace_boxed(args.transforms_config.as_deref(), extra)?;
+    let config = args
+        .surreal
+        .to_config(args.to_namespace.clone(), args.to_database.clone());
+    let sink = S::connect(&config).await?;
+    run_sync(args, &sink, pipeline, apply_opts).await
+}
+
+/// Run with parsed [`SyncArgs`] and only TOML transforms.
+pub async fn run_args_with_sink<S: SurrealSink>(args: SyncArgs, sink: &S) -> anyhow::Result<()> {
+    let (pipeline, apply_opts) =
+        surreal_sync_runtime::load_transforms_from_args(args.transforms_config.as_deref())?;
+    let cancel = install_shutdown_token();
+    orchestrate::<_, NullStore>(sink, args, cancel, None, pipeline, apply_opts).await
+}
+
+#[derive(Parser)]
+#[command(
+    name = "surreal-sync-mssql",
+    about = "Embeddable SQL Server sync (same flags as `surreal-sync from mssql`)"
+)]
+struct EmbedCli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+/// Parses CLI args, connects the sink type you pass, and sets up checkpoints.
+pub async fn run<S: SinkWithCheckpoints>(
+    extra: impl IntoIterator<Item = Box<dyn InPlaceTransform>>,
+) -> anyhow::Result<()> {
+    init();
+    let cli = EmbedCli::parse();
+    match cli.command {
+        Commands::Sync(args) => run_sync_with_extra_transforms::<S>(*args, extra).await,
+    }
+}
+
+async fn orchestrate<S, St>(
+    sink: &S,
+    args: SyncArgs,
+    cancel: CancellationToken,
+    checkpoint_manager: Option<&SyncManager<St>>,
+    pipeline: Pipeline,
+    apply_opts: ApplyOpts,
+) -> anyhow::Result<()>
+where
+    S: SurrealSink,
+    St: CheckpointStore,
+{
+    let transforms = SnapshotTransforms {
+        pipeline,
+        apply_opts,
+    };
+    let snapshot_mode = args.snapshot_mode;
+    let strategy = args.strategy;
+    let chunk_size = args.chunk_size;
+    let source_opts = source_opts(&args);
+    let sync_opts = sync_opts(&args);
+    let stream_options = tail_options(&args, cancel.clone())?;
+
+    match snapshot_mode {
+        SnapshotModeArg::Only => {
+            snapshot_full(
+                sink,
+                &source_opts,
+                &sync_opts,
+                strategy,
+                chunk_size,
+                cancel,
+                checkpoint_manager,
+                &transforms,
+            )
+            .await?;
+            Ok(())
+        }
+        SnapshotModeArg::Never => {
+            let from_checkpoint = match checkpoint_manager {
+                Some(manager) => read_latest_replication_checkpoint(manager).await?,
+                None => anyhow::bail!(
+                    "--checkpoint-dir or --checkpoints-surreal-table is required with --snapshot-mode never"
+                ),
+            };
+            run_replication_tail_with_transforms(
+                sink,
+                source_opts,
+                from_checkpoint,
+                stream_options,
+                checkpoint_manager,
+                &transforms.pipeline,
+                &transforms.apply_opts,
+            )
+            .await
+        }
+        SnapshotModeArg::Initial => {
+            let interleaved_outcome = match strategy {
+                SyncStrategy::InterleavedSnapshot => {
+                    let initial = run_initial_interleaved_snapshot_with_transforms(
+                        sink,
+                        &source_opts,
+                        chunk_size,
+                        cancel.clone(),
+                        checkpoint_manager,
+                        &transforms,
+                    )
+                    .await?;
+                    initial.sync_outcome
+                }
+                SyncStrategy::SequentialSnapshot => {
+                    let checkpoint = run_sequential_snapshot_with_transforms(
+                        sink,
+                        &source_opts,
+                        &sync_opts,
+                        chunk_size,
+                        &cancel,
+                        checkpoint_manager,
+                        &transforms.pipeline,
+                        &transforms.apply_opts,
+                    )
+                    .await?;
+                    if cancel.is_cancelled() {
+                        tracing::info!(
+                            "Sync cancelled during SNAPSHOT dump; not handing off to streaming. \
+                             Resume from FullSyncStart: {}",
+                            checkpoint.to_cli_string()
+                        );
+                        return Ok(());
+                    }
+                    return run_replication_tail_with_transforms(
+                        sink,
+                        source_opts,
+                        checkpoint,
+                        stream_options,
+                        checkpoint_manager,
+                        &transforms.pipeline,
+                        &transforms.apply_opts,
+                    )
+                    .await;
+                }
+            };
+
+            if let Some(outcome) = interleaved_outcome {
+                if outcome.cancelled {
+                    tracing::info!(
+                        "Sync cancelled during snapshot; not handing off to streaming. \
+                         Resume from FullSyncStart: {}",
+                        outcome.start.to_cli_string()
+                    );
+                    return Ok(());
+                }
+                run_replication_tail_with_transforms(
+                    sink,
+                    source_opts,
+                    outcome.end,
+                    stream_options,
+                    checkpoint_manager,
+                    &transforms.pipeline,
+                    &transforms.apply_opts,
+                )
+                .await
+            } else {
+                Ok(())
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn snapshot_full<S, St>(
+    sink: &S,
+    source_opts: &SourceOpts,
+    sync_opts: &SyncOpts,
+    strategy: SyncStrategy,
+    chunk_size: usize,
+    cancel: CancellationToken,
+    manager: Option<&SyncManager<St>>,
+    transforms: &SnapshotTransforms,
+) -> anyhow::Result<Option<crate::from_mssql::InterleavedFullSyncOutcome>>
+where
+    S: SurrealSink,
+    St: CheckpointStore,
+{
+    match strategy {
+        SyncStrategy::InterleavedSnapshot => {
+            let outcome = run_interleaved_snapshot_full_sync_with_transforms(
+                sink,
+                source_opts,
+                chunk_size,
+                cancel,
+                manager,
+                InterleavedFullSyncOptions::default(),
+                transforms,
+            )
+            .await?;
+            if outcome.cancelled {
+                tracing::info!(
+                    "SQL Server watermark snapshot cancelled; resume from FullSyncStart: {}",
+                    outcome.start.to_cli_string()
+                );
+                return Ok(None);
+            }
+            tracing::info!(
+                "SQL Server watermark snapshot completed (final checkpoint: {})",
+                outcome.end.to_cli_string()
+            );
+            Ok(Some(outcome))
+        }
+        SyncStrategy::SequentialSnapshot => {
+            let checkpoint = run_sequential_snapshot_with_transforms(
+                sink,
+                source_opts,
+                sync_opts,
+                chunk_size,
+                &cancel,
+                manager,
+                &transforms.pipeline,
+                &transforms.apply_opts,
+            )
+            .await?;
+            tracing::info!(
+                "Sequential SNAPSHOT-isolation dump completed (LSN {})",
+                checkpoint.to_cli_string()
+            );
+            Ok(None)
+        }
+    }
+}

--- a/crates/mssql/src/from_mssql/incremental_sync.rs
+++ b/crates/mssql/src/from_mssql/incremental_sync.rs
@@ -1,0 +1,306 @@
+//! SQL Server CDC replication tail (after snapshot handoff).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use surreal_sync_core::SurrealSink;
+use surreal_sync_core::{Checkpoint, CheckpointStore, DatabaseSchema, SyncManager, SyncPhase};
+use surreal_sync_runtime::{
+    ApplyOpts, CheckpointPolicy, Pipeline, PositionedEvent, SourceDriver, SourceRuntimeOpts,
+    StopReason,
+};
+use tracing::info;
+
+use crate::from_mssql::catalog::{MssqlTableMeta, TableSyncKind};
+use crate::from_mssql::cdc::{self, CdcChange, CdcOperation};
+use crate::from_mssql::checkpoint::{MssqlCheckpoint, MssqlLsn};
+use crate::from_mssql::client::MssqlClient;
+use crate::from_mssql::regular::{self, RegularCdc};
+use crate::from_mssql::schema::temporal_targets;
+use crate::from_mssql::temporal;
+use crate::from_mssql::SourceOpts;
+
+const DEFAULT_IDLE_SLEEP: Duration = Duration::from_millis(100);
+const DEFAULT_CHECKPOINT_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Options for the CDC replication tail.
+#[derive(Clone, Debug)]
+pub struct ReplicationTailOptions {
+    pub deadline: Option<DateTime<Utc>>,
+    pub until: Option<MssqlLsn>,
+    pub checkpoint_interval: Duration,
+    pub idle_sleep: Duration,
+    pub cancel: tokio_util::sync::CancellationToken,
+    pub event_batch_size: usize,
+}
+
+impl ReplicationTailOptions {
+    pub fn stream(deadline: Option<DateTime<Utc>>, until: Option<MssqlLsn>) -> Self {
+        Self {
+            deadline,
+            until,
+            checkpoint_interval: DEFAULT_CHECKPOINT_INTERVAL,
+            idle_sleep: DEFAULT_IDLE_SLEEP,
+            cancel: tokio_util::sync::CancellationToken::new(),
+            event_batch_size: 32,
+        }
+    }
+
+    pub fn with_cancel(mut self, cancel: tokio_util::sync::CancellationToken) -> Self {
+        self.cancel = cancel;
+        self
+    }
+}
+
+pub async fn run_replication_tail<S: SurrealSink>(
+    surreal: &S,
+    from_opts: SourceOpts,
+    from_checkpoint: MssqlCheckpoint,
+) -> Result<()> {
+    run_replication_tail_with_checkpoints::<S, surreal_sync_core::NullStore>(
+        surreal,
+        from_opts,
+        from_checkpoint,
+        ReplicationTailOptions::stream(None, None),
+        None,
+    )
+    .await
+}
+
+pub async fn run_replication_tail_with_checkpoints<S, St>(
+    surreal: &S,
+    from_opts: SourceOpts,
+    from_checkpoint: MssqlCheckpoint,
+    options: ReplicationTailOptions,
+    checkpoint_manager: Option<&SyncManager<St>>,
+) -> Result<()>
+where
+    S: SurrealSink,
+    St: CheckpointStore,
+{
+    let pipeline = Pipeline::new();
+    let apply_opts = ApplyOpts::identity();
+    run_replication_tail_with_transforms(
+        surreal,
+        from_opts,
+        from_checkpoint,
+        options,
+        checkpoint_manager,
+        &pipeline,
+        &apply_opts,
+    )
+    .await
+}
+
+pub async fn run_replication_tail_with_transforms<S, St>(
+    surreal: &S,
+    from_opts: SourceOpts,
+    from_checkpoint: MssqlCheckpoint,
+    options: ReplicationTailOptions,
+    checkpoint_manager: Option<&SyncManager<St>>,
+    pipeline: &Pipeline,
+    apply_opts: &ApplyOpts,
+) -> Result<()>
+where
+    S: SurrealSink,
+    St: CheckpointStore,
+{
+    info!(
+        "Starting SQL Server CDC incremental sync from checkpoint: {}",
+        from_checkpoint.to_cli_string()
+    );
+
+    let client = crate::from_mssql::client::connect(&from_opts.connection_string).await?;
+    let metas =
+        crate::from_mssql::catalog::collect_database_schema(&client, &from_opts.tables).await?;
+    let db_schema = crate::from_mssql::schema::database_schema(&metas);
+    let mut driver = MssqlSourceDriver {
+        client,
+        metas,
+        db_schema,
+        relation_tables: from_opts.relation_tables.clone(),
+        from_lsn: Some(from_checkpoint.lsn.clone()),
+        last_sunk: Some(from_checkpoint.clone()),
+        options: options.clone(),
+        checkpoint_manager,
+        until_reached: false,
+        cancel_seen: false,
+        total_changes: 0,
+    };
+
+    let runtime_opts = SourceRuntimeOpts::new();
+    let transformer = Arc::new(pipeline.clone());
+    let exit = surreal_sync_runtime::run_source_runtime_with(
+        &mut driver,
+        surreal,
+        transformer,
+        apply_opts,
+        &runtime_opts,
+    )
+    .await?;
+
+    match exit {
+        surreal_sync_runtime::RuntimeExit::Stopped(StopReason::Cancelled) => {
+            info!("Cancellation requested, stopping incremental sync");
+        }
+        surreal_sync_runtime::RuntimeExit::Stopped(StopReason::Deadline) => {
+            info!("Deadline reached, stopping incremental sync");
+        }
+        surreal_sync_runtime::RuntimeExit::Stopped(StopReason::Until) => {
+            info!("Reached target LSN, stopping incremental sync");
+        }
+        surreal_sync_runtime::RuntimeExit::Stopped(StopReason::Finished) => {
+            info!("SQL Server CDC source finished");
+        }
+    }
+
+    if let Some(cp) = driver.last_sunk.clone() {
+        if let Some(manager) = checkpoint_manager {
+            manager
+                .emit_checkpoint(&cp, SyncPhase::CatchUpProgress)
+                .await?;
+        }
+    }
+    info!(
+        "SQL Server CDC incremental sync completed: {} changes sunk",
+        driver.total_changes
+    );
+    Ok(())
+}
+
+struct MssqlSourceDriver<'a, St: CheckpointStore> {
+    client: MssqlClient,
+    metas: Vec<MssqlTableMeta>,
+    db_schema: DatabaseSchema,
+    relation_tables: Vec<String>,
+    from_lsn: Option<MssqlLsn>,
+    last_sunk: Option<MssqlCheckpoint>,
+    options: ReplicationTailOptions,
+    checkpoint_manager: Option<&'a SyncManager<St>>,
+    until_reached: bool,
+    cancel_seen: bool,
+    total_changes: u64,
+}
+
+impl<St> MssqlSourceDriver<'_, St>
+where
+    St: CheckpointStore,
+{
+    async fn poll_all(&mut self) -> Result<Vec<(CdcChange, MssqlTableMeta)>> {
+        let Some(to) = cdc::max_lsn(&self.client).await? else {
+            return Ok(Vec::new());
+        };
+        if let Some(until) = &self.options.until {
+            if to >= *until {
+                self.until_reached = true;
+            }
+        }
+        let mut batch = Vec::new();
+        for meta in &self.metas {
+            let changes =
+                cdc::poll_changes(&self.client, meta, self.from_lsn.as_ref(), &to).await?;
+            for ch in changes {
+                batch.push((ch, meta.clone()));
+            }
+        }
+        Ok(batch)
+    }
+}
+
+#[async_trait::async_trait]
+impl<St> SourceDriver for MssqlSourceDriver<'_, St>
+where
+    St: CheckpointStore,
+{
+    type Position = MssqlCheckpoint;
+
+    async fn poll_work(&mut self) -> Result<Vec<PositionedEvent<Self::Position>>> {
+        if self.options.cancel.is_cancelled() {
+            self.cancel_seen = true;
+            return Ok(Vec::new());
+        }
+        if let Some(deadline) = self.options.deadline {
+            if Utc::now() >= deadline {
+                return Ok(Vec::new());
+            }
+        }
+
+        let batch = self.poll_all().await?;
+        if batch.is_empty() {
+            tokio::time::sleep(self.options.idle_sleep).await;
+            return Ok(Vec::new());
+        }
+
+        let temporal = temporal_targets(&self.metas);
+        let mut events = Vec::new();
+        for (change, meta) in batch {
+            let pos = MssqlCheckpoint::new(change.start_lsn.clone());
+            match meta.kind {
+                TableSyncKind::Regular => {
+                    if change.operation == CdcOperation::UpdateBefore {
+                        continue;
+                    }
+                    let td = self.db_schema.get_table(&meta.target);
+                    match regular::apply_change(
+                        &meta,
+                        &change,
+                        td,
+                        &self.relation_tables,
+                        &temporal,
+                    )? {
+                        RegularCdc::Row(c) => events.push(PositionedEvent::change(c, pos)),
+                        RegularCdc::Relation(r) => {
+                            events.push(PositionedEvent::relation_change(r, pos))
+                        }
+                    }
+                }
+                TableSyncKind::Temporal => {
+                    let action = temporal::apply_change(&meta, &change)?;
+                    if let Some(c) = action.new_version {
+                        events.push(PositionedEvent::change(c, pos));
+                    }
+                }
+            }
+        }
+        Ok(events)
+    }
+
+    async fn advance_watermark(&mut self, position: Self::Position) -> Result<()> {
+        self.from_lsn = Some(position.lsn.clone());
+        self.last_sunk = Some(position);
+        self.total_changes += 1;
+        Ok(())
+    }
+
+    fn stop_reason(&self) -> Option<StopReason> {
+        if self.cancel_seen || self.options.cancel.is_cancelled() {
+            return Some(StopReason::Cancelled);
+        }
+        if let Some(deadline) = self.options.deadline {
+            if Utc::now() >= deadline {
+                return Some(StopReason::Deadline);
+            }
+        }
+        if self.until_reached {
+            return Some(StopReason::Until);
+        }
+        None
+    }
+
+    fn checkpoint_policy(&self) -> CheckpointPolicy {
+        CheckpointPolicy::IntervalWhenDrained {
+            interval: self.options.checkpoint_interval,
+        }
+    }
+
+    async fn persist_checkpoint(&mut self, position: Self::Position) -> Result<()> {
+        if let Some(manager) = self.checkpoint_manager {
+            manager
+                .emit_checkpoint(&position, SyncPhase::CatchUpProgress)
+                .await?;
+        }
+        Ok(())
+    }
+}

--- a/crates/mssql/src/from_mssql/incremental_sync.rs
+++ b/crates/mssql/src/from_mssql/incremental_sync.rs
@@ -257,7 +257,8 @@ where
                     }
                 }
                 TableSyncKind::Temporal => {
-                    let action = temporal::apply_change(&meta, &change)?;
+                    let td = self.db_schema.get_table(&meta.target);
+                    let action = temporal::apply_change(&meta, &change, td, &temporal)?;
                     if let Some(c) = action.new_version {
                         events.push(PositionedEvent::change(c, pos));
                     }

--- a/crates/mssql/src/from_mssql/mod.rs
+++ b/crates/mssql/src/from_mssql/mod.rs
@@ -1,0 +1,90 @@
+//! SQL Server CDC source for surreal-sync.
+//!
+//! # Embed surface
+//!
+//! Only [`run`], [`FlattenId`], [`InPlaceTransform`], and [`Value`] are the
+//! supported embed API:
+//!
+//! ```ignore
+//! use surreal_sync_mssql::{run, FlattenId, InPlaceTransform, Value};
+//! use surreal_sync_surreal::Surreal3Sink;
+//!
+//! run::<Surreal3Sink>([Box::new(FlattenId::default()) as Box<dyn InPlaceTransform>]).await?;
+//! ```
+
+pub(crate) mod embed;
+
+mod catalog;
+mod cdc;
+mod checkpoint;
+mod client;
+mod incremental_sync;
+mod naming;
+mod regular;
+mod schema;
+mod sequential;
+mod signal;
+mod temporal;
+mod watermark_source;
+
+#[doc(hidden)]
+pub mod testing;
+
+pub use catalog::{collect_database_schema, list_user_tables, TableSyncKind};
+pub use checkpoint::{MssqlCheckpoint, MssqlLsn};
+pub use incremental_sync::{
+    run_replication_tail, run_replication_tail_with_checkpoints,
+    run_replication_tail_with_transforms, ReplicationTailOptions,
+};
+pub use naming::{detect_collisions, parse_table_ref, target_table_name, QualifiedName};
+pub use sequential::run_sequential_snapshot_with_transforms;
+pub use signal::SIGNAL_TABLE;
+pub use temporal::version_id;
+pub use watermark_source::{
+    run_initial_interleaved_snapshot, run_initial_interleaved_snapshot_with_transforms,
+    run_interleaved_snapshot_full_sync, run_interleaved_snapshot_full_sync_with_transforms,
+    ConnectOptions, InterleavedFullSyncOptions, InterleavedFullSyncOutcome, MssqlWatermarkSource,
+};
+
+pub use regular::record_id;
+
+/// SQL Server source connection options.
+#[derive(Clone, Debug, Default)]
+pub struct SourceOpts {
+    pub connection_string: String,
+    pub tables: Vec<String>,
+    pub relation_tables: Vec<String>,
+    pub schemafull: bool,
+    pub dry_run: bool,
+}
+
+/// Sync options (non-connection related).
+#[derive(Clone, Debug)]
+pub struct SyncOpts {
+    pub batch_size: usize,
+    pub dry_run: bool,
+    /// Emit `DEFINE TABLE` / `FIELD` / `INDEX` before copying rows (opt-in).
+    pub schemafull: bool,
+}
+
+impl Default for SyncOpts {
+    fn default() -> Self {
+        Self {
+            batch_size: 1000,
+            dry_run: false,
+            schemafull: false,
+        }
+    }
+}
+
+/// Public embed surface — only these four items are the supported embed API.
+pub use embed::{run, FlattenId, InPlaceTransform, Value};
+
+/// Stock CLI argv helpers (`run_sync`, clap args). Not part of the embed API.
+#[doc(hidden)]
+pub mod cli {
+    pub use super::embed::{
+        run_args_with_sink, run_sync, Commands, Pipeline, SnapshotModeArg, SyncArgs, SyncStrategy,
+        DEFAULT_CHUNK_SIZE,
+    };
+}

--- a/crates/mssql/src/from_mssql/naming.rs
+++ b/crates/mssql/src/from_mssql/naming.rs
@@ -1,0 +1,160 @@
+//! Source table names (`dbo.Article`) and SurrealDB target names (`Article`).
+
+use anyhow::{anyhow, Result};
+use std::collections::HashMap;
+
+/// Schema-qualified SQL Server table name.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct QualifiedName {
+    /// Schema (defaults to `dbo` when a bare table name is given).
+    pub schema: String,
+    /// Table name without schema.
+    pub table: String,
+}
+
+impl QualifiedName {
+    /// Build a qualified name.
+    pub fn new(schema: impl Into<String>, table: impl Into<String>) -> Self {
+        Self {
+            schema: schema.into(),
+            table: table.into(),
+        }
+    }
+
+    /// `schema.table` without brackets.
+    pub fn dotted(&self) -> String {
+        format!("{}.{}", self.schema, self.table)
+    }
+
+    /// Bracketed `[schema].[table]` for T-SQL.
+    pub fn quoted(&self) -> String {
+        format!("{}.{}", bracket(&self.schema), bracket(&self.table))
+    }
+}
+
+impl std::fmt::Display for QualifiedName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.dotted())
+    }
+}
+
+/// Quote a T-SQL identifier.
+pub fn bracket(name: &str) -> String {
+    format!("[{}]", name.replace(']', "]]"))
+}
+
+fn strip_brackets(part: &str) -> &str {
+    let part = part.trim();
+    part.strip_prefix('[')
+        .and_then(|s| s.strip_suffix(']'))
+        .unwrap_or(part)
+}
+
+/// Parse `table`, `schema.table`, or `[dbo].[Article]`. A bare name is `dbo`.
+pub fn parse_table_ref(input: &str) -> Result<QualifiedName> {
+    let input = input.trim();
+    if input.is_empty() {
+        anyhow::bail!("empty table name");
+    }
+    let parts: Vec<&str> = if input.contains('[') {
+        input
+            .split('.')
+            .map(strip_brackets)
+            .filter(|p| !p.is_empty())
+            .collect()
+    } else {
+        input.split('.').map(str::trim).collect()
+    };
+    match parts.as_slice() {
+        [table] => Ok(QualifiedName::new("dbo", *table)),
+        [schema, table] => Ok(QualifiedName::new(*schema, *table)),
+        _ => Err(anyhow!(
+            "invalid table name `{input}`; use `table` or `schema.table`"
+        )),
+    }
+}
+
+/// SurrealDB table name: `dbo.T` → `T`, `sales.Order` → `sales__Order`.
+pub fn target_table_name(name: &QualifiedName) -> String {
+    if name.schema.eq_ignore_ascii_case("dbo") {
+        name.table.clone()
+    } else {
+        format!("{}__{}", name.schema, name.table)
+    }
+}
+
+/// Error if two source tables would write the same SurrealDB table.
+pub fn detect_collisions(names: &[QualifiedName]) -> Result<()> {
+    let mut by_target: HashMap<String, Vec<String>> = HashMap::new();
+    for name in names {
+        by_target
+            .entry(target_table_name(name))
+            .or_default()
+            .push(name.dotted());
+    }
+    let mut colliding: Vec<(String, Vec<String>)> = by_target
+        .into_iter()
+        .filter(|(_, sources)| sources.len() > 1)
+        .collect();
+    if colliding.is_empty() {
+        return Ok(());
+    }
+    colliding.sort_by(|a, b| a.0.cmp(&b.0));
+    let detail = colliding
+        .into_iter()
+        .map(|(target, sources)| format!("{target} <= {}", sources.join(", ")))
+        .collect::<Vec<_>>()
+        .join("; ");
+    Err(anyhow!(
+        "source tables map to the same SurrealDB table name: {detail}"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_bare_and_qualified() {
+        assert_eq!(
+            parse_table_ref("Article").unwrap(),
+            QualifiedName::new("dbo", "Article")
+        );
+        assert_eq!(
+            parse_table_ref("sales.Order").unwrap(),
+            QualifiedName::new("sales", "Order")
+        );
+        assert_eq!(
+            parse_table_ref("[dbo].[Article]").unwrap(),
+            QualifiedName::new("dbo", "Article")
+        );
+    }
+
+    #[test]
+    fn target_names() {
+        assert_eq!(
+            target_table_name(&QualifiedName::new("dbo", "Article")),
+            "Article"
+        );
+        assert_eq!(
+            target_table_name(&QualifiedName::new("sales", "Order")),
+            "sales__Order"
+        );
+    }
+
+    #[test]
+    fn collisions_list_sources() {
+        detect_collisions(&[
+            QualifiedName::new("dbo", "T"),
+            QualifiedName::new("sales", "Order"),
+        ])
+        .unwrap();
+        let err = detect_collisions(&[
+            QualifiedName::new("dbo", "sales__Order"),
+            QualifiedName::new("sales", "Order"),
+        ])
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("sales__Order"), "{err}");
+    }
+}

--- a/crates/mssql/src/from_mssql/regular.rs
+++ b/crates/mssql/src/from_mssql/regular.rs
@@ -4,7 +4,8 @@ use anyhow::Result;
 use std::collections::{HashMap, HashSet};
 use surreal_sync_core::{
     build_composite_record_id, build_relation_from_change, build_relation_from_row, classify_table,
-    Change, ChangeOp, Relation, RelationChange, Row, TableDefinition, TableKind, Value,
+    flatten_composite_id, Change, ChangeOp, ForeignKeyDefinition, Relation, RelationChange, Row,
+    TableDefinition, TableKind, Value,
 };
 
 use crate::from_mssql::catalog::{MssqlColumnMeta, MssqlTableMeta};
@@ -92,10 +93,10 @@ pub fn entity_row(
     temporal_targets: &HashSet<String>,
 ) -> Row {
     let mut fields = fields;
+    let id = record_id(pk_parts(&fields, pk_columns));
     if let Some(td) = table_def {
         transform_fks(&mut fields, td, temporal_targets);
     }
-    let id = record_id(pk_parts(&fields, pk_columns));
     Row::new(target, index, id, fields)
 }
 
@@ -185,11 +186,11 @@ pub fn apply_change(
     temporal_targets: &HashSet<String>,
 ) -> Result<RegularCdc> {
     let mut fields = change.fields.clone();
+    let id = record_id(pk_parts(&fields, &meta.pk_columns));
     if let Some(td) = table_def {
         transform_fks(&mut fields, td, temporal_targets);
         match classify(td, relation_tables, temporal_targets) {
             TableKind::Relation { in_fk, out_fk } => {
-                let id = record_id(pk_parts(&fields, &meta.pk_columns));
                 let op = match change.operation {
                     CdcOperation::Delete => ChangeOp::Delete,
                     CdcOperation::Insert => ChangeOp::Create,
@@ -202,7 +203,6 @@ pub fn apply_change(
             TableKind::Entity => {}
         }
     }
-    let id = record_id(pk_parts(&fields, &meta.pk_columns));
     let op = match change.operation {
         CdcOperation::Delete => ChangeOp::Delete,
         CdcOperation::Insert => ChangeOp::Create,
@@ -221,6 +221,97 @@ pub fn apply_change(
 pub enum RegularCdc {
     Row(Change),
     Relation(RelationChange),
+}
+
+/// Flatten snapshot items so interleaved `read_chunk` can sink join tables as rows.
+pub fn snapshot_rows(
+    meta: &MssqlTableMeta,
+    maps: Vec<HashMap<String, Value>>,
+    start_index: u64,
+    table_def: Option<&TableDefinition>,
+    relation_tables: &[String],
+    temporal_targets: &HashSet<String>,
+) -> Vec<Row> {
+    if let Some(td) = table_def {
+        if let TableKind::Relation { in_fk, out_fk } =
+            classify(td, relation_tables, temporal_targets)
+        {
+            return maps
+                .into_iter()
+                .enumerate()
+                .map(|(i, fields)| {
+                    relation_row_keeping_pk(
+                        &meta.target,
+                        start_index + i as u64,
+                        fields,
+                        &meta.pk_columns,
+                        &in_fk,
+                        &out_fk,
+                    )
+                })
+                .collect();
+        }
+    }
+    let (rows, _) = snapshot_items(
+        meta,
+        maps,
+        start_index,
+        table_def,
+        relation_tables,
+        temporal_targets,
+    );
+    rows
+}
+
+/// Join-table row for interleaved snapshot: keep source PK columns for keyset
+/// cursors and add `in` / `out` Things for graph queries.
+fn relation_row_keeping_pk(
+    target: &str,
+    index: u64,
+    mut fields: HashMap<String, Value>,
+    pk_columns: &[String],
+    in_fk: &ForeignKeyDefinition,
+    out_fk: &ForeignKeyDefinition,
+) -> Row {
+    let id = flatten_composite_id(record_id(pk_parts(&fields, pk_columns)), ":");
+    add_endpoint_thing(&mut fields, in_fk, "in");
+    add_endpoint_thing(&mut fields, out_fk, "out");
+    Row::new(target, index, id, fields)
+}
+
+fn add_endpoint_thing(fields: &mut HashMap<String, Value>, fk: &ForeignKeyDefinition, name: &str) {
+    if let Some(col) = fk.columns.first() {
+        if let Some(value) = fields.get(col).cloned() {
+            let thing = match value {
+                Value::Null => Value::Null,
+                other => Value::Thing {
+                    table: fk.referenced_table.clone(),
+                    id: Box::new(other),
+                },
+            };
+            fields.insert(name.to_string(), thing);
+        }
+    }
+}
+
+/// Relation properties plus `in` / `out` record links.
+pub fn relation_fields(rel: &Relation) -> HashMap<String, Value> {
+    let mut fields = rel.data.clone();
+    fields.insert(
+        "in".into(),
+        Value::Thing {
+            table: rel.input.table.clone(),
+            id: Box::new(rel.input.id.clone()),
+        },
+    );
+    fields.insert(
+        "out".into(),
+        Value::Thing {
+            table: rel.output.table.clone(),
+            id: Box::new(rel.output.id.clone()),
+        },
+    );
+    fields
 }
 
 /// Snapshot items from field maps (entity rows or relations).

--- a/crates/mssql/src/from_mssql/regular.rs
+++ b/crates/mssql/src/from_mssql/regular.rs
@@ -1,0 +1,264 @@
+//! Ordinary (non-temporal) tables: PK record ids, keyset reads, Thing FKs.
+
+use anyhow::Result;
+use std::collections::{HashMap, HashSet};
+use surreal_sync_core::{
+    build_composite_record_id, build_relation_from_change, build_relation_from_row, classify_table,
+    Change, ChangeOp, Relation, RelationChange, Row, TableDefinition, TableKind, Value,
+};
+
+use crate::from_mssql::catalog::{MssqlColumnMeta, MssqlTableMeta};
+use crate::from_mssql::cdc::{CdcChange, CdcOperation};
+use crate::from_mssql::client::{MssqlClient, SqlArg};
+use crate::from_mssql::naming::bracket;
+use crate::types::tiberius_to_value;
+
+/// Record id from ordered PK values (scalar or array).
+pub fn record_id(pk_parts: Vec<Value>) -> Value {
+    build_composite_record_id(pk_parts)
+}
+
+/// Extract PK field values in catalog order.
+pub fn pk_parts(fields: &HashMap<String, Value>, pk_columns: &[String]) -> Vec<Value> {
+    pk_columns
+        .iter()
+        .map(|c| fields.get(c).cloned().unwrap_or(Value::Null))
+        .collect()
+}
+
+/// Wrap FKs as `record<Target>` except FKs whose referenced table is temporal.
+pub fn transform_fks(
+    fields: &mut HashMap<String, Value>,
+    table_def: &TableDefinition,
+    temporal_targets: &HashSet<String>,
+) {
+    for fk in &table_def.foreign_keys {
+        if fk.columns.len() != 1 {
+            continue;
+        }
+        if temporal_targets.contains(&fk.referenced_table) {
+            continue;
+        }
+        let col = &fk.columns[0];
+        if let Some(value) = fields.remove(col) {
+            let transformed = match value {
+                Value::Null => Value::Null,
+                other => Value::Thing {
+                    table: fk.referenced_table.clone(),
+                    id: Box::new(other),
+                },
+            };
+            fields.insert(col.clone(), transformed);
+        }
+    }
+}
+
+pub fn classify(
+    table_def: &TableDefinition,
+    relation_tables: &[String],
+    temporal_targets: &HashSet<String>,
+) -> TableKind {
+    match classify_table(table_def, relation_tables) {
+        TableKind::Relation { in_fk, out_fk }
+            if temporal_targets.contains(&in_fk.referenced_table)
+                || temporal_targets.contains(&out_fk.referenced_table) =>
+        {
+            TableKind::Entity
+        }
+        other => other,
+    }
+}
+
+/// Convert a SQL Server row into fields keyed by column name.
+pub fn fields_from_row(
+    row: &tiberius::Row,
+    columns: &[MssqlColumnMeta],
+) -> Result<HashMap<String, Value>> {
+    let mut fields = HashMap::new();
+    for (idx, col) in columns.iter().enumerate() {
+        let value = tiberius_to_value(row, idx, &col.universal_type)?;
+        fields.insert(col.name.clone(), value);
+    }
+    Ok(fields)
+}
+
+/// Build a snapshot [`Row`] (entity) from field map.
+pub fn entity_row(
+    target: &str,
+    index: u64,
+    fields: HashMap<String, Value>,
+    pk_columns: &[String],
+    table_def: Option<&TableDefinition>,
+    temporal_targets: &HashSet<String>,
+) -> Row {
+    let mut fields = fields;
+    if let Some(td) = table_def {
+        transform_fks(&mut fields, td, temporal_targets);
+    }
+    let id = record_id(pk_parts(&fields, pk_columns));
+    Row::new(target, index, id, fields)
+}
+
+/// Build a relation from a join-table field map.
+pub fn relation_from_fields(
+    target: &str,
+    fields: HashMap<String, Value>,
+    pk_columns: &[String],
+    in_fk: &surreal_sync_core::ForeignKeyDefinition,
+    out_fk: &surreal_sync_core::ForeignKeyDefinition,
+) -> Relation {
+    let id = record_id(pk_parts(&fields, pk_columns));
+    build_relation_from_row(target, id, fields, in_fk, out_fk)
+}
+
+fn keyset_predicate(pk_columns: &[String], start_param: usize) -> (String, usize) {
+    // (c1 > @p) OR (c1 = @p AND c2 > @q) OR …
+    let mut clauses = Vec::new();
+    let n = pk_columns.len();
+    for depth in 0..n {
+        let mut parts = Vec::new();
+        for (i, col) in pk_columns.iter().enumerate().take(depth) {
+            parts.push(format!("{} = @P{}", bracket(col), start_param + i));
+        }
+        parts.push(format!(
+            "{} > @P{}",
+            bracket(&pk_columns[depth]),
+            start_param + depth
+        ));
+        clauses.push(format!("({})", parts.join(" AND ")));
+    }
+    (clauses.join(" OR "), start_param + n)
+}
+
+fn order_by(pk_columns: &[String]) -> String {
+    pk_columns
+        .iter()
+        .map(|c| bracket(c))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn select_list(columns: &[MssqlColumnMeta]) -> String {
+    columns
+        .iter()
+        .map(|c| bracket(&c.name))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Keyset page of an ordinary table: `WHERE (pk) > @after ORDER BY pk FETCH NEXT n`.
+pub async fn read_chunk(
+    client: &MssqlClient,
+    meta: &MssqlTableMeta,
+    after: Option<&[Value]>,
+    limit: usize,
+) -> Result<Vec<HashMap<String, Value>>> {
+    let cols = select_list(&meta.columns);
+    let order = order_by(&meta.pk_columns);
+    let mut sql = format!("SELECT {cols} FROM {}", meta.source.quoted());
+    let mut args = Vec::new();
+    if let Some(after) = after {
+        let (pred, _) = keyset_predicate(&meta.pk_columns, 1);
+        sql.push_str(" WHERE ");
+        sql.push_str(&pred);
+        for v in after {
+            args.push(SqlArg::from_value(v)?);
+        }
+    }
+    sql.push_str(&format!(
+        " ORDER BY {order} OFFSET 0 ROWS FETCH NEXT {limit} ROWS ONLY"
+    ));
+    let rows = client.query(&sql, &args).await?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(fields_from_row(&row, &meta.columns)?);
+    }
+    Ok(out)
+}
+
+/// CDC row → Change or RelationChange for an ordinary table.
+pub fn apply_change(
+    meta: &MssqlTableMeta,
+    change: &CdcChange,
+    table_def: Option<&TableDefinition>,
+    relation_tables: &[String],
+    temporal_targets: &HashSet<String>,
+) -> Result<RegularCdc> {
+    let mut fields = change.fields.clone();
+    if let Some(td) = table_def {
+        transform_fks(&mut fields, td, temporal_targets);
+        match classify(td, relation_tables, temporal_targets) {
+            TableKind::Relation { in_fk, out_fk } => {
+                let id = record_id(pk_parts(&fields, &meta.pk_columns));
+                let op = match change.operation {
+                    CdcOperation::Delete => ChangeOp::Delete,
+                    CdcOperation::Insert => ChangeOp::Create,
+                    CdcOperation::UpdateAfter | CdcOperation::UpdateBefore => ChangeOp::Update,
+                };
+                let relation =
+                    build_relation_from_change(&meta.target, id, fields, &in_fk, &out_fk);
+                return Ok(RegularCdc::Relation(RelationChange::new(op, relation)));
+            }
+            TableKind::Entity => {}
+        }
+    }
+    let id = record_id(pk_parts(&fields, &meta.pk_columns));
+    let op = match change.operation {
+        CdcOperation::Delete => ChangeOp::Delete,
+        CdcOperation::Insert => ChangeOp::Create,
+        CdcOperation::UpdateAfter | CdcOperation::UpdateBefore => ChangeOp::Update,
+    };
+    let fields = if op == ChangeOp::Delete {
+        None
+    } else {
+        Some(fields)
+    };
+    Ok(RegularCdc::Row(Change::new(op, &meta.target, id, fields)))
+}
+
+/// CDC apply result for an ordinary table.
+#[allow(clippy::large_enum_variant)]
+pub enum RegularCdc {
+    Row(Change),
+    Relation(RelationChange),
+}
+
+/// Snapshot items from field maps (entity rows or relations).
+pub fn snapshot_items(
+    meta: &MssqlTableMeta,
+    maps: Vec<HashMap<String, Value>>,
+    start_index: u64,
+    table_def: Option<&TableDefinition>,
+    relation_tables: &[String],
+    temporal_targets: &HashSet<String>,
+) -> (Vec<Row>, Vec<Relation>) {
+    let mut rows = Vec::new();
+    let mut rels = Vec::new();
+    if let Some(td) = table_def {
+        if let TableKind::Relation { in_fk, out_fk } =
+            classify(td, relation_tables, temporal_targets)
+        {
+            for fields in maps {
+                rels.push(relation_from_fields(
+                    &meta.target,
+                    fields,
+                    &meta.pk_columns,
+                    &in_fk,
+                    &out_fk,
+                ));
+            }
+            return (rows, rels);
+        }
+    }
+    for (i, fields) in maps.into_iter().enumerate() {
+        rows.push(entity_row(
+            &meta.target,
+            start_index + i as u64,
+            fields,
+            &meta.pk_columns,
+            table_def,
+            temporal_targets,
+        ));
+    }
+    (rows, rels)
+}

--- a/crates/mssql/src/from_mssql/schema.rs
+++ b/crates/mssql/src/from_mssql/schema.rs
@@ -1,0 +1,84 @@
+//! Map the SQL Server catalog to `DatabaseSchema` and SCHEMAFULL extras.
+
+use std::collections::HashSet;
+use surreal_sync_core::{
+    ColumnDefinition, DatabaseSchema, PeriodBound, SchemaIndex, SchemafullExtras, TableDefinition,
+};
+
+use crate::from_mssql::catalog::{column_definitions, MssqlTableMeta, TableSyncKind};
+use crate::from_mssql::temporal::{cookbook_indexes, extra_is_current_field};
+
+/// Surreal target names of system-versioned tables (FKs to these stay scalars).
+pub fn temporal_targets(metas: &[MssqlTableMeta]) -> HashSet<String> {
+    metas
+        .iter()
+        .filter(|m| m.kind == TableSyncKind::Temporal)
+        .map(|m| m.target.clone())
+        .collect()
+}
+
+/// Build a [`DatabaseSchema`] using Surreal target table names.
+pub fn database_schema(metas: &[MssqlTableMeta]) -> DatabaseSchema {
+    let tables = metas
+        .iter()
+        .map(|meta| {
+            let (primary_key, columns) = column_definitions(meta);
+            let mut extra_cols = columns;
+            if meta.kind == TableSyncKind::Temporal {
+                extra_cols.push(ColumnDefinition::new(
+                    "is_current",
+                    surreal_sync_core::Type::Bool,
+                ));
+            }
+            let mut td = TableDefinition::new(&meta.target, primary_key, extra_cols);
+            td.foreign_keys = meta.foreign_keys.clone();
+            if meta.pk_columns.len() > 1 {
+                td.composite_primary_key = Some(meta.pk_columns.clone());
+            }
+            td
+        })
+        .collect();
+    DatabaseSchema::new(tables)
+}
+
+/// SCHEMAFULL extras: ordinary btree indexes, temporal cookbook indexes, period ASSERT, `is_current`.
+pub fn schemafull_extras(
+    metas: &[MssqlTableMeta],
+    relation_tables: Vec<String>,
+) -> SchemafullExtras {
+    let scalar_fk_targets = temporal_targets(metas);
+    let mut extras = SchemafullExtras {
+        scalar_fk_targets,
+        relation_tables,
+        ..SchemafullExtras::default()
+    };
+    for meta in metas {
+        match meta.kind {
+            TableSyncKind::Regular => {
+                for idx in &meta.indexes {
+                    if idx.is_primary {
+                        continue;
+                    }
+                    extras.indexes.push(SchemaIndex {
+                        table: meta.target.clone(),
+                        name: idx.name.clone(),
+                        fields: idx.columns.clone(),
+                        unique: idx.unique,
+                    });
+                }
+            }
+            TableSyncKind::Temporal => {
+                extras.indexes.extend(cookbook_indexes(meta));
+                extras.extra_fields.push(extra_is_current_field(meta));
+                if let (Some(start), Some(end)) = (&meta.period_start, &meta.period_end) {
+                    extras.period_bounds.push(PeriodBound {
+                        table: meta.target.clone(),
+                        start: start.clone(),
+                        end: end.clone(),
+                    });
+                }
+            }
+        }
+    }
+    extras
+}

--- a/crates/mssql/src/from_mssql/sequential.rs
+++ b/crates/mssql/src/from_mssql/sequential.rs
@@ -1,0 +1,331 @@
+//! Sequential SNAPSHOT-isolation dump (CDC tail is started by the embed orchestrator).
+
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use surreal_sync_core::SurrealSink;
+use surreal_sync_core::{
+    Checkpoint, CheckpointStore, DatabaseSchema, Row, SyncManager, SyncPhase, TableDefinition,
+    TableKind, Value,
+};
+use surreal_sync_runtime::{
+    run_source_runtime_with, write_relations, ApplyOpts, Pipeline, RowChunkDriver, RowChunkSource,
+    SourceRuntimeOpts,
+};
+use tracing::info;
+
+use crate::from_mssql::catalog::{collect_database_schema, MssqlTableMeta, TableSyncKind};
+use crate::from_mssql::cdc;
+use crate::from_mssql::checkpoint::MssqlCheckpoint;
+use crate::from_mssql::client::MssqlClient;
+use crate::from_mssql::regular;
+use crate::from_mssql::schema::{database_schema, schemafull_extras, temporal_targets};
+use crate::from_mssql::temporal;
+use crate::from_mssql::{SourceOpts, SyncOpts};
+
+/// Copy tables in one SNAPSHOT-isolation transaction and return the snapshot LSN.
+///
+/// Writers are not locked (SNAPSHOT isolation is MVCC). Requires
+/// `ALLOW_SNAPSHOT_ISOLATION`. There is no signal table on this path.
+/// `--snapshot-mode initial` starts CDC from the returned checkpoint;
+/// `--snapshot-mode only` stops after this dump.
+#[allow(clippy::too_many_arguments)]
+pub async fn run_sequential_snapshot_with_transforms<S, St>(
+    sink: &S,
+    from_opts: &SourceOpts,
+    sync_opts: &SyncOpts,
+    chunk_size: usize,
+    cancel: &tokio_util::sync::CancellationToken,
+    manager: Option<&SyncManager<St>>,
+    pipeline: &Pipeline,
+    apply_opts: &ApplyOpts,
+) -> Result<MssqlCheckpoint>
+where
+    S: SurrealSink,
+    St: CheckpointStore,
+{
+    let client = crate::from_mssql::client::connect(&from_opts.connection_string).await?;
+    ensure_snapshot_isolation(&client).await?;
+
+    cdc::ensure_cdc_enabled(&client).await?;
+    let metas = collect_database_schema(&client, &from_opts.tables).await?;
+    for meta in &metas {
+        cdc::ensure_table_cdc(&client, &meta.source).await?;
+    }
+
+    let snapshot_lsn = loop {
+        if let Some(lsn) = cdc::max_lsn(&client).await? {
+            break lsn;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        if cancel.is_cancelled() {
+            anyhow::bail!("SNAPSHOT dump cancelled before CDC reported a max LSN");
+        }
+    };
+    let start = MssqlCheckpoint::new(snapshot_lsn);
+    if let Some(manager) = manager {
+        manager
+            .emit_checkpoint(&start, SyncPhase::FullSyncStart)
+            .await?;
+        info!(
+            "SNAPSHOT isolation dump starting at LSN {}",
+            start.to_cli_string()
+        );
+    }
+
+    let db_schema = database_schema(&metas);
+    let extras = schemafull_extras(&metas, from_opts.relation_tables.clone());
+    surreal_sync_core::maybe_emit_schemafull(
+        sink,
+        &db_schema,
+        &extras,
+        sync_opts.schemafull,
+        sync_opts.dry_run,
+    )
+    .await?;
+
+    client
+        .simple_query("SET TRANSACTION ISOLATION LEVEL SNAPSHOT; BEGIN TRANSACTION;")
+        .await?;
+
+    let temporal = temporal_targets(&metas);
+    let dump_result = dump_tables(
+        &client,
+        sink,
+        &metas,
+        &db_schema,
+        &from_opts.relation_tables,
+        &temporal,
+        chunk_size,
+        sync_opts,
+        cancel,
+        pipeline,
+        apply_opts,
+    )
+    .await;
+
+    let commit = client.simple_query("COMMIT TRANSACTION;").await;
+    dump_result?;
+    commit?;
+
+    if let Some(manager) = manager {
+        manager
+            .emit_checkpoint(&start, SyncPhase::FullSyncEnd)
+            .await?;
+    }
+
+    Ok(start)
+}
+
+async fn ensure_snapshot_isolation(client: &MssqlClient) -> Result<()> {
+    let rows = client
+        .query(
+            "SELECT snapshot_isolation_state, DB_NAME() FROM sys.databases WHERE database_id = DB_ID()",
+            &[],
+        )
+        .await?;
+    let state: u8 = rows
+        .first()
+        .and_then(|r| r.try_get::<u8, _>(0).ok().flatten())
+        .or_else(|| {
+            rows.first()
+                .and_then(|r| r.try_get::<i32, _>(0).ok().flatten())
+                .map(|v| v as u8)
+        })
+        .unwrap_or(0);
+    let db: String = rows
+        .first()
+        .and_then(|r| r.try_get::<&str, _>(1).ok().flatten())
+        .unwrap_or("the current database")
+        .to_string();
+    if state == 1 {
+        return Ok(());
+    }
+    Err(anyhow!(
+        "SNAPSHOT isolation is not enabled for database `{db}`. A DBA must run:\n\
+         ALTER DATABASE [{db}] SET ALLOW_SNAPSHOT_ISOLATION ON"
+    ))
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn dump_tables<S: SurrealSink>(
+    client: &MssqlClient,
+    sink: &S,
+    metas: &[MssqlTableMeta],
+    db_schema: &DatabaseSchema,
+    relation_tables: &[String],
+    temporal: &std::collections::HashSet<String>,
+    chunk_size: usize,
+    sync_opts: &SyncOpts,
+    cancel: &tokio_util::sync::CancellationToken,
+    pipeline: &Pipeline,
+    apply_opts: &ApplyOpts,
+) -> Result<()> {
+    for meta in metas {
+        if cancel.is_cancelled() {
+            info!(
+                "Cancellation requested during SNAPSHOT dump; stopping before `{}`",
+                meta.source
+            );
+            return Ok(());
+        }
+        info!("Copying table {}", meta.source);
+        if sync_opts.dry_run {
+            continue;
+        }
+        let td = db_schema.get_table(&meta.target);
+        if meta.kind == TableSyncKind::Regular {
+            if let Some(td) = td {
+                if let TableKind::Relation { .. } = regular::classify(td, relation_tables, temporal)
+                {
+                    dump_relations(
+                        client,
+                        sink,
+                        meta,
+                        td,
+                        relation_tables,
+                        temporal,
+                        chunk_size,
+                        pipeline,
+                        apply_opts,
+                    )
+                    .await?;
+                    continue;
+                }
+            }
+        }
+        let source = KeysetChunkSource {
+            client: client.clone(),
+            meta: meta.clone(),
+            after: None,
+            chunk_size,
+            table_def: td.cloned(),
+            relation_tables: relation_tables.to_vec(),
+            temporal: temporal.clone(),
+            done: false,
+        };
+        let mut driver = RowChunkDriver::new(source);
+        let transformer = Arc::new(pipeline.clone());
+        run_source_runtime_with(
+            &mut driver,
+            sink,
+            transformer,
+            apply_opts,
+            &SourceRuntimeOpts::new(),
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn dump_relations<S: SurrealSink>(
+    client: &MssqlClient,
+    sink: &S,
+    meta: &MssqlTableMeta,
+    td: &TableDefinition,
+    relation_tables: &[String],
+    temporal: &std::collections::HashSet<String>,
+    chunk_size: usize,
+    pipeline: &Pipeline,
+    apply_opts: &ApplyOpts,
+) -> Result<()> {
+    let mut after: Option<Vec<Value>> = None;
+    loop {
+        let maps = regular::read_chunk(client, meta, after.as_deref(), chunk_size).await?;
+        if maps.is_empty() {
+            break;
+        }
+        after = maps.last().map(|m| {
+            meta.pk_columns
+                .iter()
+                .map(|c| m.get(c).cloned().unwrap_or(Value::Null))
+                .collect()
+        });
+        let (_, rels) = regular::snapshot_items(meta, maps, 0, Some(td), relation_tables, temporal);
+        if rels.is_empty() {
+            break;
+        }
+        write_relations(sink, pipeline, rels, apply_opts).await?;
+    }
+    Ok(())
+}
+
+struct KeysetChunkSource {
+    client: MssqlClient,
+    meta: MssqlTableMeta,
+    after: Option<Vec<Value>>,
+    chunk_size: usize,
+    table_def: Option<TableDefinition>,
+    relation_tables: Vec<String>,
+    temporal: std::collections::HashSet<String>,
+    done: bool,
+}
+
+#[async_trait]
+impl RowChunkSource for KeysetChunkSource {
+    async fn next_chunk(&mut self) -> Result<Option<Vec<Row>>> {
+        if self.done {
+            return Ok(None);
+        }
+        let maps = match self.meta.kind {
+            TableSyncKind::Regular => {
+                regular::read_chunk(
+                    &self.client,
+                    &self.meta,
+                    self.after.as_deref(),
+                    self.chunk_size,
+                )
+                .await?
+            }
+            TableSyncKind::Temporal => {
+                temporal::read_chunk(
+                    &self.client,
+                    &self.meta,
+                    self.after.as_deref(),
+                    self.chunk_size,
+                )
+                .await?
+            }
+        };
+        if maps.is_empty() {
+            self.done = true;
+            return Ok(None);
+        }
+        let rows = match self.meta.kind {
+            TableSyncKind::Regular => {
+                let (rows, _) = regular::snapshot_items(
+                    &self.meta,
+                    maps,
+                    0,
+                    self.table_def.as_ref(),
+                    &self.relation_tables,
+                    &self.temporal,
+                );
+                if let Some(last) = rows.last() {
+                    self.after = Some(
+                        self.meta
+                            .pk_columns
+                            .iter()
+                            .map(|c| last.fields.get(c).cloned().unwrap_or(Value::Null))
+                            .collect(),
+                    );
+                }
+                rows
+            }
+            TableSyncKind::Temporal => {
+                let rows = temporal::rows_from_maps(&self.meta, maps, 0);
+                if let Some(last) = rows.last() {
+                    self.after = Some(temporal::chunk_after_from_row(&self.meta, last));
+                }
+                rows
+            }
+        };
+        if rows.is_empty() {
+            self.done = true;
+            return Ok(None);
+        }
+        Ok(Some(rows))
+    }
+}

--- a/crates/mssql/src/from_mssql/sequential.rs
+++ b/crates/mssql/src/from_mssql/sequential.rs
@@ -315,7 +315,13 @@ impl RowChunkSource for KeysetChunkSource {
                 rows
             }
             TableSyncKind::Temporal => {
-                let rows = temporal::rows_from_maps(&self.meta, maps, 0);
+                let rows = temporal::rows_from_maps(
+                    &self.meta,
+                    maps,
+                    0,
+                    self.table_def.as_ref(),
+                    &self.temporal,
+                );
                 if let Some(last) = rows.last() {
                     self.after = Some(temporal::chunk_after_from_row(&self.meta, last));
                 }

--- a/crates/mssql/src/from_mssql/signal.rs
+++ b/crates/mssql/src/from_mssql/signal.rs
@@ -1,0 +1,46 @@
+//! Watermark / signal table on the SQL Server source.
+
+use anyhow::Result;
+use uuid::Uuid;
+
+use crate::from_mssql::cdc::ensure_table_cdc;
+use crate::from_mssql::client::{MssqlClient, SqlArg};
+use crate::from_mssql::naming::QualifiedName;
+
+/// Signal table used for interleaved watermark rows (`dbo.surreal_sync_signal`).
+pub const SIGNAL_TABLE: &str = "surreal_sync_signal";
+
+/// Qualified name of the signal table.
+pub fn signal_qualified() -> QualifiedName {
+    QualifiedName::new("dbo", SIGNAL_TABLE)
+}
+
+fn create_signal_table_sql() -> String {
+    format!(
+        "IF OBJECT_ID(N'dbo.{SIGNAL_TABLE}', N'U') IS NULL \
+         CREATE TABLE dbo.{SIGNAL_TABLE} ( \
+            id uniqueidentifier NOT NULL PRIMARY KEY, \
+            kind nvarchar(32) NOT NULL, \
+            tables nvarchar(max) NULL, \
+            consumed bit NOT NULL CONSTRAINT DF_{SIGNAL_TABLE}_consumed DEFAULT (0) \
+         );"
+    )
+}
+
+/// Create the signal table and enable CDC on it.
+pub async fn ensure_signal_table(client: &MssqlClient) -> Result<()> {
+    client.simple_query(&create_signal_table_sql()).await?;
+    ensure_table_cdc(client, &signal_qualified()).await?;
+    Ok(())
+}
+
+/// Insert a watermark row. That insert must appear in CDC as a UUID primary key.
+pub async fn insert_watermark(client: &MssqlClient, kind: &str, id: Uuid) -> Result<()> {
+    client
+        .execute(
+            &format!("INSERT INTO dbo.{SIGNAL_TABLE} (id, kind, consumed) VALUES (@P1, @P2, 0)"),
+            &[SqlArg::Uuid(id), SqlArg::String(kind.to_string())],
+        )
+        .await?;
+    Ok(())
+}

--- a/crates/mssql/src/from_mssql/temporal.rs
+++ b/crates/mssql/src/from_mssql/temporal.rs
@@ -3,15 +3,17 @@
 use anyhow::Result;
 use chrono::Datelike;
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use surreal_sync_core::{
-    build_composite_record_id, Change, ChangeOp, Row, SchemaFieldExtra, SchemaIndex, Value,
+    build_composite_record_id, Change, ChangeOp, Row, SchemaFieldExtra, SchemaIndex,
+    TableDefinition, Value,
 };
 
 use crate::from_mssql::catalog::{MssqlColumnMeta, MssqlTableMeta};
 use crate::from_mssql::cdc::{CdcChange, CdcOperation};
 use crate::from_mssql::client::{MssqlClient, SqlArg};
 use crate::from_mssql::naming::bracket;
+use crate::from_mssql::regular;
 use crate::types::tiberius_to_value;
 
 /// Hash remaining field values (sorted keys) for the version id.
@@ -97,10 +99,15 @@ fn remaining_for_hash(
 }
 
 /// Assign version ids and `is_current` for a snapshot chunk (duplicate ordinals are local).
+///
+/// FKs to ordinary tables become Things after the version id is computed so the
+/// content hash stays on source scalars. FKs to temporal tables stay scalars.
 pub fn rows_from_maps(
     meta: &MssqlTableMeta,
     maps: Vec<HashMap<String, Value>>,
     start_index: u64,
+    table_def: Option<&TableDefinition>,
+    temporal_targets: &HashSet<String>,
 ) -> Vec<Row> {
     let start = meta.period_start.as_deref().unwrap_or("ValidFrom");
     let end = meta.period_end.as_deref().unwrap_or("ValidTo");
@@ -130,6 +137,9 @@ pub fn rows_from_maps(
         let ordinal = seen.entry(key).or_insert(-1);
         *ordinal += 1;
         let id = version_id(pk, &from, &to, &remaining, *ordinal);
+        if let Some(td) = table_def {
+            regular::transform_fks(&mut fields, td, temporal_targets);
+        }
         rows.push(Row::new(
             meta.target.clone(),
             start_index + i as u64,
@@ -305,6 +315,8 @@ fn version_change(
     mut fields: HashMap<String, Value>,
     is_current: bool,
     op: ChangeOp,
+    table_def: Option<&TableDefinition>,
+    temporal_targets: &HashSet<String>,
 ) -> Change {
     let start = meta.period_start.as_deref().unwrap_or("ValidFrom");
     let end = meta.period_end.as_deref().unwrap_or("ValidTo");
@@ -319,20 +331,42 @@ fn version_change(
         &remaining,
         0,
     );
+    if let Some(td) = table_def {
+        regular::transform_fks(&mut fields, td, temporal_targets);
+    }
     Change::new(op, &meta.target, id, Some(fields))
 }
 
 /// CDC apply: INSERT/UPDATE write a new current version; before-image/DELETE clear `is_current`.
-pub fn apply_change(meta: &MssqlTableMeta, change: &CdcChange) -> Result<TemporalCdc> {
+pub fn apply_change(
+    meta: &MssqlTableMeta,
+    change: &CdcChange,
+    table_def: Option<&TableDefinition>,
+    temporal_targets: &HashSet<String>,
+) -> Result<TemporalCdc> {
     match change.operation {
         CdcOperation::Insert | CdcOperation::UpdateAfter => {
-            let new_version = version_change(meta, change.fields.clone(), true, ChangeOp::Create);
+            let new_version = version_change(
+                meta,
+                change.fields.clone(),
+                true,
+                ChangeOp::Create,
+                table_def,
+                temporal_targets,
+            );
             Ok(TemporalCdc {
                 new_version: Some(new_version),
             })
         }
         CdcOperation::Delete | CdcOperation::UpdateBefore => {
-            let prior = version_change(meta, change.fields.clone(), false, ChangeOp::Update);
+            let prior = version_change(
+                meta,
+                change.fields.clone(),
+                false,
+                ChangeOp::Update,
+                table_def,
+                temporal_targets,
+            );
             Ok(TemporalCdc {
                 new_version: Some(prior),
             })

--- a/crates/mssql/src/from_mssql/temporal.rs
+++ b/crates/mssql/src/from_mssql/temporal.rs
@@ -1,0 +1,359 @@
+//! System-versioned temporal tables: version ids, UNION ALL snapshot, is_current.
+
+use anyhow::Result;
+use chrono::Datelike;
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use surreal_sync_core::{
+    build_composite_record_id, Change, ChangeOp, Row, SchemaFieldExtra, SchemaIndex, Value,
+};
+
+use crate::from_mssql::catalog::{MssqlColumnMeta, MssqlTableMeta};
+use crate::from_mssql::cdc::{CdcChange, CdcOperation};
+use crate::from_mssql::client::{MssqlClient, SqlArg};
+use crate::from_mssql::naming::bracket;
+use crate::types::tiberius_to_value;
+
+/// Hash remaining field values (sorted keys) for the version id.
+pub fn hash_version_content(fields: &HashMap<String, Value>) -> String {
+    let mut keys: Vec<&String> = fields.keys().collect();
+    keys.sort();
+    let mut hasher = Sha256::new();
+    for k in keys {
+        hasher.update(k.as_bytes());
+        hasher.update(b"=");
+        let json = serde_json::to_string(fields.get(k).unwrap()).unwrap_or_default();
+        hasher.update(json.as_bytes());
+        hasher.update(b";");
+    }
+    hex::encode(hasher.finalize())
+}
+
+fn iso8601(value: &Value) -> String {
+    match value {
+        Value::LocalDateTime(dt)
+        | Value::LocalDateTimeNano(dt)
+        | Value::ZonedDateTime(dt)
+        | Value::Date(dt)
+        | Value::Time(dt) => dt.to_rfc3339(),
+        Value::Text(s) | Value::VarChar { value: s, .. } | Value::Char { value: s, .. } => {
+            s.clone()
+        }
+        other => format!("{other:?}"),
+    }
+}
+
+/// Array record id: PK parts + period start + period end + content hash + duplicate ordinal.
+pub fn version_id(
+    pk_parts: Vec<Value>,
+    period_start: &str,
+    period_end: &str,
+    remaining_fields: &HashMap<String, Value>,
+    duplicate_ordinal: i64,
+) -> Value {
+    let hash = hash_version_content(remaining_fields);
+    let mut parts = pk_parts;
+    parts.push(Value::Text(period_start.to_string()));
+    parts.push(Value::Text(period_end.to_string()));
+    parts.push(Value::Text(hash));
+    parts.push(Value::Int64(duplicate_ordinal));
+    build_composite_record_id(parts)
+}
+
+/// True when ValidTo is the open sentinel (year 9999).
+pub fn is_open_period_end(value: &Value) -> bool {
+    match value {
+        Value::LocalDateTime(dt)
+        | Value::LocalDateTimeNano(dt)
+        | Value::ZonedDateTime(dt)
+        | Value::Date(dt) => dt.year() >= 9999,
+        _ => false,
+    }
+}
+
+fn pk_parts(fields: &HashMap<String, Value>, pk_columns: &[String]) -> Vec<Value> {
+    pk_columns
+        .iter()
+        .map(|c| fields.get(c).cloned().unwrap_or(Value::Null))
+        .collect()
+}
+
+fn remaining_for_hash(
+    fields: &HashMap<String, Value>,
+    pk_columns: &[String],
+    period_start: &str,
+    period_end: &str,
+) -> HashMap<String, Value> {
+    fields
+        .iter()
+        .filter(|(k, _)| {
+            *k != period_start
+                && *k != period_end
+                && *k != "is_current"
+                && !pk_columns.iter().any(|p| p == *k)
+        })
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect()
+}
+
+/// Assign version ids and `is_current` for a snapshot chunk (duplicate ordinals are local).
+pub fn rows_from_maps(
+    meta: &MssqlTableMeta,
+    maps: Vec<HashMap<String, Value>>,
+    start_index: u64,
+) -> Vec<Row> {
+    let start = meta.period_start.as_deref().unwrap_or("ValidFrom");
+    let end = meta.period_end.as_deref().unwrap_or("ValidTo");
+    let mut seen: HashMap<String, i64> = HashMap::new();
+    let mut rows = Vec::new();
+    for (i, mut fields) in maps.into_iter().enumerate() {
+        let from = iso8601(fields.get(start).unwrap_or(&Value::Null));
+        let to = iso8601(fields.get(end).unwrap_or(&Value::Null));
+        let is_current = fields
+            .get("is_current")
+            .and_then(|v| match v {
+                Value::Bool(b) => Some(*b),
+                Value::Int16(n) => Some(*n != 0),
+                Value::Int32(n) => Some(*n != 0),
+                Value::Int64(n) => Some(*n != 0),
+                _ => None,
+            })
+            .unwrap_or_else(|| is_open_period_end(fields.get(end).unwrap_or(&Value::Null)));
+        fields.insert("is_current".into(), Value::Bool(is_current));
+        let remaining = remaining_for_hash(&fields, &meta.pk_columns, start, end);
+        let hash = hash_version_content(&remaining);
+        let pk = pk_parts(&fields, &meta.pk_columns);
+        let key = format!(
+            "{}|{from}|{to}|{hash}",
+            serde_json::to_string(&pk).unwrap_or_default()
+        );
+        let ordinal = seen.entry(key).or_insert(-1);
+        *ordinal += 1;
+        let id = version_id(pk, &from, &to, &remaining, *ordinal);
+        rows.push(Row::new(
+            meta.target.clone(),
+            start_index + i as u64,
+            id,
+            fields,
+        ));
+    }
+    rows
+}
+
+fn union_sql(meta: &MssqlTableMeta) -> Result<String> {
+    let history = meta.history.as_ref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "temporal table `{}` has no history table in the catalog",
+            meta.source
+        )
+    })?;
+    let start = meta.period_start.as_deref().unwrap_or("ValidFrom");
+    let end = meta.period_end.as_deref().unwrap_or("ValidTo");
+    let mut names: Vec<String> = meta.columns.iter().map(|c| c.name.clone()).collect();
+    for extra in [start, end] {
+        if !names.iter().any(|n| n.eq_ignore_ascii_case(extra)) {
+            names.push(extra.to_string());
+        }
+    }
+    let cols: Vec<String> = names.iter().map(|c| bracket(c)).collect();
+    // Period columns may be HIDDEN; name them explicitly. Do not use FOR SYSTEM_TIME ALL
+    // (it drops same-transaction zero-duration versions).
+    let current_select = format!(
+        "SELECT {}, CAST(1 AS bit) AS {} FROM {}",
+        cols.join(", "),
+        bracket("is_current"),
+        meta.source.quoted()
+    );
+    let history_select = format!(
+        "SELECT {}, CAST(0 AS bit) AS {} FROM {}",
+        cols.join(", "),
+        bracket("is_current"),
+        history.quoted()
+    );
+    Ok(format!("{current_select} UNION ALL {history_select}"))
+}
+
+fn keyset_order(meta: &MssqlTableMeta) -> Vec<String> {
+    let start = meta
+        .period_start
+        .clone()
+        .unwrap_or_else(|| "ValidFrom".into());
+    let end = meta.period_end.clone().unwrap_or_else(|| "ValidTo".into());
+    let mut cols = meta.pk_columns.clone();
+    cols.push(start);
+    cols.push(end);
+    cols
+}
+
+fn keyset_predicate(cols: &[String], start_param: usize) -> String {
+    let mut clauses = Vec::new();
+    for depth in 0..cols.len() {
+        let mut parts = Vec::new();
+        for (i, col) in cols.iter().enumerate().take(depth) {
+            parts.push(format!("{} = @P{}", bracket(col), start_param + i));
+        }
+        parts.push(format!(
+            "{} > @P{}",
+            bracket(&cols[depth]),
+            start_param + depth
+        ));
+        clauses.push(format!("({})", parts.join(" AND ")));
+    }
+    clauses.join(" OR ")
+}
+
+/// UNION ALL current + history, keyset-ordered by business PK + period start + period end.
+pub async fn read_chunk(
+    client: &MssqlClient,
+    meta: &MssqlTableMeta,
+    after: Option<&[Value]>,
+    limit: usize,
+) -> Result<Vec<HashMap<String, Value>>> {
+    let inner = union_sql(meta)?;
+    let order_cols = keyset_order(meta);
+    let order = order_cols
+        .iter()
+        .map(|c| bracket(c))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let mut sql = format!("SELECT * FROM ({inner}) AS versions");
+    let mut args = Vec::new();
+    if let Some(after) = after {
+        sql.push_str(" WHERE ");
+        sql.push_str(&keyset_predicate(&order_cols, 1));
+        for v in after {
+            args.push(SqlArg::from_value(v)?);
+        }
+    }
+    sql.push_str(&format!(
+        " ORDER BY {order} OFFSET 0 ROWS FETCH NEXT {limit} ROWS ONLY"
+    ));
+    let rows = client.query(&sql, &args).await?;
+    // UNION ALL adds is_current as the last column.
+    let mut columns: Vec<MssqlColumnMeta> = meta.columns.clone();
+    columns.push(MssqlColumnMeta {
+        name: "is_current".into(),
+        type_name: "bit".into(),
+        nullable: false,
+        ordinal: i32::MAX,
+        universal_type: surreal_sync_core::Type::Bool,
+    });
+    let mut out = Vec::new();
+    for row in rows {
+        let mut fields = HashMap::new();
+        for (idx, col) in columns.iter().enumerate() {
+            fields.insert(
+                col.name.clone(),
+                tiberius_to_value(&row, idx, &col.universal_type)?,
+            );
+        }
+        out.push(fields);
+    }
+    Ok(out)
+}
+
+/// Cookbook indexes for the unified temporal table (never copy source UNIQUE/PK).
+pub fn cookbook_indexes(meta: &MssqlTableMeta) -> Vec<SchemaIndex> {
+    let start = meta
+        .period_start
+        .clone()
+        .unwrap_or_else(|| "ValidFrom".into());
+    let end = meta.period_end.clone().unwrap_or_else(|| "ValidTo".into());
+    let t = &meta.target;
+    let mut pk_and_current = meta.pk_columns.clone();
+    pk_and_current.push("is_current".into());
+    vec![
+        SchemaIndex {
+            table: t.clone(),
+            name: format!("{t}_is_current"),
+            fields: vec!["is_current".into()],
+            unique: false,
+        },
+        SchemaIndex {
+            table: t.clone(),
+            name: format!("{t}_pk"),
+            fields: meta.pk_columns.clone(),
+            unique: false,
+        },
+        SchemaIndex {
+            table: t.clone(),
+            name: format!("{t}_pk_is_current"),
+            fields: pk_and_current,
+            unique: false,
+        },
+        SchemaIndex {
+            table: t.clone(),
+            name: format!("{t}_period"),
+            fields: vec![start, end],
+            unique: false,
+        },
+    ]
+}
+
+/// Extra `is_current` field for SCHEMAFULL.
+pub fn extra_is_current_field(meta: &MssqlTableMeta) -> SchemaFieldExtra {
+    SchemaFieldExtra {
+        table: meta.target.clone(),
+        name: "is_current".into(),
+        type_name: "bool".into(),
+        nullable: false,
+    }
+}
+
+fn version_change(
+    meta: &MssqlTableMeta,
+    mut fields: HashMap<String, Value>,
+    is_current: bool,
+    op: ChangeOp,
+) -> Change {
+    let start = meta.period_start.as_deref().unwrap_or("ValidFrom");
+    let end = meta.period_end.as_deref().unwrap_or("ValidTo");
+    fields.insert("is_current".into(), Value::Bool(is_current));
+    let from = iso8601(fields.get(start).unwrap_or(&Value::Null));
+    let to = iso8601(fields.get(end).unwrap_or(&Value::Null));
+    let remaining = remaining_for_hash(&fields, &meta.pk_columns, start, end);
+    let id = version_id(
+        pk_parts(&fields, &meta.pk_columns),
+        &from,
+        &to,
+        &remaining,
+        0,
+    );
+    Change::new(op, &meta.target, id, Some(fields))
+}
+
+/// CDC apply: INSERT/UPDATE write a new current version; before-image/DELETE clear `is_current`.
+pub fn apply_change(meta: &MssqlTableMeta, change: &CdcChange) -> Result<TemporalCdc> {
+    match change.operation {
+        CdcOperation::Insert | CdcOperation::UpdateAfter => {
+            let new_version = version_change(meta, change.fields.clone(), true, ChangeOp::Create);
+            Ok(TemporalCdc {
+                new_version: Some(new_version),
+            })
+        }
+        CdcOperation::Delete | CdcOperation::UpdateBefore => {
+            let prior = version_change(meta, change.fields.clone(), false, ChangeOp::Update);
+            Ok(TemporalCdc {
+                new_version: Some(prior),
+            })
+        }
+    }
+}
+
+/// CDC translation for a temporal current-table change.
+pub struct TemporalCdc {
+    pub new_version: Option<Change>,
+}
+
+/// Keyset cursor values for the next page (business PK + period start + period end).
+pub fn chunk_after_from_row(meta: &MssqlTableMeta, row: &Row) -> Vec<Value> {
+    let start = meta.period_start.as_deref().unwrap_or("ValidFrom");
+    let end = meta.period_end.as_deref().unwrap_or("ValidTo");
+    let mut vals = Vec::new();
+    for c in &meta.pk_columns {
+        vals.push(row.fields.get(c).cloned().unwrap_or(Value::Null));
+    }
+    vals.push(row.fields.get(start).cloned().unwrap_or(Value::Null));
+    vals.push(row.fields.get(end).cloned().unwrap_or(Value::Null));
+    vals
+}

--- a/crates/mssql/src/from_mssql/testing/container.rs
+++ b/crates/mssql/src/from_mssql/testing/container.rs
@@ -1,0 +1,192 @@
+use anyhow::{Context, Result};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+use tracing::{debug, info};
+
+const DEFAULT_IMAGE: &str = "mcr.microsoft.com/mssql/server:2022-CU26-ubuntu-22.04";
+const SA_PASSWORD: &str = "Surreal_Sync1";
+
+fn image() -> String {
+    std::env::var("MSSQL_IMAGE").unwrap_or_else(|_| DEFAULT_IMAGE.to_string())
+}
+
+/// Official `mcr.microsoft.com/mssql/server` container with Agent and CDC.
+pub struct MssqlContainer {
+    pub container_name: String,
+    pub host_port: u16,
+    pub connection_string: String,
+}
+
+impl MssqlContainer {
+    pub fn new(container_name: &str) -> Self {
+        Self {
+            container_name: container_name.to_string(),
+            host_port: 0,
+            connection_string: String::new(),
+        }
+    }
+
+    pub fn start(&mut self) -> Result<()> {
+        info!("Starting SQL Server container: {}", self.container_name);
+
+        let _ = Command::new("docker")
+            .args(["rm", "-f", &self.container_name])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+
+        let image = image();
+        let output = Command::new("docker")
+            .args([
+                "run",
+                "--name",
+                &self.container_name,
+                "--platform",
+                "linux/amd64",
+                "-e",
+                // Required by Microsoft's image (SQL Server EULA:
+                // https://go.microsoft.com/fwlink/?linkid=2143497). Developer
+                // edition is for test only.
+                "ACCEPT_EULA=Y",
+                "-e",
+                &format!("MSSQL_SA_PASSWORD={SA_PASSWORD}"),
+                "-e",
+                "MSSQL_PID=Developer",
+                "-e",
+                "MSSQL_AGENT_ENABLED=true",
+                "-p",
+                "0:1433",
+                "-d",
+                &image,
+            ])
+            .output()
+            .context("Failed to start Docker container")?;
+
+        if !output.status.success() {
+            anyhow::bail!(
+                "Failed to start container: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        self.host_port = get_dynamic_port(&self.container_name)?;
+        self.connection_string = self.connection_string_for("testdb");
+        Ok(())
+    }
+
+    /// ADO.NET string for `database` on this container (SQL auth, encrypt, trust cert).
+    pub fn connection_string_for(&self, database: &str) -> String {
+        format!(
+            "Server=tcp:localhost,{};User=sa;Password={SA_PASSWORD};Database={database};\
+             TrustServerCertificate=true;Encrypt=true",
+            self.host_port
+        )
+    }
+
+    pub async fn wait_until_ready(&self, timeout_secs: u64) -> Result<()> {
+        let start = Instant::now();
+        let master = format!(
+            "Server=tcp:localhost,{};User=sa;Password={SA_PASSWORD};Database=master;\
+             TrustServerCertificate=true;Encrypt=true",
+            self.host_port
+        );
+        while start.elapsed() < Duration::from_secs(timeout_secs) {
+            if crate::from_mssql::client::connect(&master).await.is_ok() {
+                return Ok(());
+            }
+            debug!("SQL Server TDS not ready yet");
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+        anyhow::bail!("SQL Server did not become ready within {timeout_secs}s")
+    }
+
+    /// Wait for Agent, create `testdb`, and enable CDC.
+    pub async fn setup_testdb(&self) -> Result<()> {
+        let master = format!(
+            "Server=tcp:localhost,{};User=sa;Password={SA_PASSWORD};Database=master;\
+             TrustServerCertificate=true;Encrypt=true",
+            self.host_port
+        );
+        let client = crate::from_mssql::client::connect(&master).await?;
+        wait_agent(&client).await?;
+        client
+            .simple_query(
+                "IF DB_ID(N'testdb') IS NULL CREATE DATABASE testdb; \
+                 ALTER DATABASE testdb SET ALLOW_SNAPSHOT_ISOLATION ON;",
+            )
+            .await?;
+        let testdb = crate::from_mssql::client::connect(&self.connection_string).await?;
+        if testdb
+            .simple_query("EXEC testdb.sys.sp_cdc_enable_db;")
+            .await
+            .is_err()
+        {
+            testdb.simple_query("EXEC sys.sp_cdc_enable_db;").await?;
+        }
+        Ok(())
+    }
+
+    pub fn stop(&self) -> Result<()> {
+        let _ = Command::new("docker")
+            .args(["stop", &self.container_name])
+            .output();
+        let _ = Command::new("docker")
+            .args(["rm", &self.container_name])
+            .output();
+        Ok(())
+    }
+}
+
+impl Drop for MssqlContainer {
+    fn drop(&mut self) {
+        let _ = self.stop();
+    }
+}
+
+async fn wait_agent(client: &crate::from_mssql::client::MssqlClient) -> Result<()> {
+    let start = Instant::now();
+    while start.elapsed() < Duration::from_secs(60) {
+        let rows = client
+            .query(
+                "SELECT status_desc FROM sys.dm_server_services \
+                 WHERE servicename LIKE N'SQL Server Agent%'",
+                &[],
+            )
+            .await;
+        if let Ok(rows) = rows {
+            if let Some(row) = rows.first() {
+                let status: Option<&str> = row.try_get(0).ok().flatten();
+                if status.is_some_and(|s| s.eq_ignore_ascii_case("Running")) {
+                    return Ok(());
+                }
+            }
+        }
+        // Agent DMV may be empty on Linux; retry CDC enable as a proxy.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    Ok(())
+}
+
+fn get_dynamic_port(container_name: &str) -> Result<u16> {
+    for attempt in 0..10 {
+        let output = Command::new("docker")
+            .args(["port", container_name, "1433"])
+            .output()
+            .context("Failed to query dynamic port")?;
+        if output.status.success() {
+            let port_output = String::from_utf8_lossy(&output.stdout);
+            if let Some(port) = port_output
+                .lines()
+                .next()
+                .and_then(|line| line.rsplit(':').next())
+                .and_then(|p| p.trim().parse::<u16>().ok())
+            {
+                return Ok(port);
+            }
+        }
+        if attempt < 9 {
+            std::thread::sleep(Duration::from_millis(200));
+        }
+    }
+    anyhow::bail!("docker port failed for {container_name}")
+}

--- a/crates/mssql/src/from_mssql/testing/mod.rs
+++ b/crates/mssql/src/from_mssql/testing/mod.rs
@@ -1,0 +1,10 @@
+//! Docker helper for SQL Server CDC tests.
+//!
+//! Running the container accepts Microsoft's EULA
+//! (https://go.microsoft.com/fwlink/?linkid=2143497). Developer edition is for
+//! test only — do not imply production licensing.
+
+mod container;
+
+pub use super::client::{connect, MssqlClient};
+pub use container::MssqlContainer;

--- a/crates/mssql/src/from_mssql/testing/mod.rs
+++ b/crates/mssql/src/from_mssql/testing/mod.rs
@@ -6,5 +6,5 @@
 
 mod container;
 
-pub use super::client::{connect, MssqlClient};
+pub use super::client::{connect, MssqlClient, SqlArg};
 pub use container::MssqlContainer;

--- a/crates/mssql/src/from_mssql/watermark_source.rs
+++ b/crates/mssql/src/from_mssql/watermark_source.rs
@@ -235,7 +235,7 @@ impl MssqlWatermarkSource {
                             op,
                             &meta.target,
                             r.relation.id.clone(),
-                            Some(r.relation.data.clone()),
+                            Some(regular::relation_fields(&r.relation)),
                         ),
                     };
                     Ok(Some(ReconciliationEvent {
@@ -247,7 +247,12 @@ impl MssqlWatermarkSource {
                 }
             },
             TableSyncKind::Temporal => {
-                let action = temporal::apply_change(meta, change)?;
+                let action = temporal::apply_change(
+                    meta,
+                    change,
+                    self.table_def(&meta.target),
+                    &self.temporal,
+                )?;
                 let Some(c) = action.new_version else {
                     return Ok(None);
                 };
@@ -337,19 +342,24 @@ impl WatermarkSource for MssqlWatermarkSource {
         match meta.kind {
             TableSyncKind::Regular => {
                 let maps = regular::read_chunk(&self.client, meta, after_vals, limit).await?;
-                let (rows, _) = regular::snapshot_items(
+                Ok(regular::snapshot_rows(
                     meta,
                     maps,
                     0,
                     self.table_def(&meta.target),
                     &self.relation_tables,
                     &self.temporal,
-                );
-                Ok(rows)
+                ))
             }
             TableSyncKind::Temporal => {
                 let maps = temporal::read_chunk(&self.client, meta, after_vals, limit).await?;
-                Ok(temporal::rows_from_maps(meta, maps, 0))
+                Ok(temporal::rows_from_maps(
+                    meta,
+                    maps,
+                    0,
+                    self.table_def(&meta.target),
+                    &self.temporal,
+                ))
             }
         }
     }

--- a/crates/mssql/src/from_mssql/watermark_source.rs
+++ b/crates/mssql/src/from_mssql/watermark_source.rs
@@ -1,0 +1,717 @@
+//! Interleaved watermark snapshot over SQL Server CDC.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Mutex;
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+use surreal_sync_core::SurrealSink;
+use surreal_sync_core::{
+    Checkpoint, CheckpointStore, DatabaseSchema, InterleavedSnapshotCheckpoint, Row, SyncManager,
+    SyncPhase, TableDefinition, Value,
+};
+use surreal_sync_runtime::{
+    run_interleaved_snapshot_with_resume_and_transforms, InterleavedSnapshotConfig,
+    NoopCheckpointer, PkTuple, ReconciliationEvent, SnapshotCheckpointer, SnapshotSignal,
+    SnapshotTransforms, TableSpec, WatermarkKind, WatermarkSource,
+};
+use tracing::info;
+use uuid::Uuid;
+
+use crate::from_mssql::catalog::{collect_database_schema, MssqlTableMeta, TableSyncKind};
+use crate::from_mssql::cdc::{self, CdcChange, CdcOperation};
+use crate::from_mssql::checkpoint::{MssqlCheckpoint, MssqlLsn};
+use crate::from_mssql::client::MssqlClient;
+use crate::from_mssql::regular;
+use crate::from_mssql::schema::{database_schema, schemafull_extras, temporal_targets};
+use crate::from_mssql::signal::{self, signal_qualified, SIGNAL_TABLE};
+use crate::from_mssql::temporal;
+use crate::from_mssql::SourceOpts;
+
+#[derive(Default)]
+struct WatermarkIds {
+    low: Option<Uuid>,
+    high: Option<Uuid>,
+}
+
+/// Options for [`MssqlWatermarkSource::connect_with_options`].
+#[derive(Clone, Debug)]
+pub struct ConnectOptions {
+    pub start_at: Option<MssqlCheckpoint>,
+    pub tables_filter: Option<Vec<String>>,
+    pub cancel: tokio_util::sync::CancellationToken,
+}
+
+impl ConnectOptions {
+    pub fn with_cancel(mut self, cancel: tokio_util::sync::CancellationToken) -> Self {
+        self.cancel = cancel;
+        self
+    }
+}
+
+impl Default for ConnectOptions {
+    fn default() -> Self {
+        Self {
+            start_at: None,
+            tables_filter: None,
+            cancel: tokio_util::sync::CancellationToken::new(),
+        }
+    }
+}
+
+/// SQL Server CDC + keyset snapshot backend for the interleaved watermark loop.
+pub struct MssqlWatermarkSource {
+    client: MssqlClient,
+    db_schema: DatabaseSchema,
+    metas: Vec<MssqlTableMeta>,
+    by_target: HashMap<String, MssqlTableMeta>,
+    tables: Vec<TableSpec>,
+    relation_tables: Vec<String>,
+    temporal: HashSet<String>,
+    from_lsn: Option<MssqlLsn>,
+    confirmed: MssqlLsn,
+    watermarks: Mutex<WatermarkIds>,
+    pending_watermarks: Mutex<HashSet<Uuid>>,
+    cancel: tokio_util::sync::CancellationToken,
+    schemafull: bool,
+    dry_run: bool,
+}
+
+impl MssqlWatermarkSource {
+    pub async fn connect(from_opts: &SourceOpts) -> Result<Self> {
+        Self::connect_with_options(from_opts, ConnectOptions::default()).await
+    }
+
+    pub async fn connect_with_options(
+        from_opts: &SourceOpts,
+        options: ConnectOptions,
+    ) -> Result<Self> {
+        let client = crate::from_mssql::client::connect(&from_opts.connection_string).await?;
+        cdc::ensure_cdc_enabled(&client).await?;
+        signal::ensure_signal_table(&client).await?;
+
+        let mut metas = collect_database_schema(&client, &from_opts.tables).await?;
+        if let Some(filter) = &options.tables_filter {
+            let allowed: HashSet<_> = filter.iter().cloned().collect();
+            metas.retain(|m| allowed.contains(&m.target) || allowed.contains(&m.source.dotted()));
+        }
+        for meta in &metas {
+            cdc::ensure_table_cdc(&client, &meta.source).await?;
+        }
+
+        let mut from_lsn = options.start_at.map(|c| c.lsn);
+        if from_lsn.is_none() {
+            // Wait until CDC has a max LSN so we do not replay an empty history.
+            for _ in 0..50 {
+                if let Some(lsn) = cdc::max_lsn(&client).await? {
+                    from_lsn = Some(lsn);
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(200)).await;
+            }
+        }
+        let confirmed = from_lsn.clone().unwrap_or_else(|| MssqlLsn(vec![0; 10]));
+
+        let db_schema = database_schema(&metas);
+        let temporal = temporal_targets(&metas);
+        let tables = metas
+            .iter()
+            .map(|m| TableSpec::new(m.target.clone(), keyset_columns(m)))
+            .collect();
+        let by_target = metas
+            .iter()
+            .map(|m| (m.target.clone(), m.clone()))
+            .collect();
+
+        Ok(Self {
+            client,
+            db_schema,
+            metas,
+            by_target,
+            tables,
+            relation_tables: from_opts.relation_tables.clone(),
+            temporal,
+            from_lsn,
+            confirmed,
+            watermarks: Mutex::new(WatermarkIds::default()),
+            pending_watermarks: Mutex::new(HashSet::new()),
+            cancel: options.cancel,
+            schemafull: from_opts.schemafull,
+            dry_run: from_opts.dry_run,
+        })
+    }
+
+    pub async fn resolve_snapshot_table_names(from_opts: &SourceOpts) -> Result<Vec<String>> {
+        let client = crate::from_mssql::client::connect(&from_opts.connection_string).await?;
+        let metas = collect_database_schema(&client, &from_opts.tables).await?;
+        Ok(metas.into_iter().map(|m| m.target).collect())
+    }
+
+    pub fn start_checkpoint(&self) -> MssqlCheckpoint {
+        MssqlCheckpoint::new(self.confirmed.clone())
+    }
+
+    pub fn with_cancel(mut self, cancel: tokio_util::sync::CancellationToken) -> Self {
+        self.cancel = cancel;
+        self
+    }
+
+    fn table_def(&self, target: &str) -> Option<&TableDefinition> {
+        self.db_schema.get_table(target)
+    }
+
+    async fn poll_cdc_once(&mut self) -> Result<Vec<ReconciliationEvent<MssqlLsn>>> {
+        let Some(to) = cdc::max_lsn(&self.client).await? else {
+            return Ok(Vec::new());
+        };
+        let mut events = Vec::new();
+        for meta in &self.metas {
+            let changes =
+                cdc::poll_changes(&self.client, meta, self.from_lsn.as_ref(), &to).await?;
+            for ch in changes {
+                if let Some(ev) = self.change_to_event(meta, &ch)? {
+                    events.push(ev);
+                }
+            }
+        }
+        let signal_changes = cdc::poll_signal_changes(
+            &self.client,
+            &signal_qualified(),
+            self.from_lsn.as_ref(),
+            &to,
+        )
+        .await?;
+        for ch in signal_changes {
+            if let Some(ev) = signal_event(&ch) {
+                let (low, high) = {
+                    let guard = self.watermarks.lock().expect("watermark lock");
+                    (guard.low, guard.high)
+                };
+                let mut pending = self.pending_watermarks.lock().expect("pending lock");
+                if let Some(id) = ev.pk.single_uuid() {
+                    if Some(id) != low && Some(id) != high {
+                        continue;
+                    }
+                    pending.remove(&id);
+                }
+                events.push(ev);
+            }
+        }
+        Ok(events)
+    }
+
+    fn change_to_event(
+        &self,
+        meta: &MssqlTableMeta,
+        change: &CdcChange,
+    ) -> Result<Option<ReconciliationEvent<MssqlLsn>>> {
+        if change.operation == CdcOperation::UpdateBefore && meta.kind == TableSyncKind::Regular {
+            return Ok(None);
+        }
+        match meta.kind {
+            TableSyncKind::Regular => match regular::apply_change(
+                meta,
+                change,
+                self.table_def(&meta.target),
+                &self.relation_tables,
+                &self.temporal,
+            )? {
+                regular::RegularCdc::Row(c) => {
+                    let pk = pk_from_change(&c, &meta.pk_columns);
+                    Ok(Some(ReconciliationEvent {
+                        position: change.start_lsn.clone(),
+                        table: meta.target.clone(),
+                        pk,
+                        change: c,
+                    }))
+                }
+                regular::RegularCdc::Relation(r) => {
+                    let pk = PkTuple::new(vec![r.relation.id.clone()]);
+                    let row_change = match r.operation {
+                        surreal_sync_core::ChangeOp::Delete => {
+                            surreal_sync_core::Change::delete(&meta.target, r.relation.id.clone())
+                        }
+                        op => surreal_sync_core::Change::new(
+                            op,
+                            &meta.target,
+                            r.relation.id.clone(),
+                            Some(r.relation.data.clone()),
+                        ),
+                    };
+                    Ok(Some(ReconciliationEvent {
+                        position: change.start_lsn.clone(),
+                        table: meta.target.clone(),
+                        pk,
+                        change: row_change,
+                    }))
+                }
+            },
+            TableSyncKind::Temporal => {
+                let action = temporal::apply_change(meta, change)?;
+                let Some(c) = action.new_version else {
+                    return Ok(None);
+                };
+                let pk = pk_from_fields(&change.fields, &meta.pk_columns);
+                Ok(Some(ReconciliationEvent {
+                    position: change.start_lsn.clone(),
+                    table: meta.target.clone(),
+                    pk,
+                    change: c,
+                }))
+            }
+        }
+    }
+}
+
+fn keyset_columns(meta: &MssqlTableMeta) -> Vec<String> {
+    match meta.kind {
+        TableSyncKind::Regular => meta.pk_columns.clone(),
+        TableSyncKind::Temporal => {
+            let mut c = meta.pk_columns.clone();
+            c.push(
+                meta.period_start
+                    .clone()
+                    .unwrap_or_else(|| "ValidFrom".into()),
+            );
+            c.push(meta.period_end.clone().unwrap_or_else(|| "ValidTo".into()));
+            c
+        }
+    }
+}
+
+fn pk_from_change(change: &surreal_sync_core::Change, pk_columns: &[String]) -> PkTuple {
+    if let Some(fields) = &change.fields {
+        return pk_from_fields(fields, pk_columns);
+    }
+    PkTuple::new(vec![change.id.clone()])
+}
+
+fn pk_from_fields(fields: &HashMap<String, Value>, pk_columns: &[String]) -> PkTuple {
+    PkTuple::new(
+        pk_columns
+            .iter()
+            .map(|c| fields.get(c).cloned().unwrap_or(Value::Null))
+            .collect(),
+    )
+}
+
+fn signal_event(change: &CdcChange) -> Option<ReconciliationEvent<MssqlLsn>> {
+    if change.operation != CdcOperation::Insert {
+        return None;
+    }
+    let id = match change.fields.get("id") {
+        Some(Value::Uuid(u)) => *u,
+        _ => return None,
+    };
+    Some(ReconciliationEvent {
+        position: change.start_lsn.clone(),
+        table: SIGNAL_TABLE.to_string(),
+        pk: PkTuple::new(vec![Value::Uuid(id)]),
+        change: surreal_sync_core::Change::create(
+            SIGNAL_TABLE,
+            Value::Uuid(id),
+            change.fields.clone(),
+        ),
+    })
+}
+
+#[async_trait::async_trait]
+impl WatermarkSource for MssqlWatermarkSource {
+    type Position = MssqlLsn;
+
+    async fn snapshot_tables(&self) -> Result<Vec<TableSpec>> {
+        Ok(self.tables.clone())
+    }
+
+    async fn read_chunk(
+        &self,
+        table: &TableSpec,
+        after: Option<&PkTuple>,
+        limit: usize,
+    ) -> Result<Vec<Row>> {
+        let meta = self
+            .by_target
+            .get(&table.table)
+            .ok_or_else(|| anyhow!("unknown snapshot table `{}`", table.table))?;
+        let after_vals = after.map(|p| p.0.as_slice());
+        match meta.kind {
+            TableSyncKind::Regular => {
+                let maps = regular::read_chunk(&self.client, meta, after_vals, limit).await?;
+                let (rows, _) = regular::snapshot_items(
+                    meta,
+                    maps,
+                    0,
+                    self.table_def(&meta.target),
+                    &self.relation_tables,
+                    &self.temporal,
+                );
+                Ok(rows)
+            }
+            TableSyncKind::Temporal => {
+                let maps = temporal::read_chunk(&self.client, meta, after_vals, limit).await?;
+                Ok(temporal::rows_from_maps(meta, maps, 0))
+            }
+        }
+    }
+
+    async fn write_watermark(&self, kind: WatermarkKind, id: Uuid) -> Result<()> {
+        let kind_str = match kind {
+            WatermarkKind::Low => "low",
+            WatermarkKind::High => "high",
+        };
+        signal::insert_watermark(&self.client, kind_str, id).await?;
+        {
+            let mut guard = self.watermarks.lock().expect("watermark lock");
+            match kind {
+                WatermarkKind::Low => guard.low = Some(id),
+                WatermarkKind::High => guard.high = Some(id),
+            }
+        }
+        self.pending_watermarks
+            .lock()
+            .expect("pending lock")
+            .insert(id);
+        Ok(())
+    }
+
+    async fn next_reconciliation_events(
+        &mut self,
+    ) -> Result<Vec<ReconciliationEvent<Self::Position>>> {
+        for attempt in 0..40 {
+            if self.cancel.is_cancelled() {
+                return Err(anyhow!("interleaved snapshot cancelled"));
+            }
+            let events = self.poll_cdc_once().await?;
+            let pending = self.pending_watermarks.lock().expect("pending lock").len();
+            if !events.is_empty() || pending == 0 {
+                if events.is_empty() {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                }
+                return Ok(events);
+            }
+            // Wait for the Agent capture job to land the watermark insert.
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            if attempt == 39 {
+                anyhow::bail!(
+                    "CDC did not capture watermark rows in time. {}",
+                    "SQL Server Agent must be running (Linux containers: MSSQL_AGENT_ENABLED=true)."
+                );
+            }
+        }
+        Ok(Vec::new())
+    }
+
+    async fn current_position(&self) -> Result<Self::Position> {
+        Ok(self.confirmed.clone())
+    }
+
+    async fn commit_reconciled(&mut self, position: Self::Position) -> Result<()> {
+        self.from_lsn = Some(position.clone());
+        self.confirmed = position;
+        Ok(())
+    }
+
+    async fn read_signals(&mut self) -> Result<Vec<SnapshotSignal>> {
+        Ok(Vec::new())
+    }
+
+    async fn resolve_tables(&self, names: &[String]) -> Result<Vec<TableSpec>> {
+        Ok(self
+            .tables
+            .iter()
+            .filter(|t| names.iter().any(|n| n == &t.table))
+            .cloned()
+            .collect())
+    }
+}
+
+/// Options controlling interleaved snapshot restart and table selection.
+#[derive(Clone, Debug)]
+pub struct InterleavedFullSyncOptions {
+    pub resume_progress: Option<InterleavedSnapshotCheckpoint>,
+    pub tables_filter: Option<Vec<String>>,
+    pub start_at: Option<MssqlCheckpoint>,
+    pub emit_full_sync_start: bool,
+}
+
+impl Default for InterleavedFullSyncOptions {
+    fn default() -> Self {
+        Self {
+            resume_progress: None,
+            tables_filter: None,
+            start_at: None,
+            emit_full_sync_start: true,
+        }
+    }
+}
+
+/// Outcome of an interleaved snapshot full sync.
+#[derive(Debug, Clone)]
+pub struct InterleavedFullSyncOutcome {
+    pub start: MssqlCheckpoint,
+    pub end: MssqlCheckpoint,
+    pub cancelled: bool,
+}
+
+pub async fn run_interleaved_snapshot_full_sync<S, St>(
+    surreal: &S,
+    from_opts: &SourceOpts,
+    chunk_size: usize,
+    cancel: tokio_util::sync::CancellationToken,
+    manager: Option<&SyncManager<St>>,
+    options: InterleavedFullSyncOptions,
+) -> Result<InterleavedFullSyncOutcome>
+where
+    S: SurrealSink,
+    St: CheckpointStore,
+{
+    let transforms = SnapshotTransforms::identity();
+    run_interleaved_snapshot_full_sync_with_transforms(
+        surreal,
+        from_opts,
+        chunk_size,
+        cancel,
+        manager,
+        options,
+        &transforms,
+    )
+    .await
+}
+
+pub async fn run_interleaved_snapshot_full_sync_with_transforms<S, St>(
+    surreal: &S,
+    from_opts: &SourceOpts,
+    chunk_size: usize,
+    cancel: tokio_util::sync::CancellationToken,
+    manager: Option<&SyncManager<St>>,
+    options: InterleavedFullSyncOptions,
+    transforms: &SnapshotTransforms,
+) -> Result<InterleavedFullSyncOutcome>
+where
+    S: SurrealSink,
+    St: CheckpointStore,
+{
+    let connect_opts = ConnectOptions {
+        start_at: options.start_at.clone(),
+        tables_filter: options.tables_filter.clone(),
+        cancel: cancel.clone(),
+    };
+    let mut source = MssqlWatermarkSource::connect_with_options(from_opts, connect_opts).await?;
+
+    let extras = schemafull_extras(&source.metas, from_opts.relation_tables.clone());
+    surreal_sync_core::maybe_emit_schemafull(
+        surreal,
+        &source.db_schema,
+        &extras,
+        source.schemafull,
+        source.dry_run,
+    )
+    .await?;
+
+    let start = if options.emit_full_sync_start {
+        let start = source.start_checkpoint();
+        if let Some(manager) = manager {
+            manager
+                .emit_checkpoint(&start, SyncPhase::FullSyncStart)
+                .await?;
+            info!(
+                "Emitted interleaved snapshot start checkpoint: {}",
+                start.to_cli_string()
+            );
+        }
+        start
+    } else {
+        source.start_checkpoint()
+    };
+
+    let config = InterleavedSnapshotConfig { chunk_size };
+    let resume_ref = options.resume_progress.as_ref();
+    let snapshot_result = if let Some(manager) = manager {
+        let mut checkpointer = ManagerRefCheckpointer { manager };
+        run_interleaved_snapshot_with_resume_and_transforms(
+            &mut source,
+            surreal,
+            &config,
+            &mut checkpointer,
+            resume_ref,
+            transforms,
+        )
+        .await
+    } else {
+        run_interleaved_snapshot_with_resume_and_transforms(
+            &mut source,
+            surreal,
+            &config,
+            &mut NoopCheckpointer,
+            resume_ref,
+            transforms,
+        )
+        .await
+    };
+
+    match snapshot_result {
+        Ok(result) => {
+            let end = MssqlCheckpoint::new(result.final_position);
+            info!(
+                "SQL Server watermark snapshot complete (final LSN {}, peak buffered rows: {})",
+                end.lsn, result.peak_buffered_rows
+            );
+            if let Some(manager) = manager {
+                manager
+                    .emit_checkpoint(&end, SyncPhase::FullSyncEnd)
+                    .await?;
+            }
+            Ok(InterleavedFullSyncOutcome {
+                start,
+                end,
+                cancelled: false,
+            })
+        }
+        Err(e) if cancel.is_cancelled() => {
+            info!("Interleaved snapshot cancelled ({e}); FullSyncStart remains the resume point");
+            Ok(InterleavedFullSyncOutcome {
+                end: start.clone(),
+                start,
+                cancelled: true,
+            })
+        }
+        Err(e) => Err(e),
+    }
+}
+
+struct ManagerRefCheckpointer<'a, St: CheckpointStore> {
+    manager: &'a SyncManager<St>,
+}
+
+#[async_trait::async_trait]
+impl<St: CheckpointStore> SnapshotCheckpointer for ManagerRefCheckpointer<'_, St> {
+    async fn save_progress(&mut self, checkpoint: &InterleavedSnapshotCheckpoint) -> Result<()> {
+        self.manager
+            .emit_checkpoint(checkpoint, SyncPhase::SnapshotProgress)
+            .await?;
+        Ok(())
+    }
+}
+
+/// Result of the initial interleaved snapshot planning step.
+#[derive(Debug, Clone)]
+pub struct InitialInterleavedOutcome {
+    pub snapshot_skipped: bool,
+    pub sync_outcome: Option<InterleavedFullSyncOutcome>,
+}
+
+pub async fn run_initial_interleaved_snapshot<S, St>(
+    surreal: &S,
+    from_opts: &SourceOpts,
+    chunk_size: usize,
+    cancel: tokio_util::sync::CancellationToken,
+    manager: Option<&SyncManager<St>>,
+) -> Result<InitialInterleavedOutcome>
+where
+    S: SurrealSink,
+    St: CheckpointStore,
+{
+    let transforms = SnapshotTransforms::identity();
+    run_initial_interleaved_snapshot_with_transforms(
+        surreal,
+        from_opts,
+        chunk_size,
+        cancel,
+        manager,
+        &transforms,
+    )
+    .await
+}
+
+pub async fn run_initial_interleaved_snapshot_with_transforms<S, St>(
+    surreal: &S,
+    from_opts: &SourceOpts,
+    chunk_size: usize,
+    cancel: tokio_util::sync::CancellationToken,
+    manager: Option<&SyncManager<St>>,
+    transforms: &SnapshotTransforms,
+) -> Result<InitialInterleavedOutcome>
+where
+    S: SurrealSink,
+    St: CheckpointStore,
+{
+    if let Some(manager) = manager {
+        if let Ok(progress) = manager
+            .read_checkpoint::<InterleavedSnapshotCheckpoint>(SyncPhase::SnapshotProgress)
+            .await
+        {
+            if !progress.all_done() {
+                info!("Resuming interleaved snapshot from saved per-chunk progress");
+                let start_at = resume_checkpoint_from_progress(&progress)?;
+                let outcome = run_interleaved_snapshot_full_sync_with_transforms(
+                    surreal,
+                    from_opts,
+                    chunk_size,
+                    cancel,
+                    Some(manager),
+                    InterleavedFullSyncOptions {
+                        resume_progress: Some(progress),
+                        start_at: Some(start_at),
+                        emit_full_sync_start: false,
+                        ..InterleavedFullSyncOptions::default()
+                    },
+                    transforms,
+                )
+                .await?;
+                return Ok(InitialInterleavedOutcome {
+                    snapshot_skipped: false,
+                    sync_outcome: Some(outcome),
+                });
+            }
+        }
+        if let Ok(end) = manager
+            .read_checkpoint::<MssqlCheckpoint>(SyncPhase::FullSyncEnd)
+            .await
+        {
+            info!(
+                "Snapshot already complete; skipping snapshot and streaming from {}",
+                end.to_cli_string()
+            );
+            return Ok(InitialInterleavedOutcome {
+                snapshot_skipped: true,
+                sync_outcome: Some(InterleavedFullSyncOutcome {
+                    start: end.clone(),
+                    end,
+                    cancelled: false,
+                }),
+            });
+        }
+    }
+
+    let outcome = run_interleaved_snapshot_full_sync_with_transforms(
+        surreal,
+        from_opts,
+        chunk_size,
+        cancel,
+        manager,
+        InterleavedFullSyncOptions {
+            emit_full_sync_start: true,
+            ..InterleavedFullSyncOptions::default()
+        },
+        transforms,
+    )
+    .await?;
+    Ok(InitialInterleavedOutcome {
+        snapshot_skipped: false,
+        sync_outcome: Some(outcome),
+    })
+}
+
+fn resume_checkpoint_from_progress(
+    progress: &InterleavedSnapshotCheckpoint,
+) -> Result<MssqlCheckpoint> {
+    let lsn: MssqlLsn =
+        serde_json::from_value(progress.reconciliation_pos.clone()).or_else(|_| {
+            progress
+                .reconciliation_pos
+                .as_str()
+                .ok_or_else(|| anyhow!("cannot parse snapshot LSN"))
+                .and_then(MssqlLsn::from_hex)
+        })?;
+    Ok(MssqlCheckpoint::new(lsn))
+}

--- a/crates/mssql/src/lib.rs
+++ b/crates/mssql/src/lib.rs
@@ -1,0 +1,21 @@
+//! SQL Server type mapping and `from mssql` origin for surreal-sync.
+//!
+//! # Embed
+//!
+//! With the `from_mssql` feature, embedders use only:
+//!
+//! ```ignore
+//! use surreal_sync_mssql::{run, FlattenId, InPlaceTransform, Value};
+//! // or: use surreal_sync_mssql::from_mssql::{run, FlattenId, InPlaceTransform, Value};
+//! ```
+
+#[cfg(feature = "types")]
+pub mod types;
+
+#[cfg(feature = "from_mssql")]
+pub mod from_mssql;
+
+/// Crate-root sugar for the public embed surface (same four items as
+/// [`from_mssql`]).
+#[cfg(feature = "from_mssql")]
+pub use from_mssql::{run, FlattenId, InPlaceTransform, Value};

--- a/crates/mssql/src/types.rs
+++ b/crates/mssql/src/types.rs
@@ -163,13 +163,22 @@ pub fn tiberius_to_value(
             Some(v) => Ok(Value::Float64(v)),
         },
         Type::Decimal { precision, scale } => {
-            match row
-                .try_get::<tiberius::numeric::Numeric, _>(col_idx)
-                .with_context(ctx)?
-            {
+            // DECIMAL/NUMERIC arrive as Tiberius Numeric. MONEY/SMALLMONEY are
+            // exposed as f64 by the driver.
+            if let Ok(opt) = row.try_get::<tiberius::numeric::Numeric, _>(col_idx) {
+                return Ok(match opt {
+                    None => Value::Null,
+                    Some(n) => Value::Decimal {
+                        value: n.to_string(),
+                        precision: *precision,
+                        scale: *scale,
+                    },
+                });
+            }
+            match row.try_get::<f64, _>(col_idx).with_context(ctx)? {
                 None => Ok(Value::Null),
-                Some(n) => Ok(Value::Decimal {
-                    value: n.to_string(),
+                Some(f) => Ok(Value::Decimal {
+                    value: format!("{f:.prec$}", prec = *scale as usize),
                     precision: *precision,
                     scale: *scale,
                 }),
@@ -190,8 +199,10 @@ pub fn tiberius_to_value(
             }),
         },
         Type::Text => {
-            if let Ok(Some(xml)) = row.try_get::<&tiberius::xml::XmlData, _>(col_idx) {
-                return Ok(Value::Text(xml.to_string()));
+            match row.try_get::<&tiberius::xml::XmlData, _>(col_idx) {
+                Ok(Some(xml)) => return Ok(Value::Text(xml.to_string())),
+                Ok(None) => return Ok(Value::Null),
+                Err(_) => {}
             }
             match row.try_get::<&str, _>(col_idx).with_context(ctx)? {
                 None => Ok(Value::Null),

--- a/crates/mssql/src/types.rs
+++ b/crates/mssql/src/types.rs
@@ -1,0 +1,309 @@
+//! Map SQL Server column types to the surreal-sync universal [`Type`].
+//!
+//! Types that cannot be copied losslessly are rejected before export.
+
+use surreal_sync_core::Type;
+
+/// A SQL Server type that surreal-sync will not copy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnsupportedMssqlType {
+    /// SQL Server type name as reported by the catalog (for example `geography`).
+    pub type_name: String,
+}
+
+impl std::fmt::Display for UnsupportedMssqlType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "SQL Server type `{}` cannot be synced to SurrealDB",
+            self.type_name
+        )
+    }
+}
+
+impl std::error::Error for UnsupportedMssqlType {}
+
+impl UnsupportedMssqlType {
+    /// Create an error for `type_name`.
+    pub fn new(type_name: impl Into<String>) -> Self {
+        Self {
+            type_name: type_name.into(),
+        }
+    }
+}
+
+fn is_rejected(type_name: &str) -> bool {
+    matches!(
+        type_name,
+        "sql_variant"
+            | "hierarchyid"
+            | "geography"
+            | "geometry"
+            | "cursor"
+            | "table"
+            | "rowversion"
+            | "timestamp"
+            | "udt"
+    )
+}
+
+/// Map a SQL Server catalog type to the universal type universe.
+///
+/// `length` is the character length when known. `max_length` is
+/// `sys.columns.max_length` (`-1` means `MAX`).
+///
+/// `timestamp` is SQL Server's binary rowversion, not a datetime, and is
+/// rejected.
+pub fn mssql_column_to_universal_type(
+    type_name: &str,
+    precision: Option<u8>,
+    scale: Option<u8>,
+    length: Option<u16>,
+    max_length: Option<i32>,
+) -> Result<Type, UnsupportedMssqlType> {
+    let normalized = type_name.trim().to_ascii_lowercase();
+    if is_rejected(&normalized) {
+        return Err(UnsupportedMssqlType::new(type_name));
+    }
+
+    let is_max = max_length == Some(-1);
+
+    Ok(match normalized.as_str() {
+        "bit" => Type::Bool,
+        // tinyint is 0–255; Int16 is the lossless signed home.
+        "tinyint" => Type::Int16,
+        "smallint" => Type::Int16,
+        "int" => Type::Int32,
+        "bigint" => Type::Int64,
+        "decimal" | "numeric" => Type::Decimal {
+            precision: precision.unwrap_or(18),
+            scale: scale.unwrap_or(0),
+        },
+        "money" => Type::Decimal {
+            precision: 19,
+            scale: 4,
+        },
+        "smallmoney" => Type::Decimal {
+            precision: 10,
+            scale: 4,
+        },
+        "float" => Type::Float64,
+        "real" => Type::Float32,
+        "date" => Type::Date,
+        "time" => Type::Time,
+        "datetime" | "datetime2" | "smalldatetime" => Type::LocalDateTime,
+        "datetimeoffset" => Type::ZonedDateTime,
+        "char" | "nchar" => Type::Char {
+            length: length.unwrap_or(1),
+        },
+        "varchar" | "nvarchar" => {
+            if is_max {
+                Type::Text
+            } else {
+                Type::VarChar {
+                    length: length.unwrap_or(1),
+                }
+            }
+        }
+        "text" | "ntext" | "xml" => Type::Text,
+        "sysname" => Type::VarChar { length: 128 },
+        "uniqueidentifier" => Type::Uuid,
+        "binary" | "varbinary" | "image" => Type::Bytes,
+        // CLR user-defined types show up under their type name, not `udt`.
+        other => return Err(UnsupportedMssqlType::new(other)),
+    })
+}
+
+/// Convert one Tiberius cell to a universal [`surreal_sync_core::Value`] using
+/// the catalog type as a hint.
+#[cfg(feature = "from_mssql")]
+pub fn tiberius_to_value(
+    row: &tiberius::Row,
+    col_idx: usize,
+    type_hint: &Type,
+) -> anyhow::Result<surreal_sync_core::Value> {
+    use anyhow::Context;
+    use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+    use surreal_sync_core::Value;
+
+    fn naive_utc(n: NaiveDateTime) -> DateTime<Utc> {
+        DateTime::<Utc>::from_naive_utc_and_offset(n, Utc)
+    }
+
+    let ctx = || format!("reading SQL Server column {col_idx}");
+
+    match type_hint {
+        Type::Bool => match row.try_get::<bool, _>(col_idx).with_context(ctx)? {
+            None => Ok(Value::Null),
+            Some(v) => Ok(Value::Bool(v)),
+        },
+        Type::Int16 => {
+            if let Ok(Some(v)) = row.try_get::<u8, _>(col_idx) {
+                return Ok(Value::Int16(v as i16));
+            }
+            match row.try_get::<i16, _>(col_idx).with_context(ctx)? {
+                None => Ok(Value::Null),
+                Some(v) => Ok(Value::Int16(v)),
+            }
+        }
+        Type::Int32 => match row.try_get::<i32, _>(col_idx).with_context(ctx)? {
+            None => Ok(Value::Null),
+            Some(v) => Ok(Value::Int32(v)),
+        },
+        Type::Int64 => match row.try_get::<i64, _>(col_idx).with_context(ctx)? {
+            None => Ok(Value::Null),
+            Some(v) => Ok(Value::Int64(v)),
+        },
+        Type::Float32 => match row.try_get::<f32, _>(col_idx).with_context(ctx)? {
+            None => Ok(Value::Null),
+            Some(v) => Ok(Value::Float32(v)),
+        },
+        Type::Float64 => match row.try_get::<f64, _>(col_idx).with_context(ctx)? {
+            None => Ok(Value::Null),
+            Some(v) => Ok(Value::Float64(v)),
+        },
+        Type::Decimal { precision, scale } => {
+            match row
+                .try_get::<tiberius::numeric::Numeric, _>(col_idx)
+                .with_context(ctx)?
+            {
+                None => Ok(Value::Null),
+                Some(n) => Ok(Value::Decimal {
+                    value: n.to_string(),
+                    precision: *precision,
+                    scale: *scale,
+                }),
+            }
+        }
+        Type::Char { length } => match row.try_get::<&str, _>(col_idx).with_context(ctx)? {
+            None => Ok(Value::Null),
+            Some(s) => Ok(Value::Char {
+                value: s.to_string(),
+                length: *length,
+            }),
+        },
+        Type::VarChar { length } => match row.try_get::<&str, _>(col_idx).with_context(ctx)? {
+            None => Ok(Value::Null),
+            Some(s) => Ok(Value::VarChar {
+                value: s.to_string(),
+                length: *length,
+            }),
+        },
+        Type::Text => {
+            if let Ok(Some(xml)) = row.try_get::<&tiberius::xml::XmlData, _>(col_idx) {
+                return Ok(Value::Text(xml.to_string()));
+            }
+            match row.try_get::<&str, _>(col_idx).with_context(ctx)? {
+                None => Ok(Value::Null),
+                Some(s) => Ok(Value::Text(s.to_string())),
+            }
+        }
+        Type::Bytes | Type::Blob => match row.try_get::<&[u8], _>(col_idx).with_context(ctx)? {
+            None => Ok(Value::Null),
+            Some(bytes) => Ok(Value::Bytes(bytes.to_vec())),
+        },
+        Type::Date => match row.try_get::<NaiveDate, _>(col_idx).with_context(ctx)? {
+            None => Ok(Value::Null),
+            Some(d) => Ok(Value::Date(naive_utc(
+                d.and_hms_opt(0, 0, 0)
+                    .ok_or_else(|| anyhow::anyhow!("invalid date"))?,
+            ))),
+        },
+        Type::Time => match row.try_get::<NaiveTime, _>(col_idx).with_context(ctx)? {
+            None => Ok(Value::Null),
+            Some(t) => {
+                let d = NaiveDate::from_ymd_opt(1970, 1, 1)
+                    .ok_or_else(|| anyhow::anyhow!("invalid epoch date"))?;
+                Ok(Value::Time(naive_utc(d.and_time(t))))
+            }
+        },
+        Type::LocalDateTime | Type::LocalDateTimeNano => {
+            match row.try_get::<NaiveDateTime, _>(col_idx).with_context(ctx)? {
+                None => Ok(Value::Null),
+                Some(n) => Ok(Value::LocalDateTime(naive_utc(n))),
+            }
+        }
+        Type::ZonedDateTime => {
+            if let Ok(opt) = row.try_get::<DateTime<FixedOffset>, _>(col_idx) {
+                return Ok(match opt {
+                    None => Value::Null,
+                    Some(dt) => Value::ZonedDateTime(dt.to_utc()),
+                });
+            }
+            match row.try_get::<DateTime<Utc>, _>(col_idx).with_context(ctx)? {
+                None => Ok(Value::Null),
+                Some(dt) => Ok(Value::ZonedDateTime(dt)),
+            }
+        }
+        Type::Uuid => match row.try_get::<uuid::Uuid, _>(col_idx).with_context(ctx)? {
+            None => Ok(Value::Null),
+            Some(u) => Ok(Value::Uuid(u)),
+        },
+        other => anyhow::bail!("no SQL Server conversion for type {other:?}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_core_types() {
+        assert_eq!(
+            mssql_column_to_universal_type("bit", None, None, None, None).unwrap(),
+            Type::Bool
+        );
+        assert_eq!(
+            mssql_column_to_universal_type("tinyint", None, None, None, None).unwrap(),
+            Type::Int16
+        );
+        assert_eq!(
+            mssql_column_to_universal_type("int", None, None, None, None).unwrap(),
+            Type::Int32
+        );
+        assert_eq!(
+            mssql_column_to_universal_type("bigint", None, None, None, None).unwrap(),
+            Type::Int64
+        );
+        assert_eq!(
+            mssql_column_to_universal_type("money", None, None, None, None).unwrap(),
+            Type::Decimal {
+                precision: 19,
+                scale: 4
+            }
+        );
+        assert_eq!(
+            mssql_column_to_universal_type("sysname", None, None, None, None).unwrap(),
+            Type::VarChar { length: 128 }
+        );
+        assert_eq!(
+            mssql_column_to_universal_type("nvarchar", None, None, Some(50), Some(100)).unwrap(),
+            Type::VarChar { length: 50 }
+        );
+        assert_eq!(
+            mssql_column_to_universal_type("varchar", None, None, None, Some(-1)).unwrap(),
+            Type::Text
+        );
+    }
+
+    #[test]
+    fn rejects_lossy_types() {
+        for name in [
+            "sql_variant",
+            "hierarchyid",
+            "geography",
+            "geometry",
+            "cursor",
+            "table",
+            "rowversion",
+            "timestamp",
+            "udt",
+            "MyClrUdt",
+        ] {
+            assert!(
+                mssql_column_to_universal_type(name, None, None, None, None).is_err(),
+                "{name}"
+            );
+        }
+    }
+}

--- a/crates/mssql/tests/transforms.rs
+++ b/crates/mssql/tests/transforms.rs
@@ -1,0 +1,130 @@
+//! Transform pipeline tests (identity + in-place mutate). No SQL Server.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+
+use surreal_sync_core::SurrealSink;
+use surreal_sync_core::{Change, Relation, Row, Value};
+use surreal_sync_runtime::{write_rows, ApplyOpts, InPlaceTransform, Pipeline};
+
+struct CaptureSink {
+    rows: Mutex<Vec<Row>>,
+    rows_written: AtomicUsize,
+}
+
+impl CaptureSink {
+    fn new() -> Self {
+        Self {
+            rows: Mutex::new(Vec::new()),
+            rows_written: AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl SurrealSink for CaptureSink {
+    async fn write_rows(&self, rows: &[Row]) -> anyhow::Result<()> {
+        self.rows_written.fetch_add(rows.len(), Ordering::SeqCst);
+        self.rows.lock().expect("lock").extend(rows.iter().cloned());
+        Ok(())
+    }
+
+    async fn write_relations(&self, _relations: &[Relation]) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn apply_change(&self, change: &Change) -> anyhow::Result<()> {
+        let mut rows = self.rows.lock().expect("lock");
+        let index = rows.len() as u64;
+        rows.push(Row::new(
+            change.table.clone(),
+            index,
+            change.id.clone(),
+            change.fields.clone().unwrap_or_default(),
+        ));
+        self.rows_written.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn apply_relation_change(
+        &self,
+        _change: &surreal_sync_core::RelationChange,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn query(&self, _sql: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+fn fixture_rows() -> Vec<Row> {
+    let mut a = HashMap::new();
+    a.insert("name".into(), Value::Text("Alice".into()));
+    let mut b = HashMap::new();
+    b.insert("name".into(), Value::Text("Bob".into()));
+    vec![
+        Row::new("people", 0, Value::Int64(1), a),
+        Row::new("people", 1, Value::Int64(2), b),
+    ]
+}
+
+fn row_name(row: &Row) -> Option<String> {
+    match row.fields.get("name")? {
+        Value::Text(value) => Some(value.clone()),
+        other => panic!("unexpected name: {other:?}"),
+    }
+}
+
+struct MutateName;
+
+impl InPlaceTransform for MutateName {
+    fn transform(
+        &self,
+        _table: &str,
+        _id: &mut Value,
+        fields: Option<&mut HashMap<String, Value>>,
+    ) -> anyhow::Result<()> {
+        if let Some(fields) = fields {
+            fields.insert("name".into(), Value::Text("mutated".into()));
+        }
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn identity_apply_writes_rows() {
+    let pipeline = Pipeline::new();
+    let apply_opts = ApplyOpts::identity();
+    let sink = CaptureSink::new();
+
+    write_rows(&sink, &pipeline, fixture_rows(), &apply_opts)
+        .await
+        .expect("identity apply");
+
+    assert_eq!(sink.rows_written.load(Ordering::SeqCst), 2);
+    let rows = sink.rows.lock().expect("lock").clone();
+    assert_eq!(row_name(&rows[0]).as_deref(), Some("Alice"));
+    assert_eq!(row_name(&rows[1]).as_deref(), Some("Bob"));
+}
+
+#[tokio::test]
+async fn inplace_mutate_rewrites_name() {
+    let mut pipeline = Pipeline::new();
+    pipeline.push_inplace(MutateName);
+    let apply_opts = ApplyOpts::identity()
+        .with_batch_size(10)
+        .with_max_in_flight(2);
+    let sink = CaptureSink::new();
+
+    write_rows(&sink, &pipeline, fixture_rows(), &apply_opts)
+        .await
+        .expect("mutate apply");
+
+    let rows = sink.rows.lock().expect("lock").clone();
+    assert_eq!(rows.len(), 2);
+    for row in &rows {
+        assert_eq!(row_name(row).as_deref(), Some("mutated"));
+    }
+}

--- a/crates/mssql/tests/types.rs
+++ b/crates/mssql/tests/types.rs
@@ -1,0 +1,135 @@
+//! Unit tests: type reject list, naming, ADO.NET parse, ids, LSN order.
+
+use std::collections::HashMap;
+use surreal_sync_core::{Checkpoint, Type, Value};
+use surreal_sync_mssql::from_mssql::{
+    detect_collisions, parse_table_ref, record_id, target_table_name, version_id, MssqlCheckpoint,
+    MssqlLsn, QualifiedName, TableSyncKind,
+};
+use surreal_sync_mssql::types::mssql_column_to_universal_type;
+
+#[test]
+fn rejects_lossy_sql_server_types() {
+    for name in [
+        "sql_variant",
+        "hierarchyid",
+        "geography",
+        "geometry",
+        "cursor",
+        "table",
+        "rowversion",
+        "timestamp",
+        "udt",
+        "MyClrUdt",
+    ] {
+        assert!(
+            mssql_column_to_universal_type(name, None, None, None, None).is_err(),
+            "{name} should be rejected"
+        );
+    }
+}
+
+#[test]
+fn maps_supported_types() {
+    assert_eq!(
+        mssql_column_to_universal_type("bit", None, None, None, None).unwrap(),
+        Type::Bool
+    );
+    assert_eq!(
+        mssql_column_to_universal_type("tinyint", None, None, None, None).unwrap(),
+        Type::Int16
+    );
+    assert_eq!(
+        mssql_column_to_universal_type("datetimeoffset", None, None, None, None).unwrap(),
+        Type::ZonedDateTime
+    );
+    assert_eq!(
+        mssql_column_to_universal_type("uniqueidentifier", None, None, None, None).unwrap(),
+        Type::Uuid
+    );
+    assert_eq!(
+        mssql_column_to_universal_type("sysname", None, None, None, None).unwrap(),
+        Type::VarChar { length: 128 }
+    );
+}
+
+#[test]
+fn naming_and_collisions() {
+    let a = parse_table_ref("Article").unwrap();
+    assert_eq!(a, QualifiedName::new("dbo", "Article"));
+    assert_eq!(target_table_name(&a), "Article");
+    let b = parse_table_ref("[sales].[Order]").unwrap();
+    assert_eq!(target_table_name(&b), "sales__Order");
+    detect_collisions(&[a, b]).unwrap();
+    let err = detect_collisions(&[
+        QualifiedName::new("dbo", "sales__Order"),
+        QualifiedName::new("sales", "Order"),
+    ])
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains("sales__Order"), "{err}");
+}
+
+#[test]
+fn ado_net_parse_sql_auth_and_integrated() {
+    tiberius::Config::from_ado_string(
+        "Server=tcp:localhost,1433;User=sa;Password=Surreal_Sync1;Database=App;\
+         TrustServerCertificate=true;Encrypt=true",
+    )
+    .expect("SQL auth ADO.NET string");
+    tiberius::Config::from_ado_string(
+        "Server=tcp:localhost,1433;IntegratedSecurity=true;Database=App;\
+         TrustServerCertificate=true;Encrypt=true",
+    )
+    .expect("IntegratedSecurity ADO.NET string");
+}
+
+#[test]
+fn table_sync_kind_regular_vs_temporal() {
+    assert_ne!(TableSyncKind::Regular, TableSyncKind::Temporal);
+}
+
+#[test]
+fn regular_vs_temporal_ids() {
+    let pk = vec![Value::Int32(1)];
+    let regular = record_id(pk.clone());
+    assert_eq!(regular, Value::Int32(1));
+
+    let mut fields = HashMap::new();
+    fields.insert("title".into(), Value::Text("hello".into()));
+    let v1 = version_id(
+        pk.clone(),
+        "2020-01-01T00:00:00Z",
+        "9999-12-31T00:00:00Z",
+        &fields,
+        0,
+    );
+    let v2 = version_id(
+        pk.clone(),
+        "2020-01-01T00:00:00Z",
+        "9999-12-31T00:00:00Z",
+        &fields,
+        0,
+    );
+    assert_eq!(v1, v2);
+    let v3 = version_id(
+        pk,
+        "2020-01-01T00:00:00Z",
+        "9999-12-31T00:00:00Z",
+        &fields,
+        1,
+    );
+    assert_ne!(v1, v3);
+}
+
+#[test]
+fn mssql_lsn_order_and_cli() {
+    let a = MssqlLsn::from_bytes(vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 1]).unwrap();
+    let b = MssqlLsn::from_bytes(vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 2]).unwrap();
+    assert!(a < b);
+    let cp = MssqlCheckpoint::new(b.clone());
+    let decoded = MssqlCheckpoint::from_cli_string(&cp.to_cli_string()).unwrap();
+    assert_eq!(decoded.lsn, b);
+    let prefixed = MssqlCheckpoint::from_cli_string(&format!("mssql:{}", b.to_hex())).unwrap();
+    assert_eq!(prefixed.lsn, b);
+}

--- a/crates/mysql/src/from_trigger/full_sync.rs
+++ b/crates/mysql/src/from_trigger/full_sync.rs
@@ -127,6 +127,18 @@ pub async fn run_full_sync_with_transforms<S: SurrealSink, CS: CheckpointStore>(
     let schema_info = collect_schema_info(&mut conn, &database_name).await?;
     info!("Collected MySQL schema information");
 
+    if sync_opts.schemafull {
+        let db_schema = super::schema::collect_mysql_database_schema(&mut conn).await?;
+        surreal_sync_core::maybe_emit_schemafull(
+            surreal,
+            &db_schema,
+            &surreal_sync_core::SchemafullExtras::default(),
+            true,
+            sync_opts.dry_run,
+        )
+        .await?;
+    }
+
     // Get list of tables to migrate (excluding system tables)
     let tables = get_user_tables(&mut conn, &database_name).await?;
 

--- a/crates/mysql/src/from_trigger/mod.rs
+++ b/crates/mysql/src/from_trigger/mod.rs
@@ -31,6 +31,7 @@ pub use interleaved_snapshot::{
     run_interleaved_snapshot_full_sync_with_transforms,
     run_interleaved_snapshot_full_sync_with_transforms_and_overrides, MySqlWatermarkSource,
 };
+pub use schema::collect_mysql_database_schema;
 pub use source::{ChangeStream, IncrementalSource, MySQLChangeStream, MySQLIncrementalSource};
 
 pub use crate::ssl::{SslMode, SslOptions};
@@ -59,4 +60,6 @@ pub struct SyncOpts {
     pub batch_size: usize,
     /// Dry run mode - don't actually write data
     pub dry_run: bool,
+    /// Emit `DEFINE TABLE` / `FIELD` / `INDEX` before copying rows (opt-in).
+    pub schemafull: bool,
 }

--- a/crates/mysql/tests/from_trigger/transforms.rs
+++ b/crates/mysql/tests/from_trigger/transforms.rs
@@ -238,6 +238,7 @@ async fn composite_pk_entity_writes_surreal_array_record_ids() -> Result<()> {
     let sync_opts = surreal_sync_mysql::from_trigger::SyncOpts {
         batch_size: 100,
         dry_run: false,
+        schemafull: false,
     };
 
     surreal_sync_mysql::from_trigger::run_full_sync::<_, surreal_sync_core::NullStore>(
@@ -344,6 +345,7 @@ async fn flatten_id_toml_writes_surreal_text_record_ids() -> Result<()> {
     let sync_opts = surreal_sync_mysql::from_trigger::SyncOpts {
         batch_size: 100,
         dry_run: false,
+        schemafull: false,
     };
 
     let cfg = surreal_sync_runtime::parse_transforms_toml(

--- a/crates/postgresql/Dockerfile.postgres16.wal2json
+++ b/crates/postgresql/Dockerfile.postgres16.wal2json
@@ -8,7 +8,7 @@
 #   docker build -t postgres-16-wal2json:dev -f ./crates/postgresql/Dockerfile.postgres16.wal2json ./crates/postgresql
 #
 # To run a Postgres container with wal2json enabled, run:
-#   docker run --name postgres1 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=testdb -it --rm postgres-16-wal2json:dev postgres -c wal_level=logical -c max_wal_senders=10 -c max_replication_slots=10 -c track_commit_timestamp=on
+#   docker run --name postgres1 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=testdb -it --rm postgres-16-wal2json:dev postgres -c wal_level=logical -c max_wal_senders=10 -c max_replication_slots=10 -c track_commit_timestamp=on -c output_plugin_libraries=wal2json
 #
 # To connect to the database, use:
 #   docker run --network=container:postgres1 -it --rm -e POSTGRES_PASSWORD=postgres postgres:16 psql --user postgres -h localhost

--- a/crates/postgresql/src/from_pgoutput/full_sync.rs
+++ b/crates/postgresql/src/from_pgoutput/full_sync.rs
@@ -116,6 +116,15 @@ pub async fn run_full_sync_cancellable_with_transforms<S: SurrealSink, CS: Check
         collect_postgresql_database_schema(&client).await?
     };
 
+    surreal_sync_core::maybe_emit_schemafull(
+        surreal,
+        &db_schema,
+        &surreal_sync_core::SchemafullExtras::default(),
+        sync_opts.schemafull,
+        sync_opts.dry_run,
+    )
+    .await?;
+
     let tables = {
         let client = sql.lock().await;
         resolve_user_tables(&client, &schema, from_opts).await?

--- a/crates/postgresql/src/from_pgoutput/mod.rs
+++ b/crates/postgresql/src/from_pgoutput/mod.rs
@@ -66,4 +66,6 @@ impl Default for SourceOpts {
 pub struct SyncOpts {
     pub batch_size: usize,
     pub dry_run: bool,
+    /// Emit `DEFINE TABLE` / `FIELD` / `INDEX` before copying rows (opt-in).
+    pub schemafull: bool,
 }

--- a/crates/postgresql/src/from_trigger/full_sync.rs
+++ b/crates/postgresql/src/from_trigger/full_sync.rs
@@ -94,6 +94,18 @@ pub async fn run_full_sync_with_transforms<S: SurrealSink, CS: CheckpointStore>(
 
     let db_schema = crate::schema::collect_database_schema_with_fks(&client).await?;
 
+    surreal_sync_core::maybe_emit_schemafull(
+        surreal,
+        &db_schema,
+        &surreal_sync_core::SchemafullExtras {
+            relation_tables: from_opts.relation_tables.clone(),
+            ..Default::default()
+        },
+        sync_opts.schemafull,
+        sync_opts.dry_run,
+    )
+    .await?;
+
     let mut total_migrated = 0;
 
     for table_name in &tables {

--- a/crates/postgresql/src/from_wal2json/full_sync.rs
+++ b/crates/postgresql/src/from_wal2json/full_sync.rs
@@ -101,6 +101,18 @@ pub async fn run_full_sync_with_transforms<S: SurrealSink, CS: CheckpointStore>(
 
     let db_schema = crate::schema::collect_database_schema_with_fks(pg_client.pg_client()).await?;
 
+    surreal_sync_core::maybe_emit_schemafull(
+        surreal,
+        &db_schema,
+        &surreal_sync_core::SchemafullExtras {
+            relation_tables: from_opts.relation_tables.clone(),
+            ..Default::default()
+        },
+        sync_opts.schemafull,
+        sync_opts.dry_run,
+    )
+    .await?;
+
     let mut total_migrated = 0;
 
     for table_name in &tables {

--- a/crates/postgresql/src/full_sync.rs
+++ b/crates/postgresql/src/full_sync.rs
@@ -24,6 +24,8 @@ pub struct SyncOpts {
     pub batch_size: usize,
     /// Dry run mode - don't actually write data
     pub dry_run: bool,
+    /// Emit `DEFINE TABLE` / `FIELD` / `INDEX` before copying rows (opt-in).
+    pub schemafull: bool,
 }
 
 /// Convert all rows of a table with FK enrichment (no sink writes).

--- a/crates/postgresql/src/lib.rs
+++ b/crates/postgresql/src/lib.rs
@@ -11,7 +11,7 @@
 
 mod autoconf;
 mod client;
-pub mod fk_transform;
+pub use surreal_sync_core::fk_transform;
 mod full_sync;
 pub mod schema;
 pub mod testing;

--- a/crates/postgresql/src/testing/container.rs
+++ b/crates/postgresql/src/testing/container.rs
@@ -117,6 +117,10 @@ impl PostgresContainer {
                 "max_replication_slots=10",
                 "-c",
                 "track_commit_timestamp=on",
+                // PostgreSQL 16.15+ refuses unlisted logical decoding plugins
+                // unless they appear in output_plugin_libraries.
+                "-c",
+                "output_plugin_libraries=wal2json",
             ])
             .output()
             .context("Failed to start Docker container")?;

--- a/crates/postgresql/tests/from_pgoutput_suite/no_pk_offset.rs
+++ b/crates/postgresql/tests/from_pgoutput_suite/no_pk_offset.rs
@@ -145,6 +145,7 @@ async fn full_sync_streams_no_pk_table_via_offset_chunks() -> Result<()> {
     let sync_opts = SyncOpts {
         batch_size: 2,
         dry_run: false,
+        schemafull: false,
     };
     let pipeline = Pipeline::new();
     let apply_opts = ApplyOpts::identity();

--- a/crates/postgresql/tests/from_pgoutput_suite/transforms.rs
+++ b/crates/postgresql/tests/from_pgoutput_suite/transforms.rs
@@ -299,6 +299,7 @@ async fn external_mutate_worker_transforms_full_sync_rows() -> Result<()> {
     let sync_opts = SyncOpts {
         batch_size: 100,
         dry_run: false,
+        schemafull: false,
     };
 
     run_full_sync_cancellable_with_transforms(

--- a/crates/postgresql/tests/from_trigger_suite/no_pk_offset.rs
+++ b/crates/postgresql/tests/from_trigger_suite/no_pk_offset.rs
@@ -144,6 +144,7 @@ async fn full_sync_streams_no_pk_table_via_offset_chunks() -> Result<()> {
     let sync_opts = surreal_sync_postgresql::SyncOpts {
         batch_size: 2,
         dry_run: false,
+        schemafull: false,
     };
     let pipeline = Pipeline::new();
     let apply_opts = ApplyOpts::identity();

--- a/crates/postgresql/tests/from_wal2json_suite/no_pk_offset.rs
+++ b/crates/postgresql/tests/from_wal2json_suite/no_pk_offset.rs
@@ -154,6 +154,7 @@ async fn full_sync_streams_no_pk_table_via_offset_chunks() -> Result<()> {
     let sync_opts = surreal_sync_postgresql::SyncOpts {
         batch_size: 2,
         dry_run: false,
+        schemafull: false,
     };
     let pipeline = Pipeline::new();
     let apply_opts = ApplyOpts::identity();

--- a/crates/postgresql/tests/from_wal2json_suite/transforms.rs
+++ b/crates/postgresql/tests/from_wal2json_suite/transforms.rs
@@ -294,6 +294,7 @@ async fn external_mutate_worker_transforms_full_sync_rows() -> Result<()> {
     let sync_opts = surreal_sync_postgresql::SyncOpts {
         batch_size: 100,
         dry_run: false,
+        schemafull: false,
     };
 
     run_full_sync_with_transforms(

--- a/crates/surreal/src/ddl.rs
+++ b/crates/surreal/src/ddl.rs
@@ -1,0 +1,10 @@
+//! SurrealQL SCHEMAFULL helpers (`DEFINE TABLE` / `FIELD` / `INDEX`).
+//!
+//! Re-exported from `surreal-sync-core` so origin crates can emit DDL through
+//! [`SurrealSink::query`](surreal_sync_core::SurrealSink::query) without linking
+//! a SurrealDB SDK.
+
+pub use surreal_sync_core::ddl::{
+    emit_schemafull, ident, maybe_emit_schemafull, schemafull_statements, PeriodBound,
+    SchemaFieldExtra, SchemaIndex, SchemafullExtras, SurrealDdl,
+};

--- a/crates/surreal/src/lib.rs
+++ b/crates/surreal/src/lib.rs
@@ -39,3 +39,6 @@ pub use v3::{Surreal3Sink, Surreal3Store};
 
 #[cfg(feature = "v3")]
 pub use v3::client::Surreal3Client;
+
+#[cfg(any(feature = "v2", feature = "v3"))]
+pub mod ddl;

--- a/crates/surreal/src/v2/sink/sink_impl.rs
+++ b/crates/surreal/src/v2/sink/sink_impl.rs
@@ -74,6 +74,11 @@ impl SurrealSink for Surreal2Sink {
     async fn apply_relation_change(&self, change: &RelationChange) -> Result<()> {
         apply_relation_change(&self.client, change, self.zero_temporal).await
     }
+
+    async fn query(&self, sql: &str) -> Result<()> {
+        self.client.query(sql).await?;
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait]

--- a/crates/surreal/src/v2/types/forward.rs
+++ b/crates/surreal/src/v2/types/forward.rs
@@ -257,6 +257,9 @@ impl From<Value> for SurrealValue {
                 // Convert the ID to a SurrealDB ID type
                 let surreal_id = match id.as_ref() {
                     Value::Text(s) => surrealdb2::sql::Id::String(s.clone()),
+                    Value::VarChar { value, .. } | Value::Char { value, .. } => {
+                        surrealdb2::sql::Id::String(value.clone())
+                    }
                     Value::Int32(i) => surrealdb2::sql::Id::Number(*i as i64),
                     Value::Int64(i) => surrealdb2::sql::Id::Number(*i),
                     Value::Uuid(u) => surrealdb2::sql::Id::Uuid(surrealdb2::sql::Uuid::from(*u)),
@@ -351,13 +354,16 @@ fn try_parse_iso8601_duration(s: &str) -> Option<std::time::Duration> {
 pub fn create_thing(table: &str, id: &Value) -> anyhow::Result<Thing> {
     let id_part = match id {
         Value::Text(s) => surrealdb2::sql::Id::String(s.clone()),
+        Value::VarChar { value, .. } | Value::Char { value, .. } => {
+            surrealdb2::sql::Id::String(value.clone())
+        }
         Value::Int32(i) => surrealdb2::sql::Id::Number(*i as i64),
         Value::Int64(i) => surrealdb2::sql::Id::Number(*i),
         Value::Uuid(u) => surrealdb2::sql::Id::Uuid(surrealdb2::sql::Uuid::from(*u)),
         Value::Ulid(u) => surrealdb2::sql::Id::String(u.to_string()),
         other => anyhow::bail!(
             "Unsupported Value type for SurrealDB ID: {other:?}. \
-             Supported types: Text, Int32, Int64, Uuid, Ulid"
+             Supported types: Text, VarChar, Char, Int32, Int64, Uuid, Ulid"
         ),
     };
     Ok(Thing::from((table, id_part)))
@@ -735,6 +741,42 @@ mod tests {
         let id = Value::Text("user123".to_string());
         let thing = create_thing("users", &id).unwrap();
         assert_eq!(thing.tb, "users");
+    }
+
+    #[test]
+    fn test_create_thing_varchar() {
+        let id = Value::VarChar {
+            value: "user_001".to_string(),
+            length: 255,
+        };
+        let thing = create_thing("users", &id).unwrap();
+        assert_eq!(thing.tb, "users");
+        assert_eq!(
+            thing.id,
+            surrealdb2::sql::Id::String("user_001".to_string())
+        );
+    }
+
+    #[test]
+    fn test_thing_varchar_id_is_string() {
+        let value = Value::Thing {
+            table: "users".to_string(),
+            id: Box::new(Value::VarChar {
+                value: "user_001".to_string(),
+                length: 255,
+            }),
+        };
+        let surreal_val = SurrealValue::from(value);
+        match surreal_val.0 {
+            SqlValue::Thing(thing) => {
+                assert_eq!(thing.tb, "users");
+                assert_eq!(
+                    thing.id,
+                    surrealdb2::sql::Id::String("user_001".to_string())
+                );
+            }
+            other => panic!("expected Thing, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/surreal/src/v2/types/record.rs
+++ b/crates/surreal/src/v2/types/record.rs
@@ -54,6 +54,9 @@ fn value_to_surreal_id(value: &Value) -> Result<surrealdb2::sql::Id> {
         Value::Int32(i) => Ok(surrealdb2::sql::Id::Number(*i as i64)),
         Value::Int64(i) => Ok(surrealdb2::sql::Id::Number(*i)),
         Value::Text(s) => Ok(surrealdb2::sql::Id::String(s.clone())),
+        Value::VarChar { value, .. } | Value::Char { value, .. } => {
+            Ok(surrealdb2::sql::Id::String(value.clone()))
+        }
         Value::Uuid(u) => Ok(surrealdb2::sql::Id::Uuid(surrealdb2::sql::Uuid::from(*u))),
         other => anyhow::bail!("Cannot convert {other:?} to SurrealDB ID"),
     }

--- a/crates/surreal/src/v3/sink/sink_impl.rs
+++ b/crates/surreal/src/v3/sink/sink_impl.rs
@@ -74,6 +74,11 @@ impl SurrealSink for Surreal3Sink {
     async fn apply_relation_change(&self, change: &RelationChange) -> Result<()> {
         apply_relation_change(&self.client, change, self.zero_temporal).await
     }
+
+    async fn query(&self, sql: &str) -> Result<()> {
+        self.client.query(sql).await?;
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait]

--- a/crates/surreal/src/v3/types/forward.rs
+++ b/crates/surreal/src/v3/types/forward.rs
@@ -250,6 +250,9 @@ impl From<Value> for SurrealValue {
                 // Convert the ID to a SurrealDB ID type
                 let surreal_id = match id.as_ref() {
                     Value::Text(s) => RecordIdKey::String(s.clone()),
+                    Value::VarChar { value, .. } | Value::Char { value, .. } => {
+                        RecordIdKey::String(value.clone())
+                    }
                     Value::Int32(i) => RecordIdKey::Number(*i as i64),
                     Value::Int64(i) => RecordIdKey::Number(*i),
                     Value::Uuid(u) => RecordIdKey::Uuid(surrealdb3::types::Uuid::from(*u)),
@@ -344,13 +347,16 @@ fn try_parse_iso8601_duration(s: &str) -> Option<std::time::Duration> {
 pub fn create_thing(table: &str, id: &Value) -> anyhow::Result<RecordId> {
     let id_part = match id {
         Value::Text(s) => RecordIdKey::String(s.clone()),
+        Value::VarChar { value, .. } | Value::Char { value, .. } => {
+            RecordIdKey::String(value.clone())
+        }
         Value::Int32(i) => RecordIdKey::Number(*i as i64),
         Value::Int64(i) => RecordIdKey::Number(*i),
         Value::Uuid(u) => RecordIdKey::Uuid(surrealdb3::types::Uuid::from(*u)),
         Value::Ulid(u) => RecordIdKey::String(u.to_string()),
         other => anyhow::bail!(
             "Unsupported Value type for SurrealDB ID: {other:?}. \
-             Supported types: Text, Int32, Int64, Uuid, Ulid"
+             Supported types: Text, VarChar, Char, Int32, Int64, Uuid, Ulid"
         ),
     };
     Ok(RecordId::new(table, id_part))
@@ -724,6 +730,36 @@ mod tests {
         let id = Value::Text("user123".to_string());
         let record_id = create_thing("users", &id).unwrap();
         assert_eq!(record_id.table.as_str(), "users");
+    }
+
+    #[test]
+    fn test_create_thing_varchar() {
+        let id = Value::VarChar {
+            value: "user_001".to_string(),
+            length: 255,
+        };
+        let record_id = create_thing("users", &id).unwrap();
+        assert_eq!(record_id.table.as_str(), "users");
+        assert_eq!(record_id.key, RecordIdKey::String("user_001".to_string()));
+    }
+
+    #[test]
+    fn test_thing_varchar_id_is_string() {
+        let value = Value::Thing {
+            table: "users".to_string(),
+            id: Box::new(Value::VarChar {
+                value: "user_001".to_string(),
+                length: 255,
+            }),
+        };
+        let surreal_val = SurrealValue::from(value);
+        match surreal_val.0 {
+            DbValue::RecordId(record_id) => {
+                assert_eq!(record_id.table.as_str(), "users");
+                assert_eq!(record_id.key, RecordIdKey::String("user_001".to_string()));
+            }
+            other => panic!("expected RecordId, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/surreal/src/v3/types/record.rs
+++ b/crates/surreal/src/v3/types/record.rs
@@ -55,6 +55,9 @@ fn value_to_surreal_id(value: &Value) -> Result<RecordIdKey> {
         Value::Int32(i) => Ok(RecordIdKey::Number(*i as i64)),
         Value::Int64(i) => Ok(RecordIdKey::Number(*i)),
         Value::Text(s) => Ok(RecordIdKey::String(s.clone())),
+        Value::VarChar { value, .. } | Value::Char { value, .. } => {
+            Ok(RecordIdKey::String(value.clone()))
+        }
         Value::Uuid(u) => Ok(RecordIdKey::Uuid(surrealdb3::types::Uuid::from(*u))),
         other => anyhow::bail!("Cannot convert {other:?} to SurrealDB ID"),
     }

--- a/crates/sync-core/src/ddl.rs
+++ b/crates/sync-core/src/ddl.rs
@@ -179,7 +179,15 @@ pub fn schemafull_statements(schema: &DatabaseSchema, extras: &SchemafullExtras)
     let mut stmts = Vec::new();
 
     for table in &schema.tables {
-        let kind = classify_table(table, &extras.relation_tables);
+        let kind = match classify_table(table, &extras.relation_tables) {
+            TableKind::Relation { in_fk, out_fk }
+                if extras.scalar_fk_targets.contains(&in_fk.referenced_table)
+                    || extras.scalar_fk_targets.contains(&out_fk.referenced_table) =>
+            {
+                TableKind::Entity
+            }
+            other => other,
+        };
         match kind {
             TableKind::Entity => {
                 stmts.push(format!("DEFINE TABLE {} SCHEMAFULL;", ident(&table.name)));
@@ -492,6 +500,21 @@ mod tests {
         assert!(!stmts
             .iter()
             .any(|s| s.contains("UNIQUE") && s.contains("Id")));
+    }
+
+    #[test]
+    fn relation_demoted_when_endpoint_is_temporal() {
+        let schema = join_schema();
+        let extras = SchemafullExtras {
+            scalar_fk_targets: HashSet::from(["books".to_string()]),
+            relation_tables: vec!["book_tags".to_string()],
+            ..SchemafullExtras::default()
+        };
+        let stmts = schemafull_statements(&schema, &extras);
+        assert!(stmts.contains(&"DEFINE TABLE book_tags SCHEMAFULL;".to_string()));
+        assert!(!stmts.iter().any(|s| s.contains("TYPE RELATION")));
+        assert!(stmts.contains(&"DEFINE FIELD book_id ON book_tags TYPE int;".to_string()));
+        assert!(stmts.contains(&"DEFINE FIELD tag_id ON book_tags TYPE record<tags>;".to_string()));
     }
 
     #[test]

--- a/crates/sync-core/src/ddl.rs
+++ b/crates/sync-core/src/ddl.rs
@@ -1,0 +1,519 @@
+//! SurrealQL SCHEMAFULL helpers (`DEFINE TABLE` / `FIELD` / `INDEX`).
+//!
+//! Used when an operator passes `--schemafull`. Schemaless remains the default:
+//! these statements are not emitted unless that flag is set.
+
+use std::collections::HashSet;
+
+use crate::foreign_keys::{classify_table, TableKind};
+use crate::schema::{ColumnDefinition, DatabaseSchema, TableDefinition};
+use crate::sink::SurrealSink;
+use crate::types::{ToDdl, Type};
+
+/// A btree-style index to emit as `DEFINE INDEX` (only with `--schemafull`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaIndex {
+    /// SurrealDB table the index is defined on.
+    pub table: String,
+    /// Index name (`DEFINE INDEX <name>`).
+    pub name: String,
+    /// Field names, in order.
+    pub fields: Vec<String>,
+    /// Whether the index is `UNIQUE`.
+    pub unique: bool,
+}
+
+/// Extra `DEFINE FIELD` not present on the source table (for example `is_current`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaFieldExtra {
+    /// SurrealDB table.
+    pub table: String,
+    /// Field name.
+    pub name: String,
+    /// SurrealQL type, e.g. `bool` or `datetime`.
+    pub type_name: String,
+    /// When true, wrap as `option<type>`.
+    pub nullable: bool,
+}
+
+/// Period start/end pair used for `ASSERT $parent.<start> <= $value` on the end field.
+///
+/// The check lives on the end field so the start value is already present when
+/// SurrealDB evaluates the assertion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeriodBound {
+    /// SurrealDB table.
+    pub table: String,
+    /// Period-start field name (SQL Server `ValidFrom` or equivalent).
+    pub start: String,
+    /// Period-end field name (SQL Server `ValidTo` or equivalent).
+    pub end: String,
+}
+
+/// Optional extras merged into SCHEMAFULL statements (indexes, temporal fields).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SchemafullExtras {
+    /// Indexes to emit. Record `id` is never indexed (it is already the primary key).
+    pub indexes: Vec<SchemaIndex>,
+    /// Extra fields such as `is_current`.
+    pub extra_fields: Vec<SchemaFieldExtra>,
+    /// Tables whose incoming FKs must stay scalars (system-versioned targets).
+    pub scalar_fk_targets: HashSet<String>,
+    /// Tables forced to `TYPE RELATION` (same override list as `classify_table`).
+    pub relation_tables: Vec<String>,
+    /// Period columns that get `ASSERT $parent.<start> <= $value` on the end field.
+    pub period_bounds: Vec<PeriodBound>,
+}
+
+/// Maps [`Type`] to a SurrealQL field type for `DEFINE FIELD`.
+pub struct SurrealDdl;
+
+impl ToDdl for SurrealDdl {
+    fn to_ddl(&self, sync_type: &Type) -> String {
+        match sync_type {
+            Type::Bool => "bool".to_string(),
+            Type::Int8 { .. } | Type::Int16 | Type::Int32 | Type::Int64 => "int".to_string(),
+            Type::Float32 | Type::Float64 => "float".to_string(),
+            Type::Decimal { .. } => "decimal".to_string(),
+            Type::Char { .. } | Type::VarChar { .. } | Type::Text => "string".to_string(),
+            Type::Blob | Type::Bytes => "bytes".to_string(),
+            Type::Date | Type::LocalDateTime | Type::LocalDateTimeNano | Type::ZonedDateTime => {
+                "datetime".to_string()
+            }
+            Type::Time | Type::TimeTz => "string".to_string(),
+            Type::Uuid => "uuid".to_string(),
+            Type::Ulid => "ulid".to_string(),
+            Type::Json | Type::Jsonb | Type::Object => "object".to_string(),
+            Type::Array { element_type } => format!("array<{}>", self.to_ddl(element_type)),
+            Type::Set { .. } | Type::Enum { .. } => "string".to_string(),
+            Type::Geometry { .. } => "geometry".to_string(),
+            Type::Duration => "duration".to_string(),
+            Type::Thing => "record".to_string(),
+        }
+    }
+}
+
+/// Quote a SurrealQL ident when it is not a plain ASCII name.
+pub fn ident(name: &str) -> String {
+    if !name.is_empty()
+        && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        && name
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+    {
+        name.to_string()
+    } else {
+        format!("`{}`", name.replace('`', "``"))
+    }
+}
+
+fn option_wrap(inner: String, nullable: bool) -> String {
+    if nullable {
+        format!("option<{inner}>")
+    } else {
+        inner
+    }
+}
+
+fn field_type_for_column(
+    table: &TableDefinition,
+    col: &ColumnDefinition,
+    extras: &SchemafullExtras,
+    ddl: &SurrealDdl,
+) -> String {
+    for fk in &table.foreign_keys {
+        if fk.columns.len() == 1 && fk.columns[0] == col.name {
+            if extras.scalar_fk_targets.contains(&fk.referenced_table) {
+                return option_wrap(ddl.to_ddl(&col.column_type), col.nullable);
+            }
+            return option_wrap(
+                format!("record<{}>", ident(&fk.referenced_table)),
+                col.nullable,
+            );
+        }
+    }
+    option_wrap(ddl.to_ddl(&col.column_type), col.nullable)
+}
+
+fn period_assert(table: &str, field: &str, extras: &SchemafullExtras) -> Option<String> {
+    extras.period_bounds.iter().find_map(|bound| {
+        if bound.table == table && bound.end == field {
+            Some(format!("$parent.{} <= $value", ident(&bound.start)))
+        } else {
+            None
+        }
+    })
+}
+
+fn define_field(table: &str, name: &str, type_ddl: &str, assert: Option<&str>) -> String {
+    let mut sql = format!(
+        "DEFINE FIELD {} ON {} TYPE {};",
+        ident(name),
+        ident(table),
+        type_ddl
+    );
+    if let Some(assert) = assert {
+        sql = format!(
+            "DEFINE FIELD {} ON {} TYPE {} ASSERT {};",
+            ident(name),
+            ident(table),
+            type_ddl,
+            assert
+        );
+    }
+    sql
+}
+
+fn all_columns(table: &TableDefinition) -> Vec<&ColumnDefinition> {
+    let mut cols = vec![&table.primary_key];
+    cols.extend(table.columns.iter());
+    cols
+}
+
+/// Build `DEFINE TABLE` / `DEFINE FIELD` / `DEFINE INDEX` statements.
+///
+/// Does not write anything. Call [`emit_schemafull`] to run them on a sink.
+pub fn schemafull_statements(schema: &DatabaseSchema, extras: &SchemafullExtras) -> Vec<String> {
+    let ddl = SurrealDdl;
+    let mut stmts = Vec::new();
+
+    for table in &schema.tables {
+        let kind = classify_table(table, &extras.relation_tables);
+        match kind {
+            TableKind::Entity => {
+                stmts.push(format!("DEFINE TABLE {} SCHEMAFULL;", ident(&table.name)));
+                for col in all_columns(table) {
+                    let type_ddl = field_type_for_column(table, col, extras, &ddl);
+                    let assert = period_assert(&table.name, &col.name, extras);
+                    stmts.push(define_field(
+                        &table.name,
+                        &col.name,
+                        &type_ddl,
+                        assert.as_deref(),
+                    ));
+                }
+            }
+            TableKind::Relation { in_fk, out_fk } => {
+                stmts.push(format!(
+                    "DEFINE TABLE {} TYPE RELATION IN {} OUT {} SCHEMAFULL;",
+                    ident(&table.name),
+                    ident(&in_fk.referenced_table),
+                    ident(&out_fk.referenced_table)
+                ));
+                let skip: HashSet<&str> = in_fk
+                    .columns
+                    .iter()
+                    .chain(out_fk.columns.iter())
+                    .map(|s| s.as_str())
+                    .collect();
+                for col in all_columns(table) {
+                    if skip.contains(col.name.as_str()) {
+                        continue;
+                    }
+                    let type_ddl = option_wrap(ddl.to_ddl(&col.column_type), col.nullable);
+                    stmts.push(define_field(&table.name, &col.name, &type_ddl, None));
+                }
+            }
+        }
+
+        for extra in extras.extra_fields.iter().filter(|f| f.table == table.name) {
+            if all_columns(table).iter().any(|c| c.name == extra.name) {
+                continue;
+            }
+            let type_ddl = option_wrap(extra.type_name.clone(), extra.nullable);
+            let assert = period_assert(&table.name, &extra.name, extras);
+            stmts.push(define_field(
+                &table.name,
+                &extra.name,
+                &type_ddl,
+                assert.as_deref(),
+            ));
+        }
+    }
+
+    for index in &extras.indexes {
+        if index.fields.len() == 1 && index.fields[0] == "id" {
+            continue;
+        }
+        let fields = index
+            .fields
+            .iter()
+            .map(|f| ident(f))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let unique = if index.unique { " UNIQUE" } else { "" };
+        stmts.push(format!(
+            "DEFINE INDEX {} ON {} FIELDS {}{};",
+            ident(&index.name),
+            ident(&index.table),
+            fields,
+            unique
+        ));
+    }
+
+    stmts
+}
+
+/// Log and run SCHEMAFULL statements on `sink`.
+pub async fn emit_schemafull<S: SurrealSink>(
+    sink: &S,
+    schema: &DatabaseSchema,
+    extras: &SchemafullExtras,
+) -> anyhow::Result<()> {
+    for stmt in schemafull_statements(schema, extras) {
+        tracing::info!("{stmt}");
+        sink.query(&stmt).await?;
+    }
+    Ok(())
+}
+
+/// Print (and optionally run) SCHEMAFULL statements when `--schemafull` is set.
+pub async fn maybe_emit_schemafull<S: SurrealSink>(
+    sink: &S,
+    schema: &DatabaseSchema,
+    extras: &SchemafullExtras,
+    schemafull: bool,
+    dry_run: bool,
+) -> anyhow::Result<()> {
+    if !schemafull {
+        return Ok(());
+    }
+    if dry_run {
+        for stmt in schemafull_statements(schema, extras) {
+            tracing::info!("{stmt}");
+        }
+        return Ok(());
+    }
+    emit_schemafull(sink, schema, extras).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ColumnDefinition, ForeignKeyDefinition, TableDefinition, Type};
+
+    fn users_books() -> DatabaseSchema {
+        let users = TableDefinition::new(
+            "users",
+            ColumnDefinition::new("id", Type::Int64),
+            vec![
+                ColumnDefinition::new("name", Type::Text),
+                ColumnDefinition::nullable("email", Type::Text),
+            ],
+        );
+        let mut books = TableDefinition::new(
+            "books",
+            ColumnDefinition::new("id", Type::Int64),
+            vec![
+                ColumnDefinition::new("title", Type::Text),
+                ColumnDefinition::new("author_id", Type::Int32),
+            ],
+        );
+        books.foreign_keys = vec![ForeignKeyDefinition {
+            constraint_name: "fk_author".to_string(),
+            columns: vec!["author_id".to_string()],
+            referenced_table: "users".to_string(),
+            referenced_columns: vec!["id".to_string()],
+        }];
+        DatabaseSchema::new(vec![users, books])
+    }
+
+    fn join_schema() -> DatabaseSchema {
+        let mut tags = TableDefinition::new(
+            "book_tags",
+            ColumnDefinition::new("book_id", Type::Int32),
+            vec![
+                ColumnDefinition::new("tag_id", Type::Int32),
+                ColumnDefinition::nullable("created_at", Type::Text),
+            ],
+        );
+        tags.composite_primary_key = Some(vec!["book_id".to_string(), "tag_id".to_string()]);
+        tags.foreign_keys = vec![
+            ForeignKeyDefinition {
+                constraint_name: "fk_book".to_string(),
+                columns: vec!["book_id".to_string()],
+                referenced_table: "books".to_string(),
+                referenced_columns: vec!["id".to_string()],
+            },
+            ForeignKeyDefinition {
+                constraint_name: "fk_tag".to_string(),
+                columns: vec!["tag_id".to_string()],
+                referenced_table: "tags".to_string(),
+                referenced_columns: vec!["id".to_string()],
+            },
+        ];
+        DatabaseSchema::new(vec![tags])
+    }
+
+    fn article_temporal() -> DatabaseSchema {
+        let article = TableDefinition::new(
+            "Article",
+            ColumnDefinition::new("Id", Type::Int32),
+            vec![
+                ColumnDefinition::new("Title", Type::Text),
+                ColumnDefinition::new("ValidFrom", Type::ZonedDateTime),
+                ColumnDefinition::new("ValidTo", Type::ZonedDateTime),
+            ],
+        );
+        DatabaseSchema::new(vec![article])
+    }
+
+    #[test]
+    fn option_string_and_record_user() {
+        let stmts = schemafull_statements(&users_books(), &SchemafullExtras::default());
+        assert!(stmts.contains(&"DEFINE TABLE users SCHEMAFULL;".to_string()));
+        assert!(stmts.contains(&"DEFINE FIELD name ON users TYPE string;".to_string()));
+        assert!(stmts.contains(&"DEFINE FIELD email ON users TYPE option<string>;".to_string()));
+        assert!(stmts.contains(&"DEFINE FIELD author_id ON books TYPE record<users>;".to_string()));
+    }
+
+    #[test]
+    fn relation_table() {
+        let stmts = schemafull_statements(&join_schema(), &SchemafullExtras::default());
+        assert!(stmts.contains(
+            &"DEFINE TABLE book_tags TYPE RELATION IN books OUT tags SCHEMAFULL;".to_string()
+        ));
+        assert!(stmts
+            .contains(&"DEFINE FIELD created_at ON book_tags TYPE option<string>;".to_string()));
+        assert!(!stmts.iter().any(|s| s.contains("book_id")));
+        assert!(!stmts
+            .iter()
+            .any(|s| s.contains("tag_id") && s.contains("DEFINE FIELD")));
+    }
+
+    #[test]
+    fn period_assert() {
+        let extras = SchemafullExtras {
+            period_bounds: vec![PeriodBound {
+                table: "Article".to_string(),
+                start: "ValidFrom".to_string(),
+                end: "ValidTo".to_string(),
+            }],
+            extra_fields: vec![SchemaFieldExtra {
+                table: "Article".to_string(),
+                name: "is_current".to_string(),
+                type_name: "bool".to_string(),
+                nullable: false,
+            }],
+            ..SchemafullExtras::default()
+        };
+        let stmts = schemafull_statements(&article_temporal(), &extras);
+        assert!(stmts.contains(
+            &"DEFINE FIELD ValidTo ON Article TYPE datetime ASSERT $parent.ValidFrom <= $value;"
+                .to_string()
+        ));
+        assert!(stmts.contains(&"DEFINE FIELD is_current ON Article TYPE bool;".to_string()));
+    }
+
+    #[test]
+    fn unique_vs_non_unique_index() {
+        let extras = SchemafullExtras {
+            indexes: vec![
+                SchemaIndex {
+                    table: "users".to_string(),
+                    name: "users_email_unique".to_string(),
+                    fields: vec!["email".to_string()],
+                    unique: true,
+                },
+                SchemaIndex {
+                    table: "users".to_string(),
+                    name: "users_name".to_string(),
+                    fields: vec!["name".to_string()],
+                    unique: false,
+                },
+                SchemaIndex {
+                    table: "users".to_string(),
+                    name: "users_id".to_string(),
+                    fields: vec!["id".to_string()],
+                    unique: true,
+                },
+            ],
+            ..SchemafullExtras::default()
+        };
+        let stmts = schemafull_statements(&users_books(), &extras);
+        assert!(stmts.contains(
+            &"DEFINE INDEX users_email_unique ON users FIELDS email UNIQUE;".to_string()
+        ));
+        assert!(stmts.contains(&"DEFINE INDEX users_name ON users FIELDS name;".to_string()));
+        assert!(!stmts.iter().any(|s| s.contains("users_id")));
+    }
+
+    #[test]
+    fn temporal_cookbook_indexes() {
+        let extras = SchemafullExtras {
+            extra_fields: vec![SchemaFieldExtra {
+                table: "Article".to_string(),
+                name: "is_current".to_string(),
+                type_name: "bool".to_string(),
+                nullable: false,
+            }],
+            indexes: vec![
+                SchemaIndex {
+                    table: "Article".to_string(),
+                    name: "Article_is_current".to_string(),
+                    fields: vec!["is_current".to_string()],
+                    unique: false,
+                },
+                SchemaIndex {
+                    table: "Article".to_string(),
+                    name: "Article_Id".to_string(),
+                    fields: vec!["Id".to_string()],
+                    unique: false,
+                },
+                SchemaIndex {
+                    table: "Article".to_string(),
+                    name: "Article_Id_is_current".to_string(),
+                    fields: vec!["Id".to_string(), "is_current".to_string()],
+                    unique: false,
+                },
+                SchemaIndex {
+                    table: "Article".to_string(),
+                    name: "Article_ValidFrom_ValidTo".to_string(),
+                    fields: vec!["ValidFrom".to_string(), "ValidTo".to_string()],
+                    unique: false,
+                },
+            ],
+            ..SchemafullExtras::default()
+        };
+        let stmts = schemafull_statements(&article_temporal(), &extras);
+        assert!(stmts
+            .iter()
+            .any(|s| s.contains("FIELDS is_current;")
+                && s.contains("DEFINE INDEX Article_is_current")));
+        assert!(stmts.contains(&"DEFINE INDEX Article_Id ON Article FIELDS Id;".to_string()));
+        assert!(stmts.contains(
+            &"DEFINE INDEX Article_Id_is_current ON Article FIELDS Id, is_current;".to_string()
+        ));
+        assert!(stmts.contains(
+            &"DEFINE INDEX Article_ValidFrom_ValidTo ON Article FIELDS ValidFrom, ValidTo;"
+                .to_string()
+        ));
+        assert!(!stmts
+            .iter()
+            .any(|s| s.contains("UNIQUE") && s.contains("Id")));
+    }
+
+    #[test]
+    fn scalar_fk_to_temporal_target() {
+        let mut orders = TableDefinition::new(
+            "orders",
+            ColumnDefinition::new("id", Type::Int64),
+            vec![ColumnDefinition::new("article_id", Type::Int32)],
+        );
+        orders.foreign_keys = vec![ForeignKeyDefinition {
+            constraint_name: "fk_article".to_string(),
+            columns: vec!["article_id".to_string()],
+            referenced_table: "Article".to_string(),
+            referenced_columns: vec!["Id".to_string()],
+        }];
+        let schema = DatabaseSchema::new(vec![orders]);
+        let extras = SchemafullExtras {
+            scalar_fk_targets: HashSet::from(["Article".to_string()]),
+            ..SchemafullExtras::default()
+        };
+        let stmts = schemafull_statements(&schema, &extras);
+        assert!(stmts.contains(&"DEFINE FIELD article_id ON orders TYPE int;".to_string()));
+        assert!(!stmts.iter().any(|s| s.contains("record<Article>")));
+    }
+}

--- a/crates/sync-core/src/fk_transform.rs
+++ b/crates/sync-core/src/fk_transform.rs
@@ -4,7 +4,8 @@
 //! and builds `Relation` instances from join-table rows.
 
 use std::collections::HashMap;
-use surreal_sync_core::{ForeignKeyDefinition, Relation, TableDefinition, ThingRef, Value};
+
+use crate::{ForeignKeyDefinition, Relation, TableDefinition, ThingRef, Value};
 
 /// Transform FK column values in a field map to record links.
 ///
@@ -107,7 +108,7 @@ fn inject_missing_fk_from_composite_id(
 /// Flatten a composite (Array) ID into a string ID.
 /// Simple IDs are returned as-is. Array IDs are joined with `:` separators.
 fn flatten_composite_id(id: Value) -> Value {
-    surreal_sync_core::flatten_composite_id(id, ":")
+    crate::flatten_composite_id(id, ":")
 }
 
 /// Extract and remove the FK value from the fields map.
@@ -124,7 +125,7 @@ fn extract_fk_value(fields: &mut HashMap<String, Value>, fk: &ForeignKeyDefiniti
             .collect();
         Value::Array {
             elements: vals,
-            element_type: Box::new(surreal_sync_core::Type::Text),
+            element_type: Box::new(crate::Type::Text),
         }
     }
 }
@@ -132,7 +133,7 @@ fn extract_fk_value(fields: &mut HashMap<String, Value>, fk: &ForeignKeyDefiniti
 #[cfg(test)]
 mod tests {
     use super::*;
-    use surreal_sync_core::{ColumnDefinition, Type};
+    use crate::{ColumnDefinition, Type};
 
     fn make_table_with_fks(fks: Vec<ForeignKeyDefinition>) -> TableDefinition {
         let mut td = TableDefinition::new(

--- a/crates/sync-core/src/lib.rs
+++ b/crates/sync-core/src/lib.rs
@@ -45,6 +45,8 @@
 //! ```
 
 pub mod checkpoint;
+pub mod ddl;
+pub mod fk_transform;
 pub mod foreign_keys;
 pub mod id_columns;
 pub mod relation_change;
@@ -67,7 +69,14 @@ pub use checkpoint::{
 pub use transform::{InPlaceTransform, Passthrough};
 
 // Foreign key types
+pub use fk_transform::{build_relation_from_change, build_relation_from_row, transform_fk_values};
 pub use foreign_keys::{classify_table, ForeignKeyDefinition, TableKind};
+
+// SCHEMAFULL SurrealQL helpers
+pub use ddl::{
+    emit_schemafull, ident, maybe_emit_schemafull, schemafull_statements, PeriodBound,
+    SchemaFieldExtra, SchemaIndex, SchemafullExtras, SurrealDdl,
+};
 
 // ID / primary-key column helpers
 pub use id_columns::{

--- a/crates/sync-core/src/sink/traits.rs
+++ b/crates/sync-core/src/sink/traits.rs
@@ -56,4 +56,13 @@ pub trait SurrealSink: Send + Sync {
     /// - Create/Update: RELATE the edge
     /// - Delete: DELETE the relation
     async fn apply_relation_change(&self, change: &RelationChange) -> Result<()>;
+
+    /// Run a SurrealQL statement (for example `DEFINE TABLE` / `DEFINE FIELD` /
+    /// `DEFINE INDEX` when `--schemafull` is set).
+    ///
+    /// Capture sinks and dry-run doubles may no-op.
+    async fn query(&self, sql: &str) -> Result<()> {
+        let _ = sql;
+        Ok(())
+    }
 }

--- a/docs/mssql.md
+++ b/docs/mssql.md
@@ -1,0 +1,127 @@
+# SQL Server Source
+
+`surreal-sync from mssql sync` copies SQL Server tables into SurrealDB using **native SQL Server CDC** (change tables filled by the Agent capture job). There is no `full` / `incremental` split: one `sync` command snapshots, then stays on the CDC stream until you stop it.
+
+Optional transforms: pass `--transforms-config` with a TOML file. Omit the flag to leave rows unchanged. Details: [How sync works](sync-pipeline.md).
+
+## The happy path
+
+```bash
+surreal-sync from mssql sync \
+  --connection-string 'Server=tcp:localhost,1433;User=sa;Password=...;Database=App;TrustServerCertificate=true;Encrypt=true' \
+  --tables dbo.Article,sales.Order \
+  --surreal-endpoint ws://localhost:8000 \
+  --surreal-username root \
+  --surreal-password root \
+  --to-namespace prod \
+  --to-database app \
+  --checkpoints-surreal-table sync_checkpoints
+```
+
+Default `--strategy interleaved-snapshot` copies each table in primary-key order **while CDC is running**, using a signal table so live writes and the copy cannot disagree. After the snapshot it keeps applying CDC until `SIGINT`/`SIGTERM` or `--timeout`.
+
+Restart the same command with the same checkpoint store to resume.
+
+## Prerequisites
+
+1. **SQL Server 2016+** (Developer, Standard, or Enterprise — **not Express**; Express has no CDC).
+2. **CDC enabled on the database:**
+
+```sql
+EXEC sys.sp_cdc_enable_db;
+```
+
+surreal-sync enables CDC on each selected table when the login can (`db_owner`). If it cannot, the error includes the `sp_cdc_enable_table` statement a DBA must run.
+
+3. **SQL Server Agent running.** CDC capture jobs do not populate change tables without it. Linux containers:
+
+```bash
+docker run --name mssql --platform linux/amd64 \
+  -e ACCEPT_EULA=Y \
+  -e MSSQL_SA_PASSWORD='Surreal_Sync1' \
+  -e MSSQL_PID=Developer \
+  -e MSSQL_AGENT_ENABLED=true \
+  -p 1433:1433 \
+  -d mcr.microsoft.com/mssql/server:2022-CU26-ubuntu-22.04
+```
+
+`ACCEPT_EULA=Y` is required by Microsoft’s image ([SQL Server EULA](https://go.microsoft.com/fwlink/?linkid=2143497)). Developer edition is free for development and test; it is not a production license.
+
+4. Every synced table needs a **primary key**.
+5. Windows Integrated Auth (`IntegratedSecurity=true`) works only on Windows. Linux and CI use SQL authentication.
+
+surreal-sync does **not** use Change Tracking or trigger/audit tables.
+
+## Snapshot modes
+
+| `--snapshot-mode` | Behavior |
+|-------------------|----------|
+| `initial` (default) | Snapshot, then continuous CDC. |
+| `never` | CDC only from the checkpoint store. |
+| `only` | Snapshot only, emit checkpoint, exit. |
+
+## Strategies
+
+| `--strategy` | When to use |
+|--------------|-------------|
+| `interleaved-snapshot` (default) | Normal path. Needs CDC, Agent, and writes to `surreal_sync_signal` (created and CDC-enabled by surreal-sync). |
+| `sequential-snapshot` | One `SET TRANSACTION ISOLATION LEVEL SNAPSHOT` read of each table, then CDC from that LSN. **Writers are not locked.** Needs `ALLOW_SNAPSHOT_ISOLATION`. Long transactions version rows in **tempdb** — size tempdb for the dump. |
+
+If snapshot isolation is off:
+
+```sql
+ALTER DATABASE [YourDb] SET ALLOW_SNAPSHOT_ISOLATION ON
+```
+
+## What gets copied
+
+- `dbo.Article` becomes Surreal table `Article`. Other schemas become `sales__Order`.
+- Composite primary keys become array record ids.
+- Foreign keys between ordinary tables become `record<Target>` links. Join tables listed in `--relation-tables` become Surreal relations.
+- Default is **schemaless**. Pass `--schemafull` to emit `DEFINE TABLE` / `FIELD` / `INDEX` before copying.
+
+### `--schemafull` indexes
+
+Ordinary tables: unique and non-unique btree indexes whose columns we sync are copied (`UNIQUE` when the source index is unique). Filtered indexes, INCLUDE columns, XML/spatial/full-text/columnstore, and indexes on skipped columns are omitted with a warning.
+
+Temporal tables: source UNIQUE/PK indexes are **not** copied onto the unified table (history reuses the business key). surreal-sync emits query indexes for `is_current`, the business key, business key + `is_current` (not unique), and the period start/end columns. Uniqueness of “one current row per key” stays SQL Server’s job — SurrealDB has no partial unique index.
+
+### Types we will not copy
+
+`sql_variant`, `hierarchyid`, `geography` / `geometry`, CLR user-defined types, `cursor` / `table`, and `rowversion` / `timestamp` (binary, not datetime) fail before export.
+
+## Temporal tables
+
+System-versioned tables are detected from the catalog. There is no `--temporal` flag. Sync the **current** table (`dbo.Article`); selecting the history table alone is an error.
+
+Every version lands in **one** Surreal table, plus `is_current`. The record id is the version (business key + period + content hash), not `Article:1`. Foreign keys **to** a temporal table stay scalars so they do not point at a single version.
+
+Period columns stay visible (`ValidFrom` / `ValidTo`, or whatever SQL Server named them), including when they are `HIDDEN` in SQL Server.
+
+| SQL Server | SurrealQL after sync |
+|---|---|
+| `SELECT * FROM dbo.Article` (current only) | `SELECT * FROM Article WHERE is_current` |
+| `… WHERE Id = 1` | `SELECT * FROM Article WHERE Id = 1 AND is_current` |
+| `FOR SYSTEM_TIME ALL` | `SELECT * FROM Article` |
+| `FOR SYSTEM_TIME AS OF $t` | `SELECT * FROM Article WHERE ValidFrom <= $t AND ValidTo > $t` |
+| `FOR SYSTEM_TIME FROM $t1 TO $t2` | `SELECT * FROM Article WHERE ValidFrom < $t2 AND ValidTo > $t1` |
+| `FOR SYSTEM_TIME CONTAINED IN ($t1, $t2)` | `SELECT * FROM Article WHERE ValidFrom >= $t1 AND ValidTo <= $t2` |
+| `SELECT * FROM dbo.ArticleHistory` | `SELECT * FROM Article WHERE is_current = false` |
+| `JOIN … ON Order.ArticleId = Article.Id` (current) | `WHERE Order.ArticleId = Article.Id AND Article.is_current` |
+
+SurrealDB cannot time-travel a graph edge the way `FOR SYSTEM_TIME AS OF` time-travels a join. Filter versions in `WHERE`.
+
+Live CDC is enabled on the current table. An UPDATE writes a new current version and clears `is_current` on the previous one.
+
+## Embed
+
+```rust
+use surreal_sync_mssql::{run, FlattenId, InPlaceTransform, Value};
+use surreal_sync_surreal::Surreal3Sink;
+
+run::<Surreal3Sink>([
+    Box::new(FlattenId::default()) as Box<dyn InPlaceTransform>,
+]).await
+```
+
+Argv is `sync` plus the same flags as the stock CLI (no `from mssql` prefix). See `examples/from-mssql`.

--- a/docs/source-ports.md
+++ b/docs/source-ports.md
@@ -40,6 +40,7 @@ spawn coverage is in `surreal-sync-runtime` pipeline config tests).
 | csv | Long-lived SourceDriver stream | Yes (shared loader + CLI e2e) | N/A | File read polls into window (no per-batch runtime restart); **one runtime per file** (no cross-file read/transform/write overlap) |
 | jsonl | Long-lived SourceDriver stream | Yes (shared loader + CLI e2e) | N/A | `conversion_rules` before Pipeline; **one runtime per file** (same as CSV) |
 | snowflake | RowChunkDriver full (per table) | Yes (shared loader) | N/A | Ingestion-only SQL REST snapshot; `--id-columns` → Array IDs (breaking vs former colon Text; restore with `flatten_id`); streams one result partition at a time into `batch_size` apply chunks; no durable source cursor / checkpoint resume |
+| mssql | WatermarkSource + SourceDriver CDC tail | Yes (shared loader + CLI e2e) | Yes | Native SQL Server CDC LSN; `--schemafull` opt-in; temporal tables auto (one Surreal table + `is_current`) |
 
 ## Porting checklist
 

--- a/docs/sync-pipeline.md
+++ b/docs/sync-pipeline.md
@@ -95,6 +95,7 @@ For every incremental batch on sources with a real post-sink durability hook, su
 | Source family | What `advance_watermark` after sink means |
 |---------------|--------------------------------|
 | MySQL/MariaDB binlog, PostgreSQL pgoutput | Store / binlog client commit + sink-safe CatchUpProgress |
+| SQL Server CDC | Last-sunk change-table LSN (`commit_reconciled` / tail `advance_watermark`) |
 | PostgreSQL wal2json | Slot `advance` only after emitted events are sunk (peeks may continue under window capacity via non-consuming peek + prefix skip) |
 | Kafka | Consumer-group `commit_batch` of **all** messages in the sunk batch (not only the last position) |
 | CSV / JSONL | No source cursor (file import) |
@@ -223,6 +224,7 @@ Every sync/import path below loads the same TOML via the shared CLI helper and r
 | `from csv` | Long-lived SourceDriver streams file reads into the window |
 | `from jsonl` | Long-lived SourceDriver streams line reads into the window |
 | `from snowflake` | Full snapshot via `RowChunkDriver` (ingestion-only; no source cursor) |
+| `from mssql sync` | Watermark snapshot + SQL Server CDC stream |
 
 ### CLI quick start
 
@@ -481,20 +483,22 @@ Operations (checkpoints, resume, ad-hoc `snapshot` where the source supports it)
 - [MySQL/MariaDB Binlog Source](mysql-binlog.md) — snapshot, stream, checkpoints, resume
 - [PostgreSQL pgoutput](postgresql-pgoutput-source.md), [wal2json](postgresql-wal2json-source.md), [trigger](postgresql.md)
 - [MySQL trigger](mysql.md) / [MariaDB trigger](mariadb.md), [MongoDB](mongodb.md), [Neo4j](neo4j.md), [Kafka](kafka.md), [CSV](csv.md), [JSONL](jsonl.md)
+- [Snowflake](snowflake.md) — one-shot SQL REST snapshot
+- [SQL Server](mssql.md) — watermark snapshot + native CDC
 - [Source ports](source-ports.md) — implementer checklist for wiring sources through `surreal-sync-runtime`
 - [Design overview](design.md) — full vs incremental sync model
 - [GitHub issue #118](https://github.com/surrealdb/surreal-sync/issues/118) — transform pipeline tracking
 
 ### Advanced: embedding (from-* crates)
 
-Depend on a source crate such as `surreal-sync-mysql`, `surreal-sync-snowflake`, `surreal-sync-json`, or `surreal-sync-kafka`, plus `surreal-sync-surreal` (feature `v2` or `v3`). For ongoing sync (CDC), also configure checkpoints. Do not depend on the `surreal-sync` CLI package as a library.
-See the **Examples** below (`examples/from-mysql-binlog`, `examples/from-snowflake`, `examples/from-jsonl`, `examples/from-kafka`).
+Depend on a source crate such as `surreal-sync-mysql`, `surreal-sync-mssql`, `surreal-sync-snowflake`, `surreal-sync-json`, or `surreal-sync-kafka`, plus `surreal-sync-surreal` (feature `v2` or `v3`). For ongoing sync (CDC), also configure checkpoints. Do not depend on the `surreal-sync` CLI package as a library.
+See the **Examples** below (`examples/from-mysql-binlog`, `examples/from-mssql`, `examples/from-snowflake`, `examples/from-jsonl`, `examples/from-kafka`).
 
 **When to use in-process vs `command` workers**
 
 | Approach | Use when |
 |----------|----------|
-| `InPlaceTransform` via `run::<Surreal3Sink>([…])` (mysql-binlog / snowflake / jsonl / kafka) | Mutate-only / same-length stages in Rust (redact, rename, flatten IDs, FK → record links) |
+| `InPlaceTransform` via `run::<Surreal3Sink>([…])` (mysql-binlog / mssql / snowflake / jsonl / kafka) | Mutate-only / same-length stages in Rust (redact, rename, flatten IDs, FK → record links) |
 | TOML `type = "command"` | External language workers, heavy enrichment, or filter/fan-out that needs a custom `BatchTransformer` |
 
 Filter-out or fan-out of events is out of scope for `InPlaceTransform` — use a
@@ -523,7 +527,19 @@ cargo run -p surreal-sync-example-from-mysql-binlog -- sync \
   --checkpoints-surreal-table sync_checkpoints
 ```
 
-`run::<Surreal3Sink>([…])` connects SurrealDB and, when you pass `--checkpoints-surreal-table` or `--checkpoint-dir`, picks where to store resume state. You do not wire that up yourself. Those checkpoint flags are for **MySQL binlog CDC** only.
+`run::<Surreal3Sink>([…])` connects SurrealDB and, when you pass `--checkpoints-surreal-table` or `--checkpoint-dir`, picks where to store resume state. You do not wire that up yourself. Those checkpoint flags apply to **CDC sources** (MySQL/MariaDB binlog, SQL Server, PostgreSQL WAL, and similar).
+
+SQL Server — [`examples/from-mssql`](../examples/from-mssql) (`surreal-sync-example-from-mssql`):
+
+```bash
+cargo run -p surreal-sync-example-from-mssql -- sync \
+  --connection-string 'Server=tcp:localhost,1433;User=sa;Password=...;Database=App;TrustServerCertificate=true;Encrypt=true' \
+  --tables dbo.Article \
+  --to-namespace prod --to-database app \
+  --checkpoints-surreal-table sync_checkpoints
+```
+
+The resume checkpoint is a SQL Server CDC LSN (same idea as a MySQL binlog position).
 
 Snowflake — [`examples/from-snowflake`](../examples/from-snowflake) (`surreal-sync-example-from-snowflake`):
 

--- a/examples/from-mssql/Cargo.toml
+++ b/examples/from-mssql/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "surreal-sync-example-from-mssql"
+version = "0.6.1"
+edition = "2021"
+publish = false
+description = "Embedder example: SQL Server CDC with in-process transforms"
+
+[[bin]]
+name = "surreal-sync-example-from-mssql"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1.0"
+tokio = { version = "1.49", features = ["full"] }
+surreal-sync-mssql = { path = "../../crates/mssql", features = ["from_mssql"] }
+surreal-sync-surreal = { path = "../../crates/surreal" }

--- a/examples/from-mssql/src/main.rs
+++ b/examples/from-mssql/src/main.rs
@@ -1,0 +1,51 @@
+//! Custom in-process SQL Server transforms (embedder example).
+//!
+//! Same flags as `surreal-sync from mssql sync`, but argv is source-shaped
+//! (no `from mssql` prefix). Pick a sink crate, define transforms, call `run`
+//! — it connects SurrealDB and chooses checkpoint storage from
+//! `--checkpoint-dir` or `--checkpoints-surreal-table`.
+//!
+//! ```bash
+//! cargo run -p surreal-sync-example-from-mssql -- sync \
+//!   --connection-string 'Server=tcp:localhost,1433;User=sa;Password=...;Database=App;TrustServerCertificate=true;Encrypt=true' \
+//!   --tables dbo.Article,sales.Order \
+//!   --to-namespace prod --to-database app \
+//!   --checkpoints-surreal-table sync_checkpoints
+//! ```
+
+use anyhow::Result;
+use std::collections::HashMap;
+use surreal_sync_mssql::{run, FlattenId, InPlaceTransform, Value};
+use surreal_sync_surreal::Surreal3Sink;
+
+/// Drop columns that must not leave the source VPC.
+struct RedactPii;
+
+impl RedactPii {
+    const DROP: &'static [&'static str] = &["password_hash", "ssn", "credit_card"];
+}
+
+impl InPlaceTransform for RedactPii {
+    fn transform(
+        &self,
+        _table: &str,
+        _id: &mut Value,
+        fields: Option<&mut HashMap<String, Value>>,
+    ) -> Result<()> {
+        if let Some(fields) = fields {
+            for key in Self::DROP {
+                fields.remove(*key);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    run::<Surreal3Sink>([
+        Box::new(FlattenId::default()) as Box<dyn InPlaceTransform>,
+        Box::new(RedactPii),
+    ])
+    .await
+}

--- a/loadtest/Dockerfile.postgres16.wal2json
+++ b/loadtest/Dockerfile.postgres16.wal2json
@@ -8,7 +8,7 @@
 #   docker build -t postgres-16-wal2json:dev -f ./crates/postgresql/Dockerfile.postgres16.wal2json ./crates/postgresql
 #
 # To run a Postgres container with wal2json enabled, run:
-#   docker run --name postgres1 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=testdb -it --rm postgres-16-wal2json:dev postgres -c wal_level=logical -c max_wal_senders=10 -c max_replication_slots=10 -c track_commit_timestamp=on
+#   docker run --name postgres1 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=testdb -it --rm postgres-16-wal2json:dev postgres -c wal_level=logical -c max_wal_senders=10 -c max_replication_slots=10 -c track_commit_timestamp=on -c output_plugin_libraries=wal2json
 #
 # To connect to the database, use:
 #   docker run --network=container:postgres1 -it --rm -e POSTGRES_PASSWORD=postgres postgres:16 psql --user postgres -h localhost

--- a/scripts/compile-embedder-examples.sh
+++ b/scripts/compile-embedder-examples.sh
@@ -39,6 +39,7 @@ PACKAGES=(
   surreal-sync-example-from-snowflake
   surreal-sync-example-from-jsonl
   surreal-sync-example-from-kafka
+  surreal-sync-example-from-mssql
 )
 
 for pkg in "${PACKAGES[@]}"; do

--- a/scripts/embed-dependency-tree-gates.sh
+++ b/scripts/embed-dependency-tree-gates.sh
@@ -25,7 +25,7 @@ fi
 
 # Kafka / snowflake / runtime / mysql must not pull surrealdb
 # in the normal+build graph (embed examples live in separate packages).
-for pkg in surreal-sync-kafka surreal-sync-snowflake surreal-sync-json surreal-sync-runtime surreal-sync-mysql; do
+for pkg in surreal-sync-kafka surreal-sync-snowflake surreal-sync-json surreal-sync-runtime surreal-sync-mysql surreal-sync-mssql; do
   out=$(cargo tree -p "$pkg" -e normal,build -i surrealdb 2>&1 || true)
   if echo "$out" | rg -q '^surrealdb v'; then
     echo "FAIL: $pkg unexpectedly depends on surrealdb:"
@@ -36,7 +36,7 @@ for pkg in surreal-sync-kafka surreal-sync-snowflake surreal-sync-json surreal-s
 done
 
 # snowflake / mysql must not pull kafka or neo4j clients
-for pkg in surreal-sync-snowflake surreal-sync-mysql surreal-sync-json; do
+for pkg in surreal-sync-snowflake surreal-sync-mysql surreal-sync-json surreal-sync-mssql; do
   for deny in rdkafka neo4rs; do
     out=$(cargo tree -p "$pkg" -e normal,build -i "$deny" 2>&1 || true)
     if echo "$out" | rg -q "^${deny} "; then
@@ -81,7 +81,7 @@ done
 
 # Documented embed graphs (examples/from-* packages mirror a real embedder).
 # Non-kafka examples must not pull rdkafka/neo4rs.
-for pkg in surreal-sync-example-from-snowflake surreal-sync-example-from-mysql-binlog surreal-sync-example-from-jsonl; do
+for pkg in surreal-sync-example-from-snowflake surreal-sync-example-from-mysql-binlog surreal-sync-example-from-jsonl surreal-sync-example-from-mssql; do
   for deny in rdkafka neo4rs; do
     out=$(cargo tree -p "$pkg" -e normal,build -i "$deny" 2>&1 || true)
     if echo "$out" | rg -q "^${deny} "; then
@@ -157,11 +157,11 @@ fi
 echo "OK: mysql-binlog example uses surreal-sync-runtime checkpoints"
 
 # Embed example sources monomorphize Surreal3Sink only
-if ! rg -n 'run::<Surreal3Sink>' examples/from-snowflake examples/from-mysql-binlog examples/from-jsonl examples/from-kafka; then
+if ! rg -n 'run::<Surreal3Sink>' examples/from-snowflake examples/from-mysql-binlog examples/from-jsonl examples/from-kafka examples/from-mssql; then
   echo "FAIL: examples should monomorphize Surreal3Sink"
   exit 1
 fi
-if rg -n 'run::<Surreal2Sink>|Surreal2Sink' examples/from-snowflake examples/from-mysql-binlog examples/from-jsonl examples/from-kafka; then
+if rg -n 'run::<Surreal2Sink>|Surreal2Sink' examples/from-snowflake examples/from-mysql-binlog examples/from-jsonl examples/from-kafka examples/from-mssql; then
   echo "FAIL: embed examples must not reference Surreal2Sink"
   exit 1
 fi

--- a/scripts/test-images.env
+++ b/scripts/test-images.env
@@ -1,6 +1,7 @@
-# Canonical Docker image tags for MySQL/MariaDB binlog integration tests.
+# Canonical Docker image tags for integration tests.
 # Consumed by: Makefile (via scripts/test-images.mk) and CI workflows.
 # Keep in sync with crates/mysql/test-images.env (Rust include_str for crates.io).
 # Override at runtime with env vars.
 MYSQL_BINLOG_IMAGE=mysql:8.0
 MARIADB_BINLOG_IMAGE=mariadb:11.4
+MSSQL_IMAGE=mcr.microsoft.com/mssql/server:2022-CU26-ubuntu-22.04

--- a/scripts/test-images.mk
+++ b/scripts/test-images.mk
@@ -1,9 +1,10 @@
-# Load canonical binlog test image tags from scripts/test-images.env.
+# Load canonical test image tags from scripts/test-images.env.
 MYSQL_BINLOG_IMAGE := $(shell grep -E '^MYSQL_BINLOG_IMAGE=' scripts/test-images.env | cut -d= -f2-)
 MARIADB_BINLOG_IMAGE := $(shell grep -E '^MARIADB_BINLOG_IMAGE=' scripts/test-images.env | cut -d= -f2-)
-export MYSQL_BINLOG_IMAGE MARIADB_BINLOG_IMAGE
+MSSQL_IMAGE := $(shell grep -E '^MSSQL_IMAGE=' scripts/test-images.env | cut -d= -f2-)
+export MYSQL_BINLOG_IMAGE MARIADB_BINLOG_IMAGE MSSQL_IMAGE
 
-.PHONY: prepull-binlog-images print-test-images
+.PHONY: prepull-binlog-images prepull-mssql-image print-test-images
 
 prepull-binlog-images:
 	@echo "🐳 Pre-pulling MySQL/MariaDB binlog test images ($(MYSQL_BINLOG_IMAGE), $(MARIADB_BINLOG_IMAGE))..."
@@ -11,6 +12,12 @@ prepull-binlog-images:
 	docker pull $(MARIADB_BINLOG_IMAGE)
 	@echo "✅ Binlog test images ready"
 
+prepull-mssql-image:
+	@echo "🐳 Pre-pulling SQL Server test image ($(MSSQL_IMAGE))..."
+	docker pull $(MSSQL_IMAGE)
+	@echo "✅ SQL Server test image ready"
+
 print-test-images:
 	@echo MYSQL_BINLOG_IMAGE=$(MYSQL_BINLOG_IMAGE)
 	@echo MARIADB_BINLOG_IMAGE=$(MARIADB_BINLOG_IMAGE)
+	@echo MSSQL_IMAGE=$(MSSQL_IMAGE)

--- a/src/from/mysql.rs
+++ b/src/from/mysql.rs
@@ -75,6 +75,7 @@ async fn run_full_v2(args: MySQLFullArgs) -> anyhow::Result<()> {
     let sync_opts = surreal_sync_mysql::from_trigger::SyncOpts {
         batch_size: args.surreal.batch_size,
         dry_run: args.surreal.dry_run,
+        schemafull: args.schemafull,
     };
     let (pipeline, apply_opts) = load_transforms_from_args(args.transforms_config.as_deref())?;
 
@@ -176,6 +177,7 @@ async fn run_full_v3(args: MySQLFullArgs) -> anyhow::Result<()> {
     let sync_opts = surreal_sync_mysql::from_trigger::SyncOpts {
         batch_size: args.surreal.batch_size,
         dry_run: args.surreal.dry_run,
+        schemafull: args.schemafull,
     };
     let (pipeline, apply_opts) = load_transforms_from_args(args.transforms_config.as_deref())?;
 
@@ -375,6 +377,7 @@ async fn resolve_mysql_database(
 /// Run a MySQL interleaved snapshot full sync, emitting the handoff
 /// position as a checkpoint (when checkpoint storage is configured) so a later
 /// `incremental` run can resume from the consistent end position.
+#[allow(clippy::too_many_arguments)]
 async fn mysql_snapshot_full<S, St>(
     sink: &S,
     connection_string: String,
@@ -383,6 +386,8 @@ async fn mysql_snapshot_full<S, St>(
     ssl: surreal_sync_mysql::from_trigger::SslMode,
     manager: Option<&SyncManager<St>>,
     transforms: &SnapshotTransforms,
+    schemafull: bool,
+    dry_run: bool,
 ) -> anyhow::Result<()>
 where
     S: SurrealSink,
@@ -391,6 +396,20 @@ where
     let pool =
         surreal_sync_mysql::from_trigger::new_mysql_pool_with_ssl(&connection_string, &ssl).await?;
     let database = resolve_mysql_database(&pool, &database).await?;
+    if schemafull {
+        let mut conn = pool.get_conn().await?;
+        mysql_async::prelude::Queryable::query_drop(&mut conn, format!("USE {database}")).await?;
+        let db_schema =
+            surreal_sync_mysql::from_trigger::collect_mysql_database_schema(&mut conn).await?;
+        surreal_sync_core::maybe_emit_schemafull(
+            sink,
+            &db_schema,
+            &surreal_sync_core::SchemafullExtras::default(),
+            true,
+            dry_run,
+        )
+        .await?;
+    }
     let config = InterleavedSnapshotConfig { chunk_size };
     let mut checkpointer = NoopCheckpointer;
     let final_seq =
@@ -456,6 +475,8 @@ async fn run_full_interleaved_snapshot_v2(args: MySQLFullArgs) -> anyhow::Result
                 args.tls.ssl_mode(),
                 Some(&manager),
                 &transforms,
+                args.schemafull,
+                args.surreal.dry_run,
             )
             .await
         }
@@ -478,6 +499,8 @@ async fn run_full_interleaved_snapshot_v2(args: MySQLFullArgs) -> anyhow::Result
                 args.tls.ssl_mode(),
                 Some(&manager),
                 &transforms,
+                args.schemafull,
+                args.surreal.dry_run,
             )
             .await
         }
@@ -490,6 +513,8 @@ async fn run_full_interleaved_snapshot_v2(args: MySQLFullArgs) -> anyhow::Result
                 args.tls.ssl_mode(),
                 None,
                 &transforms,
+                args.schemafull,
+                args.surreal.dry_run,
             )
             .await
         }
@@ -535,6 +560,8 @@ async fn run_full_interleaved_snapshot_v3(args: MySQLFullArgs) -> anyhow::Result
                 args.tls.ssl_mode(),
                 Some(&manager),
                 &transforms,
+                args.schemafull,
+                args.surreal.dry_run,
             )
             .await
         }
@@ -551,6 +578,8 @@ async fn run_full_interleaved_snapshot_v3(args: MySQLFullArgs) -> anyhow::Result
                 args.tls.ssl_mode(),
                 Some(&manager),
                 &transforms,
+                args.schemafull,
+                args.surreal.dry_run,
             )
             .await
         }
@@ -563,6 +592,8 @@ async fn run_full_interleaved_snapshot_v3(args: MySQLFullArgs) -> anyhow::Result
                 args.tls.ssl_mode(),
                 None,
                 &transforms,
+                args.schemafull,
+                args.surreal.dry_run,
             )
             .await
         }

--- a/src/from/postgresql_pgoutput.rs
+++ b/src/from/postgresql_pgoutput.rs
@@ -70,10 +70,11 @@ fn wal_source_opts(args: &PostgreSQLPgoutputSyncArgs) -> SourceOpts {
     }
 }
 
-fn wal_sync_opts(batch_size: usize, dry_run: bool) -> SyncOpts {
+fn wal_sync_opts(batch_size: usize, dry_run: bool, schemafull: bool) -> SyncOpts {
     SyncOpts {
         batch_size,
         dry_run,
+        schemafull,
     }
 }
 
@@ -185,6 +186,22 @@ where
 {
     match strategy {
         SyncStrategy::InterleavedSnapshot => {
+            if sync_opts.schemafull {
+                let client =
+                    surreal_sync_postgresql::new_postgresql_client(&source_opts.connection_string)
+                        .await?;
+                let guard = client.lock().await;
+                let db_schema =
+                    surreal_sync_postgresql::collect_database_schema_with_fks(&guard).await?;
+                surreal_sync_core::maybe_emit_schemafull(
+                    sink,
+                    &db_schema,
+                    &surreal_sync_core::SchemafullExtras::default(),
+                    true,
+                    sync_opts.dry_run,
+                )
+                .await?;
+            }
             let outcome = run_interleaved_snapshot_full_sync_with_transforms(
                 sink,
                 source_opts,
@@ -363,7 +380,11 @@ where
     let stream_options = wal_stream_options(&args)?.with_cancel(cancel.clone());
 
     let source_opts = wal_source_opts(&args);
-    let sync_opts = wal_sync_opts(args.surreal.batch_size, args.surreal.dry_run);
+    let sync_opts = wal_sync_opts(
+        args.surreal.batch_size,
+        args.surreal.dry_run,
+        args.schemafull,
+    );
 
     match snapshot_mode {
         BinlogSnapshotModeArg::Only => {

--- a/src/from/postgresql_trigger.rs
+++ b/src/from/postgresql_trigger.rs
@@ -48,6 +48,7 @@ struct ResolvedTriggerFullArgs {
     strategy: SyncStrategy,
     chunk_size: usize,
     transforms_config: Option<PathBuf>,
+    schemafull: bool,
     surreal: SurrealOpts,
 }
 
@@ -87,6 +88,7 @@ fn resolve_full_args(args: PostgreSQLTriggerFullArgs) -> anyhow::Result<Resolved
             strategy: args.strategy,
             chunk_size: args.chunk_size,
             transforms_config: args.transforms_config,
+            schemafull: args.schemafull,
             surreal: SurrealOpts {
                 surreal_endpoint: sink.endpoint,
                 surreal_username: sink.username,
@@ -115,6 +117,7 @@ fn resolve_full_args(args: PostgreSQLTriggerFullArgs) -> anyhow::Result<Resolved
             strategy: args.strategy,
             chunk_size: args.chunk_size,
             transforms_config: args.transforms_config,
+            schemafull: args.schemafull,
             surreal: args.surreal,
         })
     }
@@ -238,6 +241,7 @@ async fn run_full_v2(args: ResolvedTriggerFullArgs) -> anyhow::Result<()> {
     let sync_opts = surreal_sync_postgresql::SyncOpts {
         batch_size: args.surreal.batch_size,
         dry_run: args.surreal.dry_run,
+        schemafull: args.schemafull,
     };
     let (pipeline, apply_opts) = load_transforms_from_args(args.transforms_config.as_deref())?;
 
@@ -325,6 +329,7 @@ async fn run_full_v3(args: ResolvedTriggerFullArgs) -> anyhow::Result<()> {
     let sync_opts = surreal_sync_postgresql::SyncOpts {
         batch_size: args.surreal.batch_size,
         dry_run: args.surreal.dry_run,
+        schemafull: args.schemafull,
     };
     let (pipeline, apply_opts) = load_transforms_from_args(args.transforms_config.as_deref())?;
 
@@ -404,11 +409,30 @@ async fn pg_trigger_snapshot_full<S, St>(
     chunk_size: usize,
     manager: Option<&SyncManager<St>>,
     transforms: &SnapshotTransforms,
+    schemafull: bool,
+    dry_run: bool,
 ) -> anyhow::Result<()>
 where
     S: SurrealSink,
     St: CheckpointStore,
 {
+    if schemafull {
+        let client =
+            surreal_sync_postgresql::new_postgresql_client(&source_opts.source_uri).await?;
+        let guard = client.lock().await;
+        let db_schema = surreal_sync_postgresql::collect_database_schema_with_fks(&guard).await?;
+        surreal_sync_core::maybe_emit_schemafull(
+            sink,
+            &db_schema,
+            &surreal_sync_core::SchemafullExtras {
+                relation_tables: source_opts.relation_tables.clone(),
+                ..Default::default()
+            },
+            true,
+            dry_run,
+        )
+        .await?;
+    }
     let config = InterleavedSnapshotConfig { chunk_size };
     let mut checkpointer = NoopCheckpointer;
     let final_seq =
@@ -474,6 +498,8 @@ async fn run_full_interleaved_snapshot_v2(args: ResolvedTriggerFullArgs) -> anyh
                 args.chunk_size,
                 Some(&manager),
                 &transforms,
+                args.schemafull,
+                args.surreal.dry_run,
             )
             .await
         }
@@ -494,6 +520,8 @@ async fn run_full_interleaved_snapshot_v2(args: ResolvedTriggerFullArgs) -> anyh
                 args.chunk_size,
                 Some(&manager),
                 &transforms,
+                args.schemafull,
+                args.surreal.dry_run,
             )
             .await
         }
@@ -504,6 +532,8 @@ async fn run_full_interleaved_snapshot_v2(args: ResolvedTriggerFullArgs) -> anyh
                 args.chunk_size,
                 None,
                 &transforms,
+                args.schemafull,
+                args.surreal.dry_run,
             )
             .await
         }
@@ -550,6 +580,8 @@ async fn run_full_interleaved_snapshot_v3(args: ResolvedTriggerFullArgs) -> anyh
                 args.chunk_size,
                 Some(&manager),
                 &transforms,
+                args.schemafull,
+                args.surreal.dry_run,
             )
             .await
         }
@@ -564,6 +596,8 @@ async fn run_full_interleaved_snapshot_v3(args: ResolvedTriggerFullArgs) -> anyh
                 args.chunk_size,
                 Some(&manager),
                 &transforms,
+                args.schemafull,
+                args.surreal.dry_run,
             )
             .await
         }
@@ -574,6 +608,8 @@ async fn run_full_interleaved_snapshot_v3(args: ResolvedTriggerFullArgs) -> anyh
                 args.chunk_size,
                 None,
                 &transforms,
+                args.schemafull,
+                args.surreal.dry_run,
             )
             .await
         }

--- a/src/from/postgresql_wal2json.rs
+++ b/src/from/postgresql_wal2json.rs
@@ -49,6 +49,7 @@ struct ResolvedWal2jsonFullArgs {
     strategy: SyncStrategy,
     chunk_size: usize,
     transforms_config: Option<PathBuf>,
+    schemafull: bool,
     surreal: SurrealOpts,
 }
 
@@ -100,6 +101,7 @@ fn resolve_full_args(args: PostgreSQLLogicalFullArgs) -> anyhow::Result<Resolved
             strategy: args.strategy,
             chunk_size: args.chunk_size,
             transforms_config: args.transforms_config,
+            schemafull: args.schemafull,
             surreal: SurrealOpts {
                 surreal_endpoint: sink.endpoint,
                 surreal_username: sink.username,
@@ -130,6 +132,7 @@ fn resolve_full_args(args: PostgreSQLLogicalFullArgs) -> anyhow::Result<Resolved
             strategy: args.strategy,
             chunk_size: args.chunk_size,
             transforms_config: args.transforms_config,
+            schemafull: args.schemafull,
             surreal: args.surreal,
         })
     }
@@ -267,6 +270,7 @@ async fn run_full_v2(args: ResolvedWal2jsonFullArgs) -> anyhow::Result<()> {
     let sync_opts = surreal_sync_postgresql::SyncOpts {
         batch_size: args.surreal.batch_size,
         dry_run: args.surreal.dry_run,
+        schemafull: args.schemafull,
     };
     let (pipeline, apply_opts) = load_transforms_from_args(args.transforms_config.as_deref())?;
 
@@ -355,6 +359,7 @@ async fn run_full_v3(args: ResolvedWal2jsonFullArgs) -> anyhow::Result<()> {
     let sync_opts = surreal_sync_postgresql::SyncOpts {
         batch_size: args.surreal.batch_size,
         dry_run: args.surreal.dry_run,
+        schemafull: args.schemafull,
     };
     let (pipeline, apply_opts) = load_transforms_from_args(args.transforms_config.as_deref())?;
 
@@ -619,11 +624,30 @@ async fn wal2json_snapshot_full<S, St>(
     chunk_size: usize,
     manager: Option<&SyncManager<St>>,
     transforms: &SnapshotTransforms,
+    schemafull: bool,
+    dry_run: bool,
 ) -> anyhow::Result<()>
 where
     S: SurrealSink,
     St: CheckpointStore,
 {
+    if schemafull {
+        let client =
+            surreal_sync_postgresql::new_postgresql_client(&source_opts.connection_string).await?;
+        let guard = client.lock().await;
+        let db_schema = surreal_sync_postgresql::collect_database_schema_with_fks(&guard).await?;
+        surreal_sync_core::maybe_emit_schemafull(
+            sink,
+            &db_schema,
+            &surreal_sync_core::SchemafullExtras {
+                relation_tables: source_opts.relation_tables.clone(),
+                ..Default::default()
+            },
+            true,
+            dry_run,
+        )
+        .await?;
+    }
     let final_lsn =
         surreal_sync_postgresql::from_wal2json::run_interleaved_snapshot_full_sync_with_transforms(
             sink,
@@ -691,6 +715,8 @@ async fn run_full_interleaved_snapshot_v2(args: ResolvedWal2jsonFullArgs) -> any
                 args.chunk_size,
                 Some(&manager),
                 &transforms,
+                args.schemafull,
+                args.surreal.dry_run,
             )
             .await
         }
@@ -711,6 +737,8 @@ async fn run_full_interleaved_snapshot_v2(args: ResolvedWal2jsonFullArgs) -> any
                 args.chunk_size,
                 Some(&manager),
                 &transforms,
+                args.schemafull,
+                args.surreal.dry_run,
             )
             .await
         }
@@ -721,6 +749,8 @@ async fn run_full_interleaved_snapshot_v2(args: ResolvedWal2jsonFullArgs) -> any
                 args.chunk_size,
                 None,
                 &transforms,
+                args.schemafull,
+                args.surreal.dry_run,
             )
             .await
         }
@@ -772,6 +802,8 @@ async fn run_full_interleaved_snapshot_v3(args: ResolvedWal2jsonFullArgs) -> any
                 args.chunk_size,
                 Some(&manager),
                 &transforms,
+                args.schemafull,
+                args.surreal.dry_run,
             )
             .await
         }
@@ -786,6 +818,8 @@ async fn run_full_interleaved_snapshot_v3(args: ResolvedWal2jsonFullArgs) -> any
                 args.chunk_size,
                 Some(&manager),
                 &transforms,
+                args.schemafull,
+                args.surreal.dry_run,
             )
             .await
         }
@@ -796,6 +830,8 @@ async fn run_full_interleaved_snapshot_v3(args: ResolvedWal2jsonFullArgs) -> any
                 args.chunk_size,
                 None,
                 &transforms,
+                args.schemafull,
+                args.surreal.dry_run,
             )
             .await
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,12 @@
 //! |--------|-------|
 //! | Snowflake | `surreal-sync-snowflake` (`from_snowflake`) |
 //! | MySQL/MariaDB binlog | `surreal-sync-mysql` (`from_binlog`) |
+//! | SQL Server CDC | `surreal-sync-mssql` (`from_mssql`) |
 //! | SurrealDB sink | `surreal-sync-surreal` with feature `v2` or `v3` |
 //! | Checkpoint (CDC) | included in `surreal-sync-surreal`; or `surreal-sync-runtime::checkpoint_fs` |
 //!
 //! See `docs/sync-pipeline.md` (“Advanced: embedding”) and
-//! `examples/from-mysql-binlog` / `examples/from-snowflake`.
+//! `examples/from-mysql-binlog` / `examples/from-snowflake` / `examples/from-mssql`.
 //!
 //! # What this crate exposes
 //!

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,7 @@ use std::path::PathBuf;
 use surreal_sync_runtime::SurrealCliOpts as SurrealOpts;
 
 // Shared with binary mysql-binlog CLI glue (also used by other `from *` clap args).
+use mssql::Commands as MssqlCommands;
 pub(crate) use mysql_binlog::{
     Commands as MySQLBinlogCommands, SnapshotModeArg as BinlogSnapshotModeArg, SyncStrategy,
     TlsArgs as MySQLTlsArgs, DEFAULT_CHUNK_SIZE,
@@ -115,6 +116,7 @@ mod from;
 mod loadtest;
 
 // Stock CLI auto-detect glue (both Surreal SDKs linked). Prefer from-* for embeds.
+mod mssql;
 mod mysql_binlog;
 mod snowflake;
 
@@ -206,6 +208,13 @@ enum FromSource {
     /// Import from JSONL files
     #[command(name = "jsonl")]
     Jsonl(from::jsonl::Args),
+
+    /// Sync from SQL Server using native CDC
+    #[command(name = "mssql")]
+    Mssql {
+        #[command(subcommand)]
+        command: MssqlCommands,
+    },
 
     /// Ingest from Snowflake (full one-shot snapshot via the SQL REST API v2)
     #[command(name = "snowflake")]
@@ -572,6 +581,10 @@ struct PostgreSQLTriggerFullArgs {
     #[arg(long, value_name = "PATH")]
     transforms_config: Option<PathBuf>,
 
+    /// Create SCHEMAFULL tables and copy translatable indexes (default is schemaless)
+    #[arg(long, default_value_t = false)]
+    schemafull: bool,
+
     #[command(flatten)]
     surreal: SurrealOpts,
 }
@@ -749,6 +762,10 @@ struct MySQLFullArgs {
     /// Omit for identity (docs pass through unchanged; no transform stage dispatch).
     #[arg(long, value_name = "PATH")]
     transforms_config: Option<PathBuf>,
+
+    /// Create SCHEMAFULL tables and copy translatable indexes (default is schemaless)
+    #[arg(long, default_value_t = false)]
+    schemafull: bool,
 
     #[command(flatten)]
     tls: MySQLTlsArgs,
@@ -988,6 +1005,10 @@ struct PostgreSQLPgoutputSyncArgs {
     #[arg(long, value_name = "PATH")]
     transforms_config: Option<PathBuf>,
 
+    /// Create SCHEMAFULL tables and copy translatable indexes (default is schemaless)
+    #[arg(long, default_value_t = false)]
+    schemafull: bool,
+
     #[command(flatten)]
     surreal: SurrealOpts,
 }
@@ -1075,6 +1096,10 @@ struct PostgreSQLLogicalFullArgs {
     /// Omit for identity (docs pass through unchanged; no transform stage dispatch).
     #[arg(long, value_name = "PATH")]
     transforms_config: Option<PathBuf>,
+
+    /// Create SCHEMAFULL tables and copy translatable indexes (default is schemaless)
+    #[arg(long, default_value_t = false)]
+    schemafull: bool,
 
     #[command(flatten)]
     surreal: SurrealOpts,
@@ -1442,6 +1467,7 @@ async fn handle_from_command(source: FromSource) -> anyhow::Result<()> {
         FromSource::Kafka(args) => from::kafka::run_args(args).await?,
         FromSource::Csv(args) => from::csv::run(args).await?,
         FromSource::Jsonl(args) => from::jsonl::run_args(args).await?,
+        FromSource::Mssql { command } => mssql::run_command(command).await?,
         FromSource::Snowflake(args) => snowflake::run_args(args).await?,
     }
     Ok(())

--- a/src/mssql/mod.rs
+++ b/src/mssql/mod.rs
@@ -1,0 +1,50 @@
+//! SQL Server CDC CLI glue (Surreal version auto-detect).
+//!
+//! Embedders should call `surreal_sync_mssql::run::<Surreal3Sink>` (or
+//! `Surreal2Sink`). This module is only for the surreal-sync CLI, which
+//! auto-detects SurrealDB v2 vs v3.
+
+use surreal_sync_mssql::from_mssql::cli::{run_sync, Pipeline, SyncArgs};
+use surreal_sync_runtime::{load_transforms_from_args, SinkConnect};
+
+pub use surreal_sync_mssql::from_mssql::cli::Commands;
+
+use crate::from::{get_sdk_version, SdkVersion};
+
+/// Stock CLI: auto-detect Surreal major, connect matching sink, run embed orchestration.
+pub async fn run_command(command: Commands) -> anyhow::Result<()> {
+    match command {
+        Commands::Sync(args) => {
+            let (pipeline, apply_opts) =
+                load_transforms_from_args(args.transforms_config.as_deref())?;
+            run_sync_autodetect(*args, pipeline, apply_opts).await
+        }
+    }
+}
+
+async fn run_sync_autodetect(
+    args: SyncArgs,
+    pipeline: Pipeline,
+    apply_opts: surreal_sync_runtime::ApplyOpts,
+) -> anyhow::Result<()> {
+    let sdk_version = get_sdk_version(
+        &args.surreal.surreal_endpoint,
+        args.surreal.surreal_sdk_version.as_deref(),
+    )
+    .await?;
+
+    let config = args
+        .surreal
+        .to_config(args.to_namespace.clone(), args.to_database.clone());
+
+    match sdk_version {
+        SdkVersion::V2 => {
+            let sink = surreal_sync_surreal::v2::Surreal2Sink::connect(&config).await?;
+            run_sync(args, &sink, pipeline, apply_opts).await
+        }
+        SdkVersion::V3 => {
+            let sink = surreal_sync_surreal::v3::Surreal3Sink::connect(&config).await?;
+            run_sync(args, &sink, pipeline, apply_opts).await
+        }
+    }
+}

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -11,6 +11,7 @@ pub mod field;
 pub mod full;
 pub mod mongodb;
 pub mod mongodb_container;
+pub mod mssql;
 pub mod mysql;
 pub mod mysql_binlog_container;
 pub mod mysql_binlog_e2e;

--- a/src/testing/field.rs
+++ b/src/testing/field.rs
@@ -4,8 +4,8 @@
 //! to source-specific implementations across different database systems.
 
 use crate::testing::{
-    mongodb::MongoDBField, mysql::MySQLField, neo4j::Neo4jField, postgresql::PostgreSQLField,
-    value::SurrealDBValue,
+    mongodb::MongoDBField, mssql::MssqlField, mysql::MySQLField, neo4j::Neo4jField,
+    postgresql::PostgreSQLField, value::SurrealDBValue,
 };
 // Note: Neo4jField now uses neo4rs::BoltType directly instead of Neo4jValue
 
@@ -18,6 +18,7 @@ pub struct Field {
     pub mongodb: Option<MongoDBField>,
     pub postgresql: Option<PostgreSQLField>,
     pub mysql: Option<MySQLField>,
+    pub mssql: Option<MssqlField>,
     pub neo4j: Option<Neo4jField>,
 }
 
@@ -30,6 +31,7 @@ impl Field {
             mongodb: None,
             postgresql: None,
             mysql: None,
+            mssql: None,
             neo4j: None,
         }
     }
@@ -49,6 +51,12 @@ impl Field {
     /// Create a field with specific MySQL representation
     pub fn with_mysql(mut self, mysql_field: MySQLField) -> Self {
         self.mysql = Some(mysql_field);
+        self
+    }
+
+    /// Create a field with specific SQL Server representation
+    pub fn with_mssql(mut self, mssql_field: MssqlField) -> Self {
+        self.mssql = Some(mssql_field);
         self
     }
 

--- a/src/testing/mssql.rs
+++ b/src/testing/mssql.rs
@@ -1,0 +1,575 @@
+//! SQL Server field definitions, table injection, and unified-dataset assertions.
+
+use crate::testing::{
+    surreal::{assert_synced_auto, SurrealConnection},
+    table::{SourceDatabase, TestDataSet, TestDoc, TestTable},
+    value::{MssqlValue, SurrealDBValue},
+};
+use chrono::{DateTime, NaiveDateTime, Utc};
+use std::collections::HashSet;
+use surreal_sync_mssql::from_mssql::testing::{MssqlClient, SqlArg};
+use uuid::Uuid;
+
+/// SQL Server-specific field representation.
+#[derive(Debug, Clone)]
+pub struct MssqlField {
+    pub column_name: String,
+    pub column_value: MssqlValue,
+    pub data_type: String,
+    pub precision: Option<u32>,
+    pub scale: Option<u32>,
+}
+
+impl MssqlField {
+    pub fn nvarchar(column: impl Into<String>, value: impl Into<String>) -> Self {
+        let value = value.into();
+        MssqlField {
+            column_name: column.into(),
+            column_value: MssqlValue::NVarchar(value),
+            data_type: "NVARCHAR(255)".to_string(),
+            precision: None,
+            scale: None,
+        }
+    }
+
+    pub fn ntext(column: impl Into<String>, value: impl Into<String>) -> Self {
+        MssqlField {
+            column_name: column.into(),
+            column_value: MssqlValue::NText(value.into()),
+            data_type: "NVARCHAR(MAX)".to_string(),
+            precision: None,
+            scale: None,
+        }
+    }
+
+    pub fn xml(column: impl Into<String>, value: impl Into<String>) -> Self {
+        MssqlField {
+            column_name: column.into(),
+            column_value: MssqlValue::Xml(value.into()),
+            data_type: "XML".to_string(),
+            precision: None,
+            scale: None,
+        }
+    }
+
+    pub fn int(column: impl Into<String>, value: i32) -> Self {
+        MssqlField {
+            column_name: column.into(),
+            column_value: MssqlValue::Int(value),
+            data_type: "INT".to_string(),
+            precision: None,
+            scale: None,
+        }
+    }
+
+    pub fn bigint(column: impl Into<String>, value: i64) -> Self {
+        MssqlField {
+            column_name: column.into(),
+            column_value: MssqlValue::BigInt(value),
+            data_type: "BIGINT".to_string(),
+            precision: None,
+            scale: None,
+        }
+    }
+
+    pub fn tinyint(column: impl Into<String>, value: u8) -> Self {
+        MssqlField {
+            column_name: column.into(),
+            column_value: MssqlValue::TinyInt(value),
+            data_type: "TINYINT".to_string(),
+            precision: None,
+            scale: None,
+        }
+    }
+
+    pub fn bit(column: impl Into<String>, value: bool) -> Self {
+        MssqlField {
+            column_name: column.into(),
+            column_value: MssqlValue::Bit(value),
+            data_type: "BIT".to_string(),
+            precision: None,
+            scale: None,
+        }
+    }
+
+    pub fn float(column: impl Into<String>, value: f64) -> Self {
+        MssqlField {
+            column_name: column.into(),
+            column_value: MssqlValue::Float(value),
+            data_type: "FLOAT".to_string(),
+            precision: None,
+            scale: None,
+        }
+    }
+
+    pub fn decimal(
+        column: impl Into<String>,
+        value: impl Into<String>,
+        precision: u32,
+        scale: u32,
+    ) -> Self {
+        MssqlField {
+            column_name: column.into(),
+            column_value: MssqlValue::Decimal {
+                value: value.into(),
+                precision: Some(precision),
+                scale: Some(scale),
+            },
+            data_type: format!("DECIMAL({precision},{scale})"),
+            precision: Some(precision),
+            scale: Some(scale),
+        }
+    }
+
+    pub fn money(column: impl Into<String>, value: impl Into<String>) -> Self {
+        MssqlField {
+            column_name: column.into(),
+            column_value: MssqlValue::Money(value.into()),
+            data_type: "MONEY".to_string(),
+            precision: Some(19),
+            scale: Some(4),
+        }
+    }
+
+    pub fn datetimeoffset(column: impl Into<String>, value: DateTime<Utc>) -> Self {
+        MssqlField {
+            column_name: column.into(),
+            column_value: MssqlValue::DateTimeOffset(value),
+            data_type: "DATETIMEOFFSET".to_string(),
+            precision: None,
+            scale: None,
+        }
+    }
+
+    pub fn datetime2(column: impl Into<String>, value: NaiveDateTime) -> Self {
+        MssqlField {
+            column_name: column.into(),
+            column_value: MssqlValue::DateTime2(value),
+            data_type: "DATETIME2".to_string(),
+            precision: None,
+            scale: None,
+        }
+    }
+
+    pub fn uniqueidentifier(column: impl Into<String>, value: Uuid) -> Self {
+        MssqlField {
+            column_name: column.into(),
+            column_value: MssqlValue::UniqueIdentifier(value),
+            data_type: "UNIQUEIDENTIFIER".to_string(),
+            precision: None,
+            scale: None,
+        }
+    }
+
+    pub fn varbinary(column: impl Into<String>, value: Vec<u8>) -> Self {
+        MssqlField {
+            column_name: column.into(),
+            column_value: MssqlValue::VarBinary(value),
+            data_type: "VARBINARY(64)".to_string(),
+            precision: None,
+            scale: None,
+        }
+    }
+}
+
+fn mssql_value_to_sql_arg(value: &MssqlValue) -> SqlArg {
+    match value {
+        MssqlValue::Null => SqlArg::Null,
+        MssqlValue::Bit(b) => SqlArg::Bool(*b),
+        MssqlValue::TinyInt(v) => SqlArg::I16(*v as i16),
+        MssqlValue::SmallInt(v) => SqlArg::I16(*v),
+        MssqlValue::Int(v) => SqlArg::I32(*v),
+        MssqlValue::BigInt(v) => SqlArg::I64(*v),
+        MssqlValue::Real(v) => SqlArg::F64(*v as f64),
+        MssqlValue::Float(v) => SqlArg::F64(*v),
+        MssqlValue::Decimal { value, .. } | MssqlValue::Money(value) => {
+            SqlArg::String(value.clone())
+        }
+        MssqlValue::NChar(s)
+        | MssqlValue::NVarchar(s)
+        | MssqlValue::NText(s)
+        | MssqlValue::Xml(s) => SqlArg::String(s.clone()),
+        MssqlValue::VarBinary(b) => SqlArg::Bytes(b.clone()),
+        MssqlValue::UniqueIdentifier(u) => SqlArg::Uuid(*u),
+        MssqlValue::DateTime2(dt) => SqlArg::String(dt.format("%Y-%m-%dT%H:%M:%S%.f").to_string()),
+        MssqlValue::DateTimeOffset(dt) => SqlArg::String(dt.to_rfc3339()),
+    }
+}
+
+fn placeholder_for(idx: usize, value: &MssqlValue) -> String {
+    let p = format!("@P{}", idx + 1);
+    match value {
+        MssqlValue::TinyInt(_) => format!("CAST({p} AS TINYINT)"),
+        MssqlValue::Decimal {
+            precision, scale, ..
+        } => {
+            let prec = precision.unwrap_or(18);
+            let scale = scale.unwrap_or(0);
+            format!("CAST({p} AS DECIMAL({prec},{scale}))")
+        }
+        MssqlValue::Money(_) => format!("CAST({p} AS MONEY)"),
+        MssqlValue::Xml(_) => format!("CAST({p} AS XML)"),
+        MssqlValue::DateTime2(_) => format!("CAST({p} AS DATETIME2)"),
+        MssqlValue::DateTimeOffset(_) => format!("CAST({p} AS DATETIMEOFFSET)"),
+        MssqlValue::Real(_) => format!("CAST({p} AS REAL)"),
+        _ => p,
+    }
+}
+
+/// Drop unified dataset tables, disabling system-versioning when needed.
+pub async fn cleanup_unified_dataset_tables(
+    client: &MssqlClient,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let tables = [
+        "authored_by",
+        "all_types_posts",
+        "all_types_users",
+        "people",
+        "users",
+        "posts",
+        "authored",
+        "Article",
+        "Comment",
+    ];
+    for table in tables {
+        let sql = format!(
+            r#"
+IF OBJECT_ID(N'dbo.{table}', N'U') IS NOT NULL
+BEGIN
+    IF OBJECTPROPERTY(OBJECT_ID(N'dbo.{table}'), 'TableTemporalType') = 2
+        ALTER TABLE [dbo].[{table}] SET (SYSTEM_VERSIONING = OFF);
+    IF OBJECT_ID(N'dbo.{table}_history', N'U') IS NOT NULL
+        DROP TABLE [dbo].[{table}_history];
+    DROP TABLE [dbo].[{table}];
+END
+"#
+        );
+        client.simple_query(&sql).await?;
+    }
+    Ok(())
+}
+
+/// Create unified tables (and indexes) in SQL Server.
+///
+/// `temporal_tables` names receive `PERIOD FOR SYSTEM_TIME` + `SYSTEM_VERSIONING`.
+pub async fn create_tables_and_indices(
+    client: &MssqlClient,
+    dataset: &TestDataSet,
+    temporal_tables: &[&str],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let temporal: HashSet<&str> = temporal_tables.iter().copied().collect();
+    for table in dataset.tables.iter().chain(dataset.relations.iter()) {
+        let is_temporal = temporal.contains(table.name.as_str());
+        let create_sql = table
+            .schema
+            .mssql
+            .to_create_table_ddl(&table.name, is_temporal);
+        client.simple_query(&create_sql).await.map_err(|e| {
+            format!(
+                "creating table {}: {e}\nSQL: {}",
+                table.name,
+                create_sql.replace('\n', " ")
+            )
+        })?;
+        for index in &table.schema.mssql.indexes {
+            let index_sql = table.schema.mssql.to_create_index_ddl(&table.name, index);
+            client.simple_query(&index_sql).await.map_err(|e| {
+                format!(
+                    "creating index {} on {}: {e}\nSQL: {index_sql}",
+                    index.name, table.name
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
+
+/// Insert every unified table and relation row.
+pub async fn insert_rows(
+    client: &MssqlClient,
+    dataset: &TestDataSet,
+) -> Result<(), Box<dyn std::error::Error>> {
+    for table in dataset.tables.iter().chain(dataset.relations.iter()) {
+        inject_test_table_mssql(client, table).await?;
+    }
+    Ok(())
+}
+
+/// Insert rows for a single table.
+pub async fn inject_test_table_mssql(
+    client: &MssqlClient,
+    table: &TestTable,
+) -> Result<(), Box<dyn std::error::Error>> {
+    for doc in &table.documents {
+        let mssql_doc = doc.to_mssql_doc();
+        if mssql_doc.is_empty() {
+            continue;
+        }
+        let columns: Vec<String> = mssql_doc.keys().cloned().collect();
+        let placeholders: Vec<String> = columns
+            .iter()
+            .enumerate()
+            .map(|(i, col)| placeholder_for(i, &mssql_doc[col]))
+            .collect();
+        let insert_sql = format!(
+            "INSERT INTO [dbo].[{}] ({}) VALUES ({})",
+            table.name,
+            columns
+                .iter()
+                .map(|c| format!("[{c}]"))
+                .collect::<Vec<_>>()
+                .join(", "),
+            placeholders.join(", ")
+        );
+        let args: Vec<SqlArg> = columns
+            .iter()
+            .map(|col| mssql_value_to_sql_arg(&mssql_doc[col]))
+            .collect();
+        client
+            .execute(&insert_sql, &args)
+            .await
+            .map_err(|e| format!("inserting into {}: {e}\nSQL: {insert_sql}", table.name))?;
+    }
+    Ok(())
+}
+
+fn business_pk_column(doc: &TestDoc) -> Option<String> {
+    doc.get_field("id")
+        .and_then(|f| f.mssql.as_ref())
+        .map(|m| m.column_name.clone())
+}
+
+fn business_pk_value(doc: &TestDoc) -> Option<String> {
+    match doc.get_field("id").map(|f| &f.value) {
+        Some(SurrealDBValue::Thing { id, .. }) => match id.as_ref() {
+            SurrealDBValue::String(s) => Some(s.clone()),
+            SurrealDBValue::Int64(i) => Some(i.to_string()),
+            SurrealDBValue::Int32(i) => Some(i.to_string()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Ordinary (non-temporal) unified sync: every MSSQL-mapped field of every row.
+pub async fn assert_synced_mssql(
+    conn: &SurrealConnection,
+    dataset: &TestDataSet,
+    test_prefix: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    assert_synced_auto(conn, dataset, test_prefix, SourceDatabase::Mssql).await?;
+    for relation in &dataset.relations {
+        assert_relation_rows(conn, relation, test_prefix, false, false).await?;
+    }
+    Ok(())
+}
+
+/// Mixed temporal graph: current versions of `temporal_tables` are matched
+/// field-by-field to the unified dataset (version ids, not `Table:pk`).
+/// Non-temporal unified tables still use PK record ids.
+pub async fn assert_synced_mssql_temporal(
+    conn: &SurrealConnection,
+    dataset: &TestDataSet,
+    test_prefix: &str,
+    temporal_tables: &[&str],
+) -> Result<(), Box<dyn std::error::Error>> {
+    crate::testing::surreal::assert_synced_mixed_temporal_auto(
+        conn,
+        dataset,
+        test_prefix,
+        SourceDatabase::Mssql,
+        temporal_tables,
+    )
+    .await?;
+    let users_temporal = temporal_tables.contains(&"all_types_users");
+    let posts_temporal = temporal_tables.contains(&"all_types_posts");
+    for relation in &dataset.relations {
+        assert_relation_rows(conn, relation, test_prefix, users_temporal, posts_temporal).await?;
+    }
+    Ok(())
+}
+
+async fn assert_relation_rows(
+    conn: &SurrealConnection,
+    relation: &TestTable,
+    test_prefix: &str,
+    users_temporal: bool,
+    posts_temporal: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let demoted_to_entity = users_temporal || posts_temporal;
+    let count_sql = format!("SELECT count() FROM {} GROUP ALL", relation.name);
+    let count = query_count(conn, &count_sql).await?;
+    assert_eq!(
+        count,
+        relation.documents.len(),
+        "{test_prefix}: relation '{}' count mismatch - expected {}, found {count}",
+        relation.name,
+        relation.documents.len()
+    );
+
+    for (doc_idx, expected_doc) in relation.documents.iter().enumerate() {
+        let expected = expected_doc.to_surrealdb_doc_for_source(SourceDatabase::Mssql);
+        let user_id = mssql_column_string(expected_doc, "in")
+            .or_else(|| thing_id_string(expected.get("in")))
+            .ok_or("authored_by in/user_id missing")?;
+        let post_id = mssql_column_string(expected_doc, "out")
+            .or_else(|| thing_id_string(expected.get("out")))
+            .ok_or("authored_by out/post_id missing")?;
+
+        let sql = if demoted_to_entity {
+            let user_pred = if users_temporal {
+                "user_id = $user_id".to_string()
+            } else {
+                "user_id = type::thing('all_types_users', $user_id)".to_string()
+            };
+            let post_pred = if posts_temporal {
+                "post_id = $post_id".to_string()
+            } else {
+                "post_id = type::thing('all_types_posts', $post_id)".to_string()
+            };
+            format!(
+                "SELECT * FROM {} WHERE {user_pred} AND {post_pred}",
+                relation.name
+            )
+        } else {
+            format!(
+                "SELECT * FROM {} WHERE in = type::thing('all_types_users', $user_id) AND out = type::thing('all_types_posts', $post_id)",
+                relation.name
+            )
+        };
+        let dump = query_debug_bound(conn, &sql, &user_id, &post_id).await?;
+        assert!(
+            dump.contains(&user_id),
+            "{test_prefix}: relation doc {} missing user endpoint {user_id}: {dump}",
+            doc_idx + 1
+        );
+        assert!(
+            dump.contains(&post_id),
+            "{test_prefix}: relation doc {} missing post endpoint {post_id}: {dump}",
+            doc_idx + 1
+        );
+        if users_temporal {
+            assert!(
+                !dump_has_record_link(&dump, "all_types_users"),
+                "{test_prefix}: FK to temporal users must stay scalar: {dump}"
+            );
+        } else if !demoted_to_entity {
+            assert!(
+                dump_has_record_link(&dump, "all_types_users"),
+                "{test_prefix}: relation doc {} missing in Thing: {dump}",
+                doc_idx + 1
+            );
+        }
+        if posts_temporal {
+            assert!(
+                !dump_has_record_link(&dump, "all_types_posts"),
+                "{test_prefix}: FK to temporal posts must stay scalar: {dump}"
+            );
+        } else if !demoted_to_entity {
+            assert!(
+                dump_has_record_link(&dump, "all_types_posts"),
+                "{test_prefix}: relation doc {} missing out Thing: {dump}",
+                doc_idx + 1
+            );
+        }
+        if expected.contains_key("relationship_created") {
+            assert!(
+                dump.contains("relationship_created"),
+                "{test_prefix}: relation doc {} missing relationship_created: {dump}",
+                doc_idx + 1
+            );
+        }
+    }
+    Ok(())
+}
+
+fn mssql_column_string(doc: &TestDoc, logical: &str) -> Option<String> {
+    match doc.get_field(logical)?.mssql.as_ref()?.column_value {
+        MssqlValue::NVarchar(ref s) | MssqlValue::NText(ref s) | MssqlValue::NChar(ref s) => {
+            Some(s.clone())
+        }
+        _ => None,
+    }
+}
+
+pub fn dump_has_record_link(dump: &str, table: &str) -> bool {
+    dump.contains(&format!("tb: \"{table}\""))
+        || dump.contains(&format!("table: \"{table}\""))
+        || dump.contains(&format!("{table}:"))
+}
+
+fn thing_id_string(value: Option<&SurrealDBValue>) -> Option<String> {
+    match value {
+        Some(SurrealDBValue::Thing { id, .. }) => match id.as_ref() {
+            SurrealDBValue::String(s) => Some(s.clone()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+async fn query_count(
+    conn: &SurrealConnection,
+    sql: &str,
+) -> Result<usize, Box<dyn std::error::Error>> {
+    match conn {
+        SurrealConnection::V2(db) => {
+            let mut r = db.query(sql).await?;
+            let count: Option<i64> = r.take((0, "count"))?;
+            Ok(count.unwrap_or(0) as usize)
+        }
+        SurrealConnection::V3(db) => {
+            let mut r = db.query(sql).await?;
+            let count: Option<i64> = r.take((0, "count"))?;
+            Ok(count.unwrap_or(0) as usize)
+        }
+    }
+}
+
+async fn query_debug_bound(
+    conn: &SurrealConnection,
+    sql: &str,
+    user_id: &str,
+    post_id: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    match conn {
+        SurrealConnection::V2(db) => {
+            let r = db
+                .query(sql)
+                .bind(("user_id", user_id.to_string()))
+                .bind(("post_id", post_id.to_string()))
+                .await?;
+            Ok(format!("{r:?}"))
+        }
+        SurrealConnection::V3(db) => {
+            let r = db
+                .query(sql)
+                .bind(("user_id", user_id.to_string()))
+                .bind(("post_id", post_id.to_string()))
+                .await?;
+            Ok(format!("{r:?}"))
+        }
+    }
+}
+
+/// Qualified names for CLI `--tables`.
+pub fn unified_table_args() -> Vec<String> {
+    vec![
+        "dbo.all_types_users".into(),
+        "dbo.all_types_posts".into(),
+        "dbo.authored_by".into(),
+    ]
+}
+
+pub fn unified_entity_table_args() -> Vec<String> {
+    vec!["dbo.all_types_users".into(), "dbo.all_types_posts".into()]
+}
+
+pub fn unified_surreal_tables() -> &'static [&'static str] {
+    &["all_types_users", "all_types_posts", "authored_by"]
+}
+
+/// Used by temporal lookup; re-exported so surreal.rs can read PK column names.
+pub fn doc_business_pk(doc: &TestDoc) -> Option<(String, String)> {
+    Some((business_pk_column(doc)?, business_pk_value(doc)?))
+}

--- a/src/testing/mysql_e2e.rs
+++ b/src/testing/mysql_e2e.rs
@@ -53,6 +53,7 @@ pub async fn run_full_sync_e2e(
     let sync_opts = surreal_sync_mysql::from_trigger::SyncOpts {
         batch_size: 1000,
         dry_run: false,
+        schemafull: false,
     };
 
     match &conn {
@@ -130,6 +131,7 @@ pub async fn run_incremental_e2e(
     let sync_opts = surreal_sync_mysql::from_trigger::SyncOpts {
         batch_size: 1000,
         dry_run: false,
+        schemafull: false,
     };
 
     let checkpoint_store =

--- a/src/testing/postgresql_pgoutput_e2e.rs
+++ b/src/testing/postgresql_pgoutput_e2e.rs
@@ -78,6 +78,7 @@ pub async fn run_postgresql_pgoutput_full_sync_e2e(
     let sync_opts = SyncOpts {
         batch_size: 1000,
         dry_run: false,
+        schemafull: false,
     };
 
     match &conn {
@@ -137,6 +138,7 @@ pub async fn run_postgresql_pgoutput_incremental_e2e(
     let sync_opts = SyncOpts {
         batch_size: 1000,
         dry_run: false,
+        schemafull: false,
     };
 
     let checkpoint_store =

--- a/src/testing/posts.rs
+++ b/src/testing/posts.rs
@@ -5,6 +5,7 @@
 use crate::testing::{
     field::Field,
     mongodb::MongoDBField,
+    mssql::MssqlField,
     mysql::MySQLField,
     neo4j::bolt,
     neo4j::Neo4jField,
@@ -52,7 +53,8 @@ pub fn create_posts_table() -> TestTable {
                 .with_neo4j(Neo4jField {
                     property_name: "id".to_string(),
                     property_value: bolt::string("post_001"),
-                }),
+                })
+                .with_mssql(MssqlField::nvarchar("post_id", "post_001")),
                 Field::simple(
                     "author_id",
                     SurrealDBValue::Thing {
@@ -83,7 +85,8 @@ pub fn create_posts_table() -> TestTable {
                 .with_neo4j(Neo4jField {
                     property_name: "author_id".to_string(),
                     property_value: bolt::string("user_001"),
-                }),
+                })
+                .with_mssql(MssqlField::nvarchar("author_id", "user_001")),
                 Field::simple(
                     "title",
                     SurrealDBValue::String("Database Testing".to_string()),
@@ -111,7 +114,8 @@ pub fn create_posts_table() -> TestTable {
                 .with_neo4j(Neo4jField {
                     property_name: "title".to_string(),
                     property_value: bolt::string("Database Testing"),
-                }),
+                })
+                .with_mssql(MssqlField::nvarchar("title", "Database Testing")),
                 Field::simple(
                     "content",
                     SurrealDBValue::String(
@@ -149,7 +153,11 @@ pub fn create_posts_table() -> TestTable {
                     property_value: bolt::string(
                         "This post tests complex data types across databases",
                     ),
-                }),
+                })
+                .with_mssql(MssqlField::ntext(
+                    "content",
+                    "This post tests complex data types across databases",
+                )),
                 Field::simple("view_count", SurrealDBValue::Int64(150))
                     .with_postgresql(PostgreSQLField {
                         column_name: "view_count".to_string(),
@@ -174,7 +182,8 @@ pub fn create_posts_table() -> TestTable {
                     .with_neo4j(Neo4jField {
                         property_name: "view_count".to_string(),
                         property_value: bolt::int(150),
-                    }),
+                    })
+                    .with_mssql(MssqlField::bigint("view_count", 150)),
                 Field::simple("published", SurrealDBValue::Bool(true))
                     .with_postgresql(PostgreSQLField {
                         column_name: "published".to_string(),
@@ -199,7 +208,8 @@ pub fn create_posts_table() -> TestTable {
                     .with_neo4j(Neo4jField {
                         property_name: "published".to_string(),
                         property_value: bolt::bool(true),
-                    }),
+                    })
+                    .with_mssql(MssqlField::bit("published", true)),
                 // MongoDB RegularExpression field (database-specific)
                 // MongoDB regex is converted to SurrealDB/Rust regex format: (?flags)pattern
                 Field::simple(
@@ -284,7 +294,8 @@ pub fn create_posts_table() -> TestTable {
                     .with_neo4j(Neo4jField {
                         property_name: "created_at".to_string(),
                         property_value: bolt::datetime(Utc::now()),
-                    }),
+                    })
+                    .with_mssql(MssqlField::datetimeoffset("created_at", Utc::now())),
                 Field::simple("updated_at", SurrealDBValue::DateTime(Utc::now()))
                     .with_postgresql(PostgreSQLField {
                         column_name: "updated_at".to_string(),
@@ -309,7 +320,8 @@ pub fn create_posts_table() -> TestTable {
                     .with_neo4j(Neo4jField {
                         property_name: "updated_at".to_string(),
                         property_value: bolt::datetime(Utc::now()),
-                    }),
+                    })
+                    .with_mssql(MssqlField::datetimeoffset("updated_at", Utc::now())),
             ]),
             // Second post
             TestDoc::new(vec![
@@ -343,7 +355,8 @@ pub fn create_posts_table() -> TestTable {
                 .with_neo4j(Neo4jField {
                     property_name: "id".to_string(),
                     property_value: bolt::string("post_002"),
-                }),
+                })
+                .with_mssql(MssqlField::nvarchar("post_id", "post_002")),
                 Field::simple(
                     "author_id",
                     SurrealDBValue::Thing {
@@ -374,7 +387,8 @@ pub fn create_posts_table() -> TestTable {
                 .with_neo4j(Neo4jField {
                     property_name: "author_id".to_string(),
                     property_value: bolt::string("user_002"),
-                }),
+                })
+                .with_mssql(MssqlField::nvarchar("author_id", "user_002")),
                 Field::simple(
                     "title",
                     SurrealDBValue::String("Advanced Sync Patterns".to_string()),
@@ -402,7 +416,8 @@ pub fn create_posts_table() -> TestTable {
                 .with_neo4j(Neo4jField {
                     property_name: "title".to_string(),
                     property_value: bolt::string("Advanced Sync Patterns"),
-                }),
+                })
+                .with_mssql(MssqlField::nvarchar("title", "Advanced Sync Patterns")),
                 Field::simple(
                     "content",
                     SurrealDBValue::String("Exploring incremental sync strategies".to_string()),
@@ -436,7 +451,11 @@ pub fn create_posts_table() -> TestTable {
                 .with_neo4j(Neo4jField {
                     property_name: "content".to_string(),
                     property_value: bolt::string("Exploring incremental sync strategies"),
-                }),
+                })
+                .with_mssql(MssqlField::ntext(
+                    "content",
+                    "Exploring incremental sync strategies",
+                )),
                 Field::simple("view_count", SurrealDBValue::Int64(89))
                     .with_postgresql(PostgreSQLField {
                         column_name: "view_count".to_string(),
@@ -461,7 +480,8 @@ pub fn create_posts_table() -> TestTable {
                     .with_neo4j(Neo4jField {
                         property_name: "view_count".to_string(),
                         property_value: bolt::int(89),
-                    }),
+                    })
+                    .with_mssql(MssqlField::bigint("view_count", 89)),
                 Field::simple("published", SurrealDBValue::Bool(false))
                     .with_postgresql(PostgreSQLField {
                         column_name: "published".to_string(),
@@ -486,7 +506,8 @@ pub fn create_posts_table() -> TestTable {
                     .with_neo4j(Neo4jField {
                         property_name: "published".to_string(),
                         property_value: bolt::bool(false),
-                    }),
+                    })
+                    .with_mssql(MssqlField::bit("published", false)),
                 // MongoDB RegularExpression field (database-specific)
                 // MongoDB regex is converted to SurrealDB/Rust regex format: (?)pattern for empty flags
                 Field::simple(
@@ -563,7 +584,8 @@ pub fn create_posts_table() -> TestTable {
                     .with_neo4j(Neo4jField {
                         property_name: "created_at".to_string(),
                         property_value: bolt::datetime(Utc::now()),
-                    }),
+                    })
+                    .with_mssql(MssqlField::datetimeoffset("created_at", Utc::now())),
                 Field::simple("updated_at", SurrealDBValue::DateTime(Utc::now()))
                     .with_postgresql(PostgreSQLField {
                         column_name: "updated_at".to_string(),
@@ -588,7 +610,8 @@ pub fn create_posts_table() -> TestTable {
                     .with_neo4j(Neo4jField {
                         property_name: "updated_at".to_string(),
                         property_value: bolt::datetime(Utc::now()),
-                    }),
+                    })
+                    .with_mssql(MssqlField::datetimeoffset("updated_at", Utc::now())),
             ]),
         ],
     )

--- a/src/testing/relations.rs
+++ b/src/testing/relations.rs
@@ -2,6 +2,7 @@
 //!
 //! Defines relationships between tables for graph database testing
 
+use crate::testing::mssql::MssqlField;
 use crate::testing::neo4j::Neo4jField;
 use crate::testing::postgresql::PostgreSQLField;
 use crate::testing::value::PostgreSQLValue;
@@ -9,8 +10,9 @@ use crate::testing::{
     field::Field,
     neo4j::bolt,
     schema::{
-        ColumnDef, IndexDef, MongoDBSchema, MongoIndexDef, MySQLSchema, Neo4jConstraintDef,
-        Neo4jIndexDef, Neo4jIndexType, Neo4jSchema, PostgreSQLSchema, PropertyDef, TestSchema,
+        ColumnDef, ConstraintDef, IndexDef, MongoDBSchema, MongoIndexDef, MssqlSchema, MySQLSchema,
+        Neo4jConstraintDef, Neo4jIndexDef, Neo4jIndexType, Neo4jSchema, PostgreSQLSchema,
+        PropertyDef, TestSchema,
     },
     table::{TestDoc, TestTable},
     value::SurrealDBValue,
@@ -39,7 +41,8 @@ pub fn create_user_post_relation() -> TestTable {
                     data_type: "TEXT".to_string(),
                     precision: None,
                     scale: None,
-                }),
+                })
+                .with_mssql(MssqlField::nvarchar("user_id", "user_001")),
                 Field::simple(
                     "out",
                     SurrealDBValue::Thing {
@@ -53,7 +56,8 @@ pub fn create_user_post_relation() -> TestTable {
                     data_type: "TEXT".to_string(),
                     precision: None,
                     scale: None,
-                }),
+                })
+                .with_mssql(MssqlField::nvarchar("post_id", "post_001")),
                 Field::simple("relationship_created", SurrealDBValue::DateTime(ts))
                     .with_postgresql(PostgreSQLField {
                         column_name: "relationship_created".to_string(),
@@ -65,7 +69,8 @@ pub fn create_user_post_relation() -> TestTable {
                     .with_neo4j(Neo4jField {
                         property_name: "relationship_created".to_string(),
                         property_value: bolt::datetime(ts),
-                    }),
+                    })
+                    .with_mssql(MssqlField::datetimeoffset("relationship_created", ts)),
             ]),
             TestDoc::new(vec![
                 Field::simple(
@@ -81,7 +86,8 @@ pub fn create_user_post_relation() -> TestTable {
                     data_type: "TEXT".to_string(),
                     precision: None,
                     scale: None,
-                }),
+                })
+                .with_mssql(MssqlField::nvarchar("user_id", "user_002")),
                 Field::simple(
                     "out",
                     SurrealDBValue::Thing {
@@ -95,7 +101,8 @@ pub fn create_user_post_relation() -> TestTable {
                     data_type: "TEXT".to_string(),
                     precision: None,
                     scale: None,
-                }),
+                })
+                .with_mssql(MssqlField::nvarchar("post_id", "post_002")),
                 Field::simple("relationship_created", SurrealDBValue::DateTime(ts))
                     .with_postgresql(PostgreSQLField {
                         column_name: "relationship_created".to_string(),
@@ -107,7 +114,8 @@ pub fn create_user_post_relation() -> TestTable {
                     .with_neo4j(Neo4jField {
                         property_name: "relationship_created".to_string(),
                         property_value: bolt::datetime(ts),
-                    }),
+                    })
+                    .with_mssql(MssqlField::datetimeoffset("relationship_created", ts)),
             ]),
         ],
     )
@@ -144,6 +152,32 @@ pub fn authored_by_schema() -> TestSchema {
             engine: "InnoDB".to_string(),
             charset: "utf8mb4".to_string(),
             collation: "utf8mb4_unicode_ci".to_string(),
+        },
+        mssql: MssqlSchema {
+            columns: vec![
+                ColumnDef::new("user_id", "NVARCHAR(255)").not_null(),
+                ColumnDef::new("post_id", "NVARCHAR(255)").not_null(),
+                ColumnDef::new("relationship_created", "DATETIMEOFFSET"),
+            ],
+            primary_key: Some("user_id, post_id".to_string()),
+            indexes: vec![IndexDef::new(
+                "idx_authored_by_user_id",
+                vec!["user_id".to_string()],
+            )],
+            constraints: vec![
+                ConstraintDef::foreign_key(
+                    "FK_authored_users",
+                    vec!["user_id".to_string()],
+                    "[dbo].[all_types_users]",
+                    vec!["user_id".to_string()],
+                ),
+                ConstraintDef::foreign_key(
+                    "FK_authored_posts",
+                    vec!["post_id".to_string()],
+                    "[dbo].[all_types_posts]",
+                    vec!["post_id".to_string()],
+                ),
+            ],
         },
         mongodb: MongoDBSchema {
             collection_name: "authored_by".to_string(),

--- a/src/testing/schema.rs
+++ b/src/testing/schema.rs
@@ -10,6 +10,7 @@ use serde_json::Value as JsonValue;
 pub struct TestSchema {
     pub postgresql: PostgreSQLSchema,
     pub mysql: MySQLSchema,
+    pub mssql: MssqlSchema,
     pub mongodb: MongoDBSchema,
     pub neo4j: Neo4jSchema,
 }
@@ -33,6 +34,15 @@ pub struct MySQLSchema {
     pub engine: String,
     pub charset: String,
     pub collation: String,
+}
+
+/// SQL Server table schema definition
+#[derive(Debug, Clone)]
+pub struct MssqlSchema {
+    pub columns: Vec<ColumnDef>,
+    pub primary_key: Option<String>,
+    pub indexes: Vec<IndexDef>,
+    pub constraints: Vec<ConstraintDef>,
 }
 
 /// MongoDB collection schema definition
@@ -140,6 +150,25 @@ impl ColumnDef {
 
         ddl
     }
+
+    /// Generate SQL Server column definition
+    pub fn to_mssql_ddl(&self) -> String {
+        let mut ddl = format!("[{}] {}", self.name, self.data_type);
+
+        if !self.nullable {
+            ddl.push_str(" NOT NULL");
+        }
+
+        if self.unique {
+            ddl.push_str(" UNIQUE");
+        }
+
+        if let Some(ref default) = self.default {
+            ddl.push_str(&format!(" DEFAULT {default}"));
+        }
+
+        ddl
+    }
 }
 
 /// Index definition for SQL databases
@@ -184,6 +213,63 @@ pub enum ConstraintType {
         on_delete: Option<String>,
         on_update: Option<String>,
     },
+}
+
+impl ConstraintDef {
+    pub fn foreign_key(
+        name: impl Into<String>,
+        columns: Vec<String>,
+        ref_table: impl Into<String>,
+        ref_columns: Vec<String>,
+    ) -> Self {
+        ConstraintDef {
+            name: name.into(),
+            constraint_type: ConstraintType::ForeignKey {
+                columns,
+                ref_table: ref_table.into(),
+                ref_columns,
+                on_delete: None,
+                on_update: None,
+            },
+        }
+    }
+
+    fn to_mssql_ddl(&self) -> String {
+        match &self.constraint_type {
+            ConstraintType::Check(expr) => {
+                format!("CONSTRAINT [{}] CHECK ({expr})", self.name)
+            }
+            ConstraintType::ForeignKey {
+                columns,
+                ref_table,
+                ref_columns,
+                on_delete,
+                on_update,
+            } => {
+                let cols = columns
+                    .iter()
+                    .map(|c| format!("[{c}]"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let refs = ref_columns
+                    .iter()
+                    .map(|c| format!("[{c}]"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let mut ddl = format!(
+                    "CONSTRAINT [{}] FOREIGN KEY ({cols}) REFERENCES {ref_table} ({refs})",
+                    self.name
+                );
+                if let Some(action) = on_delete {
+                    ddl.push_str(&format!(" ON DELETE {action}"));
+                }
+                if let Some(action) = on_update {
+                    ddl.push_str(&format!(" ON UPDATE {action}"));
+                }
+                ddl
+            }
+        }
+    }
 }
 
 /// MongoDB index definition
@@ -408,6 +494,81 @@ impl Default for MySQLSchema {
             engine: "InnoDB".to_string(),
             charset: "utf8mb4".to_string(),
             collation: "utf8mb4_general_ci".to_string(),
+        }
+    }
+}
+
+impl MssqlSchema {
+    /// Generate CREATE TABLE for SQL Server (`dbo.[name]`).
+    ///
+    /// When `temporal` is true, hidden `PERIOD FOR SYSTEM_TIME` columns are
+    /// appended and `SYSTEM_VERSIONING` is turned on.
+    pub fn to_create_table_ddl(&self, table_name: &str, temporal: bool) -> String {
+        let quoted = format!("[dbo].[{table_name}]");
+        let mut ddl = format!("CREATE TABLE {quoted} (\n");
+
+        let mut column_defs: Vec<String> = self
+            .columns
+            .iter()
+            .map(|col| format!("    {}", col.to_mssql_ddl()))
+            .collect();
+
+        if temporal {
+            column_defs.push(
+                "    [ValidFrom] DATETIME2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL"
+                    .to_string(),
+            );
+            column_defs.push(
+                "    [ValidTo] DATETIME2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL".to_string(),
+            );
+        }
+
+        ddl.push_str(&column_defs.join(",\n"));
+
+        if let Some(ref pk) = self.primary_key {
+            let pk_cols = pk
+                .split(',')
+                .map(|c| format!("[{}]", c.trim()))
+                .collect::<Vec<_>>()
+                .join(", ");
+            ddl.push_str(&format!(",\n    PRIMARY KEY ({pk_cols})"));
+        }
+
+        for constraint in &self.constraints {
+            ddl.push_str(&format!(",\n    {}", constraint.to_mssql_ddl()));
+        }
+
+        if temporal {
+            ddl.push_str(",\n    PERIOD FOR SYSTEM_TIME ([ValidFrom], [ValidTo])");
+        }
+
+        ddl.push('\n');
+        ddl.push(')');
+        if temporal {
+            ddl.push_str(&format!(
+                " WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[{table_name}_history]))"
+            ));
+        }
+        ddl
+    }
+
+    pub fn to_create_index_ddl(&self, table_name: &str, index: &IndexDef) -> String {
+        let cols = index
+            .columns
+            .iter()
+            .map(|c| format!("[{c}]"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        if index.unique {
+            format!(
+                "CREATE UNIQUE INDEX [{name}] ON [dbo].[{table_name}] ({cols})",
+                name = index.name
+            )
+        } else {
+            format!(
+                "CREATE INDEX [{name}] ON [dbo].[{table_name}] ({cols})",
+                name = index.name
+            )
         }
     }
 }

--- a/src/testing/schemas_for_tests.rs
+++ b/src/testing/schemas_for_tests.rs
@@ -4,8 +4,9 @@
 //! to enable empty table creation for checkpoint generation.
 
 use crate::testing::schema::{
-    ColumnDef, IndexDef, MongoDBSchema, MongoIndexDef, MySQLSchema, Neo4jConstraintDef,
-    Neo4jIndexDef, Neo4jIndexType, Neo4jSchema, PostgreSQLSchema, PropertyDef, TestSchema,
+    ColumnDef, ConstraintDef, IndexDef, MongoDBSchema, MongoIndexDef, MssqlSchema, MySQLSchema,
+    Neo4jConstraintDef, Neo4jIndexDef, Neo4jIndexType, Neo4jSchema, PostgreSQLSchema, PropertyDef,
+    TestSchema,
 };
 
 /// Create schema for the all_types_users test table
@@ -53,6 +54,31 @@ pub fn create_all_types_users_schema() -> TestSchema {
             engine: "InnoDB".to_string(),
             charset: "utf8mb4".to_string(),
             collation: "utf8mb4_general_ci".to_string(),
+        },
+        mssql: MssqlSchema {
+            columns: vec![
+                ColumnDef::new("user_id", "NVARCHAR(255)").not_null(),
+                ColumnDef::new("name", "NVARCHAR(255)").not_null(),
+                ColumnDef::new("email", "NVARCHAR(255)"),
+                ColumnDef::new("age", "INT"),
+                ColumnDef::new("active", "BIT").default("1"),
+                ColumnDef::new("account_balance", "DECIMAL(19, 5)"),
+                ColumnDef::new("score", "FLOAT"),
+                ColumnDef::new("created_at", "DATETIMEOFFSET").default("SYSDATETIMEOFFSET()"),
+                ColumnDef::new("reference_id", "NVARCHAR(255)"),
+                ColumnDef::new("loyalty_tier", "TINYINT"),
+                ColumnDef::new("wallet_money", "MONEY"),
+                ColumnDef::new("local_created", "DATETIME2"),
+                ColumnDef::new("legacy_guid", "UNIQUEIDENTIFIER"),
+                ColumnDef::new("avatar_blob", "VARBINARY(64)"),
+                ColumnDef::new("profile_xml", "XML"),
+            ],
+            primary_key: Some("user_id".to_string()),
+            indexes: vec![
+                IndexDef::new("idx_users_email", vec!["email".to_string()]).unique(),
+                IndexDef::new("idx_users_active", vec!["active".to_string()]),
+            ],
+            constraints: vec![],
         },
         mongodb: MongoDBSchema {
             collection_name: "all_types_users".to_string(),
@@ -144,6 +170,29 @@ pub fn create_all_types_posts_schema() -> TestSchema {
             engine: "InnoDB".to_string(),
             charset: "utf8mb4".to_string(),
             collation: "utf8mb4_general_ci".to_string(),
+        },
+        mssql: MssqlSchema {
+            columns: vec![
+                ColumnDef::new("post_id", "NVARCHAR(255)").not_null(),
+                ColumnDef::new("title", "NVARCHAR(255)").not_null(),
+                ColumnDef::new("content", "NVARCHAR(MAX)"),
+                ColumnDef::new("author_id", "NVARCHAR(255)").not_null(),
+                ColumnDef::new("published", "BIT").default("0"),
+                ColumnDef::new("view_count", "BIGINT").default("0"),
+                ColumnDef::new("created_at", "DATETIMEOFFSET").default("SYSDATETIMEOFFSET()"),
+                ColumnDef::new("updated_at", "DATETIMEOFFSET"),
+            ],
+            primary_key: Some("post_id".to_string()),
+            indexes: vec![
+                IndexDef::new("idx_posts_author", vec!["author_id".to_string()]),
+                IndexDef::new("idx_posts_published", vec!["published".to_string()]),
+            ],
+            constraints: vec![ConstraintDef::foreign_key(
+                "FK_posts_author",
+                vec!["author_id".to_string()],
+                "[dbo].[all_types_users]",
+                vec!["user_id".to_string()],
+            )],
         },
         mongodb: MongoDBSchema {
             collection_name: "all_types_posts".to_string(),

--- a/src/testing/shared_containers.rs
+++ b/src/testing/shared_containers.rs
@@ -325,5 +325,62 @@ pub async fn shared_neo4j() -> &'static surreal_sync_neo4j_source::testing::cont
     .await
 }
 
+/// Returns a shared SQL Server container (CDC + Agent), starting it on first call.
+///
+/// Running the container accepts Microsoft's EULA
+/// (https://go.microsoft.com/fwlink/?linkid=2143497). Developer edition is for
+/// test only.
+pub async fn shared_mssql() -> &'static surreal_sync_mssql::from_mssql::testing::MssqlContainer {
+    static MS: OnceCell<surreal_sync_mssql::from_mssql::testing::MssqlContainer> =
+        OnceCell::const_new();
+    MS.get_or_init(|| async {
+        let name = format!("shared-mssql-{}", std::process::id());
+        register_container(&name);
+        let mut c = surreal_sync_mssql::from_mssql::testing::MssqlContainer::new(&name);
+        c.start().expect("SQL Server start failed");
+        c.wait_until_ready(180)
+            .await
+            .expect("SQL Server not ready in 180s");
+        c.setup_testdb()
+            .await
+            .expect("SQL Server testdb/CDC setup failed");
+        c
+    })
+    .await
+}
+
+/// Create a fresh SQL Server database with CDC and snapshot isolation, and return its ADO.NET string.
+pub async fn create_mssql_test_db(
+    container: &surreal_sync_mssql::from_mssql::testing::MssqlContainer,
+    test_id: u64,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let db_name = format!("test_{test_id}");
+    let master = container.connection_string_for("master");
+    let client = surreal_sync_mssql::from_mssql::testing::connect(&master).await?;
+    client
+        .simple_query(&format!(
+            "IF DB_ID(N'{db_name}') IS NULL CREATE DATABASE [{db_name}]; \
+             ALTER DATABASE [{db_name}] SET ALLOW_SNAPSHOT_ISOLATION ON;"
+        ))
+        .await?;
+    let conn = container.connection_string_for(&db_name);
+    let db = surreal_sync_mssql::from_mssql::testing::connect(&conn).await?;
+    let mut last_err = None;
+    for _ in 0..40 {
+        match db.simple_query("EXEC sys.sp_cdc_enable_db;").await {
+            Ok(()) => return Ok(conn),
+            Err(e) => {
+                last_err = Some(e);
+                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            }
+        }
+    }
+    Err(format!(
+        "sp_cdc_enable_db failed for `{db_name}`: {}",
+        last_err.map(|e| e.to_string()).unwrap_or_default()
+    )
+    .into())
+}
+
 // Kafka container shared accessor is defined inline in the kafka test binary
 // because the surreal_sync_kafka::producer crate has linking constraints.

--- a/src/testing/surreal.rs
+++ b/src/testing/surreal.rs
@@ -108,6 +108,38 @@ pub async fn assert_synced_auto(
     }
 }
 
+/// Assert synced data, treating listed tables as temporal current versions.
+pub async fn assert_synced_mixed_temporal_auto(
+    conn: &SurrealConnection,
+    dataset: &TestDataSet,
+    test_prefix: &str,
+    source: SourceDatabase,
+    temporal_tables: &[&str],
+) -> Result<(), Box<dyn std::error::Error>> {
+    match conn {
+        SurrealConnection::V2(client) => {
+            surreal2::assert_synced_mixed_temporal(
+                client,
+                dataset,
+                test_prefix,
+                source,
+                temporal_tables,
+            )
+            .await
+        }
+        SurrealConnection::V3(client) => {
+            surreal3::assert_synced_mixed_temporal_v3(
+                client,
+                dataset,
+                test_prefix,
+                source,
+                temporal_tables,
+            )
+            .await
+        }
+    }
+}
+
 /// Get the v2 client from a SurrealConnection
 /// Returns None if the connection is v3
 pub fn as_v2(

--- a/src/testing/surreal2.rs
+++ b/src/testing/surreal2.rs
@@ -242,6 +242,7 @@ pub async fn compare_sync_results_in_surrealdb(
     expected_table: &TestTable,
     test_description: &str,
     source: SourceDatabase,
+    temporal_current: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // First, just validate the count to ensure basic sync worked
     tracing::info!(
@@ -250,7 +251,11 @@ pub async fn compare_sync_results_in_surrealdb(
         table_name
     );
 
-    let count_query = format!("SELECT count() FROM {table_name} GROUP ALL");
+    let count_query = if temporal_current {
+        format!("SELECT count() FROM {table_name} WHERE is_current GROUP ALL")
+    } else {
+        format!("SELECT count() FROM {table_name} GROUP ALL")
+    };
     let mut count_response = surreal.query(count_query).await?;
     let count_result: Option<i64> = count_response.take((0, "count"))?;
     let actual_count = count_result.unwrap_or(0) as usize;
@@ -292,12 +297,49 @@ pub async fn compare_sync_results_in_surrealdb(
         // Get the ID field to query for the specific record
         if let Some(id_field) = expected_doc.get_field("id") {
             if let SurrealDBValue::Thing { table: tb, id } = &id_field.value {
-                let id_value = match id.as_ref() {
-                    SurrealDBValue::String(s) => surrealdb2::sql::Id::String(s.clone()),
-                    SurrealDBValue::Int64(i) => surrealdb2::sql::Id::Number(*i),
-                    _ => return Err("Unsupported ID type in Thing".into()),
+                let record_id = if temporal_current {
+                    let _ = (tb, id);
+                    let (pk_col, pk_val) = crate::testing::mssql::doc_business_pk(expected_doc)
+                        .ok_or_else(|| {
+                            format!(
+                                "{test_description}: temporal document {} is missing an MSSQL PK mapping",
+                                doc_idx + 1
+                            )
+                        })?;
+                    let lookup = format!(
+                        "SELECT id FROM type::table($tb) WHERE is_current AND {pk_col} = $pk"
+                    );
+                    let mut lookup_response = surreal
+                        .query(lookup)
+                        .bind(("tb", table_name.to_string()))
+                        .bind(("pk", pk_val.clone()))
+                        .await?;
+                    let found: Vec<surrealdb2::sql::Thing> =
+                        lookup_response.take((0, "id")).map_err(|e| {
+                            format!(
+                                "{test_description}: failed to look up current version for {pk_col}={pk_val}: {e}"
+                            )
+                        })?;
+                    assert_eq!(
+                        found.len(),
+                        1,
+                        "{}: expected exactly one current version for {}={}, found {} ({:?})",
+                        test_description,
+                        pk_col,
+                        pk_val,
+                        found.len(),
+                        found
+                    );
+                    found.into_iter().next().unwrap()
+                } else {
+                    let id_value = match id.as_ref() {
+                        SurrealDBValue::String(s) => surrealdb2::sql::Id::String(s.clone()),
+                        SurrealDBValue::Int64(i) => surrealdb2::sql::Id::Number(*i),
+                        _ => return Err("Unsupported ID type in Thing".into()),
+                    };
+                    let _ = tb;
+                    surrealdb2::sql::Thing::from((tb.clone(), id_value))
                 };
-                let record_id = surrealdb2::sql::Thing::from((tb.clone(), id_value));
 
                 // For each field in the expected document, query it specifically
                 for (field_name, expected_value) in &expected_surrealdb_data {
@@ -730,8 +772,25 @@ pub async fn compare_sync_results_in_surrealdb(
                                 .query(&query)
                                 .bind(("record_id", record_id.clone()))
                                 .await?;
-                            // Retrieve and validate bytes content
-                            let actual: Vec<u8> = response.take((0, "bytes_field"))?;
+                            let actual_bytes: Option<surrealdb2::sql::Bytes> =
+                                response.take((0, "bytes_field")).map_err(|e| {
+                                    format!(
+                                        "{}: Failed to take bytes field '{}' for document {}: {}",
+                                        test_description,
+                                        field_name,
+                                        doc_idx + 1,
+                                        e
+                                    )
+                                })?;
+                            let actual: Vec<u8> =
+                                actual_bytes.map(|b| b.to_vec()).unwrap_or_else(|| {
+                                    panic!(
+                                        "{}: Document {}, Field '{}' bytes missing",
+                                        test_description,
+                                        doc_idx + 1,
+                                        field_name
+                                    )
+                                });
                             assert_eq!(
                                 actual, *expected_bytes,
                                 "{}: Document {}, Field '{}' bytes mismatch - expected {:?}, found {:?}",
@@ -739,20 +798,48 @@ pub async fn compare_sync_results_in_surrealdb(
                             );
                         }
                         SurrealDBValue::Uuid(expected_uuid) => {
-                            let actual: Option<String> =
-                                field_response.take((0, field_name.as_str())).map_err(|e| {
-                                    format!(
-                                        "{}: Failed to take UUID field '{}' for document {}: {}",
-                                        test_description,
-                                        field_name,
-                                        doc_idx + 1,
-                                        e
-                                    )
-                                })?;
-                            if let Some(actual_str) = actual {
+                            let uuid_query = format!("SELECT {field_name} FROM $record_id");
+                            let mut uuid_response = surreal
+                                .query(&uuid_query)
+                                .bind(("record_id", record_id.clone()))
+                                .await?;
+                            let as_uuid: Result<Option<uuid::Uuid>, _> =
+                                uuid_response.take((0, field_name.as_str()));
+                            if let Ok(Some(actual_uuid)) = as_uuid {
                                 assert_eq!(
-                                    actual_str,
-                                    *expected_uuid,
+                                    actual_uuid.to_string().to_ascii_lowercase(),
+                                    expected_uuid.to_ascii_lowercase(),
+                                    "{}: Document {}, Field '{}' UUID mismatch",
+                                    test_description,
+                                    doc_idx + 1,
+                                    field_name
+                                );
+                            } else {
+                                let mut str_response = surreal
+                                    .query(&uuid_query)
+                                    .bind(("record_id", record_id.clone()))
+                                    .await?;
+                                let actual: Option<String> =
+                                    str_response.take((0, field_name.as_str())).map_err(|e| {
+                                        format!(
+                                            "{}: Failed to take UUID field '{}' for document {}: {}",
+                                            test_description,
+                                            field_name,
+                                            doc_idx + 1,
+                                            e
+                                        )
+                                    })?;
+                                let actual_str = actual.unwrap_or_else(|| {
+                                    panic!(
+                                        "{}: Document {}, Field '{}' UUID missing",
+                                        test_description,
+                                        doc_idx + 1,
+                                        field_name
+                                    )
+                                });
+                                assert_eq!(
+                                    actual_str.to_ascii_lowercase(),
+                                    expected_uuid.to_ascii_lowercase(),
                                     "{}: Document {}, Field '{}' UUID mismatch",
                                     test_description,
                                     doc_idx + 1,
@@ -774,6 +861,38 @@ pub async fn compare_sync_results_in_surrealdb(
                         }
                     }
                 }
+                if temporal_current {
+                    let extra_query =
+                        "SELECT is_current, ValidFrom, ValidTo FROM $record_id".to_string();
+                    let mut extra = surreal
+                        .query(extra_query)
+                        .bind(("record_id", record_id.clone()))
+                        .await?;
+                    let is_current: Option<bool> = extra.take((0, "is_current"))?;
+                    assert_eq!(
+                        is_current,
+                        Some(true),
+                        "{}: Document {}, is_current must be true on the current version",
+                        test_description,
+                        doc_idx + 1
+                    );
+                    let valid_from: Option<chrono::DateTime<chrono::Utc>> =
+                        extra.take((0, "ValidFrom"))?;
+                    let valid_to: Option<chrono::DateTime<chrono::Utc>> =
+                        extra.take((0, "ValidTo"))?;
+                    assert!(
+                        valid_from.is_some(),
+                        "{}: Document {}, period start ValidFrom missing",
+                        test_description,
+                        doc_idx + 1
+                    );
+                    assert!(
+                        valid_to.is_some(),
+                        "{}: Document {}, period end ValidTo missing",
+                        test_description,
+                        doc_idx + 1
+                    );
+                }
             }
         }
     }
@@ -789,6 +908,7 @@ pub async fn validate_synced_table_in_surrealdb(
     expected_table: &TestTable,
     test_description: &str,
     source: SourceDatabase,
+    temporal_current: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Use the existing field-by-field validation approach
     compare_sync_results_in_surrealdb(
@@ -797,6 +917,7 @@ pub async fn validate_synced_table_in_surrealdb(
         expected_table,
         test_description,
         source,
+        temporal_current,
     )
     .await
 }
@@ -820,6 +941,7 @@ pub async fn assert_synced(
             table,
             &format!("{} - {}", test_prefix, table.name),
             source,
+            false,
         )
         .await?;
     }
@@ -832,9 +954,40 @@ pub async fn assert_synced(
                 relation,
                 &format!("{} - {}", test_prefix, relation.name),
                 source,
+                false,
             )
             .await?;
         }
+    }
+
+    Ok(())
+}
+
+/// Like [`assert_synced`], but tables listed in `temporal_tables` are matched
+/// as current system-versioned rows (version record ids, `is_current`, periods).
+pub async fn assert_synced_mixed_temporal(
+    surreal: &Surreal<Any>,
+    dataset: &crate::testing::table::TestDataSet,
+    test_prefix: &str,
+    source: SourceDatabase,
+    temporal_tables: &[&str],
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!("Asserting SurrealDB tables (temporal current versions where marked)...");
+
+    for table in &dataset.tables {
+        let temporal = temporal_tables.iter().any(|n| *n == table.name);
+        tracing::info!(
+            "Validating table '{}' (temporal_current={temporal})",
+            table.name
+        );
+        validate_synced_table_in_surrealdb(
+            surreal,
+            table,
+            &format!("{} - {}", test_prefix, table.name),
+            source,
+            temporal,
+        )
+        .await?;
     }
 
     Ok(())

--- a/src/testing/surreal3.rs
+++ b/src/testing/surreal3.rs
@@ -227,6 +227,7 @@ pub async fn compare_sync_results_in_surrealdb_v3(
     expected_table: &TestTable,
     test_description: &str,
     source: SourceDatabase,
+    temporal_current: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // First, validate the count
     tracing::info!(
@@ -235,7 +236,11 @@ pub async fn compare_sync_results_in_surrealdb_v3(
         table_name
     );
 
-    let count_query = format!("SELECT count() FROM {table_name} GROUP ALL");
+    let count_query = if temporal_current {
+        format!("SELECT count() FROM {table_name} WHERE is_current GROUP ALL")
+    } else {
+        format!("SELECT count() FROM {table_name} GROUP ALL")
+    };
     let mut count_response = surreal.query(count_query).await?;
     let count_result: Option<i64> = count_response.take((0, "count"))?;
     let actual_count = count_result.unwrap_or(0) as usize;
@@ -276,8 +281,44 @@ pub async fn compare_sync_results_in_surrealdb_v3(
         // Get the ID field to query for the specific record
         if let Some(id_field) = expected_doc.get_field("id") {
             if let SurrealDBValue::Thing { table: tb, id } = &id_field.value {
-                let id_key = to_record_id_key(id.as_ref())?;
-                let record_id = RecordId::new(tb.as_str(), id_key);
+                let record_id = if temporal_current {
+                    let _ = (tb, id);
+                    let (pk_col, pk_val) = crate::testing::mssql::doc_business_pk(expected_doc)
+                        .ok_or_else(|| {
+                            format!(
+                                "{test_description}: temporal document {} is missing an MSSQL PK mapping",
+                                doc_idx + 1
+                            )
+                        })?;
+                    let lookup = format!(
+                        "SELECT id FROM type::table($tb) WHERE is_current AND {pk_col} = $pk"
+                    );
+                    let mut lookup_response = surreal
+                        .query(lookup)
+                        .bind(("tb", table_name.to_string()))
+                        .bind(("pk", pk_val.clone()))
+                        .await?;
+                    let found: Vec<RecordId> = lookup_response.take((0, "id")).map_err(|e| {
+                        format!(
+                            "{test_description}: failed to look up current version for {pk_col}={pk_val}: {e}"
+                        )
+                    })?;
+                    assert_eq!(
+                        found.len(),
+                        1,
+                        "{}: expected exactly one current version for {}={}, found {} ({:?})",
+                        test_description,
+                        pk_col,
+                        pk_val,
+                        found.len(),
+                        found
+                    );
+                    found.into_iter().next().unwrap()
+                } else {
+                    let id_key = to_record_id_key(id.as_ref())?;
+                    let _ = tb;
+                    RecordId::new(tb.as_str(), id_key)
+                };
 
                 // For each field in the expected document, query it specifically
                 for (field_name, expected_value) in &expected_surrealdb_data {
@@ -747,20 +788,48 @@ pub async fn compare_sync_results_in_surrealdb_v3(
                             );
                         }
                         SurrealDBValue::Uuid(expected_uuid) => {
-                            let actual: Option<String> =
-                                field_response.take((0, field_name.as_str())).map_err(|e| {
-                                    format!(
-                                        "{}: Failed to take UUID field '{}' for document {}: {}",
-                                        test_description,
-                                        field_name,
-                                        doc_idx + 1,
-                                        e
-                                    )
-                                })?;
-                            if let Some(actual_str) = actual {
+                            let uuid_query = format!("SELECT {field_name} FROM $record_id");
+                            let mut uuid_response = surreal
+                                .query(&uuid_query)
+                                .bind(("record_id", record_id.clone()))
+                                .await?;
+                            let as_uuid: Result<Option<uuid::Uuid>, _> =
+                                uuid_response.take((0, field_name.as_str()));
+                            if let Ok(Some(actual_uuid)) = as_uuid {
                                 assert_eq!(
-                                    actual_str,
-                                    *expected_uuid,
+                                    actual_uuid.to_string().to_ascii_lowercase(),
+                                    expected_uuid.to_ascii_lowercase(),
+                                    "{}: Document {}, Field '{}' UUID mismatch",
+                                    test_description,
+                                    doc_idx + 1,
+                                    field_name
+                                );
+                            } else {
+                                let mut str_response = surreal
+                                    .query(&uuid_query)
+                                    .bind(("record_id", record_id.clone()))
+                                    .await?;
+                                let actual: Option<String> =
+                                    str_response.take((0, field_name.as_str())).map_err(|e| {
+                                        format!(
+                                            "{}: Failed to take UUID field '{}' for document {}: {}",
+                                            test_description,
+                                            field_name,
+                                            doc_idx + 1,
+                                            e
+                                        )
+                                    })?;
+                                let actual_str = actual.unwrap_or_else(|| {
+                                    panic!(
+                                        "{}: Document {}, Field '{}' UUID missing",
+                                        test_description,
+                                        doc_idx + 1,
+                                        field_name
+                                    )
+                                });
+                                assert_eq!(
+                                    actual_str.to_ascii_lowercase(),
+                                    expected_uuid.to_ascii_lowercase(),
                                     "{}: Document {}, Field '{}' UUID mismatch",
                                     test_description,
                                     doc_idx + 1,
@@ -780,6 +849,38 @@ pub async fn compare_sync_results_in_surrealdb_v3(
                         }
                     }
                 }
+                if temporal_current {
+                    let extra_query =
+                        "SELECT is_current, ValidFrom, ValidTo FROM $record_id".to_string();
+                    let mut extra = surreal
+                        .query(extra_query)
+                        .bind(("record_id", record_id.clone()))
+                        .await?;
+                    let is_current: Option<bool> = extra.take((0, "is_current"))?;
+                    assert_eq!(
+                        is_current,
+                        Some(true),
+                        "{}: Document {}, is_current must be true on the current version",
+                        test_description,
+                        doc_idx + 1
+                    );
+                    let valid_from: Option<chrono::DateTime<chrono::Utc>> =
+                        extra.take((0, "ValidFrom"))?;
+                    let valid_to: Option<chrono::DateTime<chrono::Utc>> =
+                        extra.take((0, "ValidTo"))?;
+                    assert!(
+                        valid_from.is_some(),
+                        "{}: Document {}, period start ValidFrom missing",
+                        test_description,
+                        doc_idx + 1
+                    );
+                    assert!(
+                        valid_to.is_some(),
+                        "{}: Document {}, period end ValidTo missing",
+                        test_description,
+                        doc_idx + 1
+                    );
+                }
             }
         }
     }
@@ -795,6 +896,7 @@ pub async fn validate_synced_table_in_surrealdb_v3(
     expected_table: &TestTable,
     test_description: &str,
     source: SourceDatabase,
+    temporal_current: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     compare_sync_results_in_surrealdb_v3(
         surreal,
@@ -802,6 +904,7 @@ pub async fn validate_synced_table_in_surrealdb_v3(
         expected_table,
         test_description,
         source,
+        temporal_current,
     )
     .await
 }
@@ -822,6 +925,7 @@ pub async fn assert_synced_v3(
             table,
             &format!("{} - {}", test_prefix, table.name),
             source,
+            false,
         )
         .await?;
     }
@@ -834,9 +938,40 @@ pub async fn assert_synced_v3(
                 relation,
                 &format!("{} - {}", test_prefix, relation.name),
                 source,
+                false,
             )
             .await?;
         }
+    }
+
+    Ok(())
+}
+
+/// Like [`assert_synced_v3`], but tables listed in `temporal_tables` are matched
+/// as current system-versioned rows (version record ids, `is_current`, periods).
+pub async fn assert_synced_mixed_temporal_v3(
+    surreal: &Surreal<Any>,
+    dataset: &crate::testing::table::TestDataSet,
+    test_prefix: &str,
+    source: SourceDatabase,
+    temporal_tables: &[&str],
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!("Asserting SurrealDB v3 tables (temporal current versions where marked)...");
+
+    for table in &dataset.tables {
+        let temporal = temporal_tables.iter().any(|n| *n == table.name);
+        tracing::info!(
+            "Validating table '{}' (temporal_current={temporal})",
+            table.name
+        );
+        validate_synced_table_in_surrealdb_v3(
+            surreal,
+            table,
+            &format!("{} - {}", test_prefix, table.name),
+            source,
+            temporal,
+        )
+        .await?;
     }
 
     Ok(())

--- a/src/testing/table.rs
+++ b/src/testing/table.rs
@@ -6,7 +6,7 @@
 use crate::testing::{
     field::Field,
     schema::TestSchema,
-    value::{MongoDBValue, MySQLValue, PostgreSQLValue, SurrealDBValue},
+    value::{MongoDBValue, MssqlValue, MySQLValue, PostgreSQLValue, SurrealDBValue},
 };
 use std::collections::HashMap;
 
@@ -17,6 +17,7 @@ pub enum SourceDatabase {
     MySQL,
     PostgreSQL,
     Neo4j,
+    Mssql,
     CSV,
     JSONL,
     Kafka,
@@ -76,6 +77,18 @@ impl TestDoc {
         doc
     }
 
+    /// Get SQL Server representation of this document
+    /// Only includes fields that have explicit MSSQL definitions
+    pub fn to_mssql_doc(&self) -> HashMap<String, MssqlValue> {
+        let mut doc = HashMap::new();
+        for field in &self.fields {
+            if let Some(mssql) = &field.mssql {
+                doc.insert(mssql.column_name.clone(), mssql.column_value.clone());
+            }
+        }
+        doc
+    }
+
     /// Get Neo4j representation of this document
     /// Only includes fields that have explicit Neo4j definitions
     pub fn to_neo4j_doc(&self) -> HashMap<String, neo4rs::BoltType> {
@@ -111,6 +124,7 @@ impl TestDoc {
                 SourceDatabase::MySQL => field.mysql.is_some(),
                 SourceDatabase::PostgreSQL => field.postgresql.is_some(),
                 SourceDatabase::Neo4j => field.neo4j.is_some(),
+                SourceDatabase::Mssql => field.mssql.is_some(),
                 // For sources without field-level definitions (CSV, JSONL, Kafka),
                 // only include fields that have definitions for multiple databases
                 // (i.e., not single-database-specific fields). This filters out
@@ -122,6 +136,7 @@ impl TestDoc {
                         field.mysql.is_some(),
                         field.postgresql.is_some(),
                         field.neo4j.is_some(),
+                        field.mssql.is_some(),
                     ]
                     .iter()
                     .filter(|&&b| b)
@@ -220,6 +235,14 @@ impl TestTable {
         self.documents
             .iter()
             .map(|doc| doc.to_mysql_doc())
+            .collect()
+    }
+
+    /// Get all documents as SQL Server representation
+    pub fn to_mssql_docs(&self) -> Vec<HashMap<String, MssqlValue>> {
+        self.documents
+            .iter()
+            .map(|doc| doc.to_mssql_doc())
             .collect()
     }
 

--- a/src/testing/users.rs
+++ b/src/testing/users.rs
@@ -5,6 +5,7 @@
 use crate::testing::{
     field::Field,
     mongodb::MongoDBField,
+    mssql::MssqlField,
     mysql::MySQLField,
     neo4j::bolt,
     neo4j::Neo4jField,
@@ -12,8 +13,9 @@ use crate::testing::{
     table::{TestDoc, TestTable},
     value::{MongoDBValue, MySQLValue, PostgreSQLValue, SurrealDBValue},
 };
-use chrono::Utc;
+use chrono::{NaiveDate, NaiveTime, Utc};
 use std::collections::HashMap;
+use uuid::Uuid;
 
 /// Create the users table with type coverage
 pub fn create_users_table() -> TestTable {
@@ -54,7 +56,8 @@ pub fn create_users_table() -> TestTable {
                 .with_neo4j(Neo4jField {
                     property_name: "id".to_string(),
                     property_value: bolt::string("user_001"),
-                }),
+                })
+                .with_mssql(MssqlField::nvarchar("user_id", "user_001")),
                 // High-precision decimal with different precision per database
                 Field::simple(
                     "account_balance",
@@ -95,7 +98,8 @@ pub fn create_users_table() -> TestTable {
                 .with_neo4j(Neo4jField {
                     property_name: "account_balance".to_string(),
                     property_value: bolt::float(12345.67890),
-                }),
+                })
+                .with_mssql(MssqlField::decimal("account_balance", "12345.67890", 19, 5)),
                 // Complex Object field with database-specific representations
                 Field::simple(
                     "metadata",
@@ -259,7 +263,11 @@ pub fn create_users_table() -> TestTable {
                 .with_neo4j(Neo4jField {
                     property_name: "reference_id".to_string(),
                     property_value: bolt::string("507f1f77bcf86cd799439011"),
-                }),
+                })
+                .with_mssql(MssqlField::nvarchar(
+                    "reference_id",
+                    "507f1f77bcf86cd799439011",
+                )),
                 // Common fields with explicit definitions for all databases
                 Field::simple("name", SurrealDBValue::String("Alice Smith".to_string()))
                     .with_postgresql(PostgreSQLField {
@@ -285,7 +293,8 @@ pub fn create_users_table() -> TestTable {
                     .with_neo4j(Neo4jField {
                         property_name: "name".to_string(),
                         property_value: bolt::string("Alice Smith"),
-                    }),
+                    })
+                    .with_mssql(MssqlField::nvarchar("name", "Alice Smith")),
                 Field::simple(
                     "email",
                     SurrealDBValue::String("alice@example.com".to_string()),
@@ -313,7 +322,8 @@ pub fn create_users_table() -> TestTable {
                 .with_neo4j(Neo4jField {
                     property_name: "email".to_string(),
                     property_value: bolt::string("alice@example.com"),
-                }),
+                })
+                .with_mssql(MssqlField::nvarchar("email", "alice@example.com")),
                 Field::simple("age", SurrealDBValue::Int32(30))
                     .with_postgresql(PostgreSQLField {
                         column_name: "age".to_string(),
@@ -338,7 +348,8 @@ pub fn create_users_table() -> TestTable {
                     .with_neo4j(Neo4jField {
                         property_name: "age".to_string(),
                         property_value: bolt::int(30),
-                    }),
+                    })
+                    .with_mssql(MssqlField::int("age", 30)),
                 Field::simple("active", SurrealDBValue::Bool(true))
                     .with_postgresql(PostgreSQLField {
                         column_name: "active".to_string(),
@@ -363,7 +374,8 @@ pub fn create_users_table() -> TestTable {
                     .with_neo4j(Neo4jField {
                         property_name: "active".to_string(),
                         property_value: bolt::bool(true),
-                    }),
+                    })
+                    .with_mssql(MssqlField::bit("active", true)),
                 Field::simple("created_at", SurrealDBValue::DateTime(Utc::now()))
                     .with_postgresql(PostgreSQLField {
                         column_name: "created_at".to_string(),
@@ -388,7 +400,8 @@ pub fn create_users_table() -> TestTable {
                     .with_neo4j(Neo4jField {
                         property_name: "created_at".to_string(),
                         property_value: bolt::datetime(Utc::now()),
-                    }),
+                    })
+                    .with_mssql(MssqlField::datetimeoffset("created_at", Utc::now())),
                 Field::simple("score", SurrealDBValue::Float64(95.7))
                     .with_postgresql(PostgreSQLField {
                         column_name: "score".to_string(),
@@ -413,7 +426,50 @@ pub fn create_users_table() -> TestTable {
                     .with_neo4j(Neo4jField {
                         property_name: "score".to_string(),
                         property_value: bolt::float(95.7),
-                    }),
+                    })
+                    .with_mssql(MssqlField::float("score", 95.7)),
+                Field::simple("loyalty_tier", SurrealDBValue::Int32(3))
+                    .with_mssql(MssqlField::tinyint("loyalty_tier", 3)),
+                Field::simple(
+                    "wallet_money",
+                    SurrealDBValue::Decimal {
+                        value: "12.3400".to_string(),
+                        precision: Some(19),
+                        scale: Some(4),
+                    },
+                )
+                .with_mssql(MssqlField::money("wallet_money", "12.3400")),
+                Field::simple(
+                    "local_created",
+                    SurrealDBValue::DateTime(
+                        NaiveDate::from_ymd_opt(2024, 1, 15)
+                            .unwrap()
+                            .and_time(NaiveTime::from_hms_opt(10, 30, 0).unwrap())
+                            .and_utc(),
+                    ),
+                )
+                .with_mssql(MssqlField::datetime2(
+                    "local_created",
+                    NaiveDate::from_ymd_opt(2024, 1, 15)
+                        .unwrap()
+                        .and_hms_opt(10, 30, 0)
+                        .unwrap(),
+                )),
+                Field::simple(
+                    "legacy_guid",
+                    SurrealDBValue::Uuid("550e8400-e29b-41d4-a716-446655440000".to_string()),
+                )
+                .with_mssql(MssqlField::uniqueidentifier(
+                    "legacy_guid",
+                    Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap(),
+                )),
+                Field::simple("avatar_blob", SurrealDBValue::Bytes(vec![0x01, 0x02, 0x03, 0x04]))
+                    .with_mssql(MssqlField::varbinary("avatar_blob", vec![0x01, 0x02, 0x03, 0x04])),
+                Field::simple(
+                    "profile_xml",
+                    SurrealDBValue::String("<root>alice</root>".to_string()),
+                )
+                .with_mssql(MssqlField::xml("profile_xml", "<root>alice</root>")),
             ]),
             // Second user with different values
             TestDoc::new(vec![
@@ -447,7 +503,8 @@ pub fn create_users_table() -> TestTable {
                 .with_neo4j(Neo4jField {
                     property_name: "id".to_string(),
                     property_value: bolt::string("user_002"),
-                }),
+                })
+                .with_mssql(MssqlField::nvarchar("user_id", "user_002")),
                 Field::simple(
                     "account_balance",
                     SurrealDBValue::Decimal {
@@ -487,7 +544,8 @@ pub fn create_users_table() -> TestTable {
                 .with_neo4j(Neo4jField {
                     property_name: "account_balance".to_string(),
                     property_value: bolt::float(98765.43210),
-                }),
+                })
+                .with_mssql(MssqlField::decimal("account_balance", "98765.43210", 19, 5)),
                 Field::simple(
                     "metadata",
                     SurrealDBValue::Object(HashMap::from([
@@ -631,7 +689,11 @@ pub fn create_users_table() -> TestTable {
                 .with_neo4j(Neo4jField {
                     property_name: "reference_id".to_string(),
                     property_value: bolt::string("507f191e810c19729de860ea"),
-                }),
+                })
+                .with_mssql(MssqlField::nvarchar(
+                    "reference_id",
+                    "507f191e810c19729de860ea",
+                )),
                 // Common fields with complete database definitions
                 Field::simple("name", SurrealDBValue::String("Bob Johnson".to_string()))
                     .with_postgresql(PostgreSQLField {
@@ -657,7 +719,8 @@ pub fn create_users_table() -> TestTable {
                     .with_neo4j(Neo4jField {
                         property_name: "name".to_string(),
                         property_value: bolt::string("Bob Johnson"),
-                    }),
+                    })
+                    .with_mssql(MssqlField::nvarchar("name", "Bob Johnson")),
                 Field::simple(
                     "email",
                     SurrealDBValue::String("bob@example.com".to_string()),
@@ -685,7 +748,8 @@ pub fn create_users_table() -> TestTable {
                 .with_neo4j(Neo4jField {
                     property_name: "email".to_string(),
                     property_value: bolt::string("bob@example.com"),
-                }),
+                })
+                .with_mssql(MssqlField::nvarchar("email", "bob@example.com")),
                 Field::simple("age", SurrealDBValue::Int32(25))
                     .with_postgresql(PostgreSQLField {
                         column_name: "age".to_string(),
@@ -710,7 +774,8 @@ pub fn create_users_table() -> TestTable {
                     .with_neo4j(Neo4jField {
                         property_name: "age".to_string(),
                         property_value: bolt::int(25),
-                    }),
+                    })
+                    .with_mssql(MssqlField::int("age", 25)),
                 Field::simple("active", SurrealDBValue::Bool(false))
                     .with_postgresql(PostgreSQLField {
                         column_name: "active".to_string(),
@@ -735,7 +800,8 @@ pub fn create_users_table() -> TestTable {
                     .with_neo4j(Neo4jField {
                         property_name: "active".to_string(),
                         property_value: bolt::bool(false),
-                    }),
+                    })
+                    .with_mssql(MssqlField::bit("active", false)),
                 Field::simple("created_at", SurrealDBValue::DateTime(Utc::now()))
                     .with_postgresql(PostgreSQLField {
                         column_name: "created_at".to_string(),
@@ -760,7 +826,8 @@ pub fn create_users_table() -> TestTable {
                     .with_neo4j(Neo4jField {
                         property_name: "created_at".to_string(),
                         property_value: bolt::datetime(Utc::now()),
-                    }),
+                    })
+                    .with_mssql(MssqlField::datetimeoffset("created_at", Utc::now())),
                 Field::simple("score", SurrealDBValue::Float64(87.3))
                     .with_postgresql(PostgreSQLField {
                         column_name: "score".to_string(),
@@ -785,7 +852,50 @@ pub fn create_users_table() -> TestTable {
                     .with_neo4j(Neo4jField {
                         property_name: "score".to_string(),
                         property_value: bolt::float(87.3),
-                    }),
+                    })
+                    .with_mssql(MssqlField::float("score", 87.3)),
+                Field::simple("loyalty_tier", SurrealDBValue::Int32(1))
+                    .with_mssql(MssqlField::tinyint("loyalty_tier", 1)),
+                Field::simple(
+                    "wallet_money",
+                    SurrealDBValue::Decimal {
+                        value: "99.9900".to_string(),
+                        precision: Some(19),
+                        scale: Some(4),
+                    },
+                )
+                .with_mssql(MssqlField::money("wallet_money", "99.9900")),
+                Field::simple(
+                    "local_created",
+                    SurrealDBValue::DateTime(
+                        NaiveDate::from_ymd_opt(2024, 6, 1)
+                            .unwrap()
+                            .and_time(NaiveTime::from_hms_opt(8, 0, 0).unwrap())
+                            .and_utc(),
+                    ),
+                )
+                .with_mssql(MssqlField::datetime2(
+                    "local_created",
+                    NaiveDate::from_ymd_opt(2024, 6, 1)
+                        .unwrap()
+                        .and_hms_opt(8, 0, 0)
+                        .unwrap(),
+                )),
+                Field::simple(
+                    "legacy_guid",
+                    SurrealDBValue::Uuid("6ba7b810-9dad-11d1-80b4-00c04fd430c8".to_string()),
+                )
+                .with_mssql(MssqlField::uniqueidentifier(
+                    "legacy_guid",
+                    Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap(),
+                )),
+                Field::simple("avatar_blob", SurrealDBValue::Bytes(vec![0xaa, 0xbb, 0xcc]))
+                    .with_mssql(MssqlField::varbinary("avatar_blob", vec![0xaa, 0xbb, 0xcc])),
+                Field::simple(
+                    "profile_xml",
+                    SurrealDBValue::String("<root>bob</root>".to_string()),
+                )
+                .with_mssql(MssqlField::xml("profile_xml", "<root>bob</root>")),
             ]),
         ],
     )

--- a/src/testing/value.rs
+++ b/src/testing/value.rs
@@ -6,6 +6,7 @@
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use std::collections::HashMap;
 use std::fmt;
+use uuid::Uuid;
 
 /// SurrealDB value types - what we expect in SurrealDB after sync
 #[derive(Debug, Clone, PartialEq)]
@@ -175,6 +176,33 @@ pub enum MySQLValue {
     Bit(Vec<bool>),
     Json(serde_json::Value),
     Geometry(String),
+}
+
+/// SQL Server value types — native representations for types surreal-sync copies.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MssqlValue {
+    Null,
+    Bit(bool),
+    TinyInt(u8),
+    SmallInt(i16),
+    Int(i32),
+    BigInt(i64),
+    Real(f32),
+    Float(f64),
+    Decimal {
+        value: String,
+        precision: Option<u32>,
+        scale: Option<u32>,
+    },
+    Money(String),
+    NChar(String),
+    NVarchar(String),
+    NText(String),
+    Xml(String),
+    VarBinary(Vec<u8>),
+    UniqueIdentifier(Uuid),
+    DateTime2(NaiveDateTime),
+    DateTimeOffset(DateTime<Utc>),
 }
 
 /// Neo4j value types - native Neo4j/Cypher representations

--- a/tests/loadtest/mysql_incremental_loadtest.rs
+++ b/tests/loadtest/mysql_incremental_loadtest.rs
@@ -107,6 +107,7 @@ async fn test_mysql_incremental_loadtest_small_scale() -> Result<(), Box<dyn std
     let sync_opts = surreal_sync_mysql::from_trigger::SyncOpts {
         batch_size: BATCH_SIZE,
         dry_run: false,
+        schemafull: false,
     };
 
     // Create sync manager with filesystem checkpoint store

--- a/tests/loadtest/mysql_loadtest.rs
+++ b/tests/loadtest/mysql_loadtest.rs
@@ -116,6 +116,7 @@ async fn test_mysql_loadtest_small_scale() -> Result<(), Box<dyn std::error::Err
     let sync_opts = surreal_sync_mysql::from_trigger::SyncOpts {
         batch_size: BATCH_SIZE,
         dry_run: false,
+        schemafull: false,
     };
 
     // Create version-aware sink and run sync

--- a/tests/loadtest/postgresql_incremental_loadtest.rs
+++ b/tests/loadtest/postgresql_incremental_loadtest.rs
@@ -114,6 +114,7 @@ async fn test_postgresql_incremental_loadtest_small_scale() -> Result<(), Box<dy
     let sync_opts = surreal_sync_postgresql::SyncOpts {
         batch_size: BATCH_SIZE,
         dry_run: false,
+        schemafull: false,
     };
 
     // Create sync manager with filesystem checkpoint store

--- a/tests/loadtest/postgresql_loadtest.rs
+++ b/tests/loadtest/postgresql_loadtest.rs
@@ -118,6 +118,7 @@ async fn test_postgresql_loadtest_small_scale() -> Result<(), Box<dyn std::error
     let sync_opts = surreal_sync_postgresql::SyncOpts {
         batch_size: BATCH_SIZE,
         dry_run: false,
+        schemafull: false,
     };
 
     // Create version-appropriate sink and run sync

--- a/tests/mssql/common.rs
+++ b/tests/mssql/common.rs
@@ -1,0 +1,142 @@
+//! Shared helpers for SQL Server e2e tests.
+
+use surreal_sync::testing::surreal::SurrealConnection;
+use surreal_sync::testing::TestConfig;
+use surreal_sync_core::ZeroTemporalPolicy;
+use surreal_sync_mssql::from_mssql::cli::{SnapshotModeArg, SyncArgs, SyncStrategy};
+use surreal_sync_runtime::{SinkConnect, SurrealCliOpts};
+
+pub fn surreal_opts(endpoint: &str) -> SurrealCliOpts {
+    SurrealCliOpts {
+        surreal_endpoint: endpoint.to_string(),
+        surreal_username: "root".into(),
+        surreal_password: "root".into(),
+        batch_size: 1000,
+        dry_run: false,
+        surreal_sdk_version: None,
+        zero_temporal: ZeroTemporalPolicy::default(),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn sync_args(
+    connection_string: String,
+    tables: Vec<String>,
+    config: &TestConfig,
+    snapshot_mode: SnapshotModeArg,
+    strategy: SyncStrategy,
+    checkpoint_dir: Option<String>,
+    schemafull: bool,
+    timeout: Option<String>,
+    relation_tables: Vec<String>,
+) -> SyncArgs {
+    SyncArgs {
+        connection_string,
+        tables,
+        relation_tables,
+        to_namespace: config.surreal_namespace.clone(),
+        to_database: config.surreal_database.clone(),
+        snapshot_mode,
+        timeout,
+        strategy,
+        chunk_size: 32,
+        checkpoint_dir,
+        checkpoints_surreal_table: None,
+        transforms_config: None,
+        schemafull,
+        surreal: surreal_opts(&config.surreal_endpoint),
+    }
+}
+
+pub async fn exec_sql(conn: &str, sql: &str) -> anyhow::Result<()> {
+    let client = surreal_sync_mssql::from_mssql::testing::connect(conn).await?;
+    client.simple_query(sql).await?;
+    Ok(())
+}
+
+pub async fn run_mssql_sync(args: SyncArgs) -> anyhow::Result<()> {
+    let (pipeline, apply_opts) =
+        surreal_sync_runtime::load_transforms_from_args(args.transforms_config.as_deref())?;
+    let http = args
+        .surreal
+        .surreal_endpoint
+        .replace("ws://", "http://")
+        .replace("wss://", "https://");
+    let detected = surreal_sync_surreal::version::detect_server_version(&http).await?;
+    let config = args
+        .surreal
+        .to_config(args.to_namespace.clone(), args.to_database.clone());
+    match detected {
+        surreal_sync_surreal::version::SurrealMajorVersion::V2 => {
+            let sink = surreal_sync_surreal::v2::Surreal2Sink::connect(&config).await?;
+            surreal_sync_mssql::from_mssql::cli::run_sync(args, &sink, pipeline, apply_opts).await
+        }
+        surreal_sync_surreal::version::SurrealMajorVersion::V3 => {
+            let sink = surreal_sync_surreal::v3::Surreal3Sink::connect(&config).await?;
+            surreal_sync_mssql::from_mssql::cli::run_sync(args, &sink, pipeline, apply_opts).await
+        }
+    }
+}
+
+pub async fn query_debug(
+    conn: &SurrealConnection,
+    sql: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    match conn {
+        SurrealConnection::V2(db) => {
+            let r = db.query(sql).await?;
+            Ok(format!("{r:?}"))
+        }
+        SurrealConnection::V3(db) => {
+            let r = db.query(sql).await?;
+            Ok(format!("{r:?}"))
+        }
+    }
+}
+
+pub fn ordinary_schema_sql() -> &'static str {
+    r#"
+CREATE TABLE dbo.users (
+  id INT NOT NULL PRIMARY KEY,
+  name NVARCHAR(64) NOT NULL
+);
+CREATE UNIQUE INDEX UX_users_name ON dbo.users(name);
+CREATE TABLE dbo.posts (
+  id INT NOT NULL PRIMARY KEY,
+  user_id INT NOT NULL,
+  title NVARCHAR(128) NOT NULL,
+  CONSTRAINT FK_posts_users FOREIGN KEY (user_id) REFERENCES dbo.users(id)
+);
+CREATE TABLE dbo.authored (
+  user_id INT NOT NULL,
+  post_id INT NOT NULL,
+  PRIMARY KEY (user_id, post_id),
+  CONSTRAINT FK_authored_users FOREIGN KEY (user_id) REFERENCES dbo.users(id),
+  CONSTRAINT FK_authored_posts FOREIGN KEY (post_id) REFERENCES dbo.posts(id)
+);
+INSERT INTO dbo.users (id, name) VALUES (1, N'alice'), (2, N'bob');
+INSERT INTO dbo.posts (id, user_id, title) VALUES (10, 1, N'hello'), (11, 2, N'world');
+INSERT INTO dbo.authored (user_id, post_id) VALUES (1, 10), (2, 11);
+"#
+}
+
+pub fn temporal_schema_sql() -> &'static str {
+    r#"
+CREATE TABLE dbo.Article (
+  Id INT NOT NULL PRIMARY KEY,
+  Title NVARCHAR(128) NOT NULL,
+  ValidFrom DATETIME2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
+  ValidTo DATETIME2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+  PERIOD FOR SYSTEM_TIME (ValidFrom, ValidTo)
+) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = dbo.ArticleHistory));
+CREATE TABLE dbo.Comment (
+  Id INT NOT NULL PRIMARY KEY,
+  ArticleId INT NOT NULL,
+  Body NVARCHAR(256) NOT NULL,
+  CONSTRAINT FK_comment_article FOREIGN KEY (ArticleId) REFERENCES dbo.Article(Id)
+);
+INSERT INTO dbo.Article (Id, Title) VALUES (1, N'first');
+UPDATE dbo.Article SET Title = N'second' WHERE Id = 1;
+INSERT INTO dbo.Comment (Id, ArticleId, Body) VALUES (1, 1, N'note');
+"#
+}

--- a/tests/mssql/common.rs
+++ b/tests/mssql/common.rs
@@ -54,6 +54,12 @@ pub async fn exec_sql(conn: &str, sql: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+pub async fn mssql_client(
+    conn: &str,
+) -> Result<surreal_sync_mssql::from_mssql::testing::MssqlClient, Box<dyn std::error::Error>> {
+    Ok(surreal_sync_mssql::from_mssql::testing::connect(conn).await?)
+}
+
 pub async fn run_mssql_sync(args: SyncArgs) -> anyhow::Result<()> {
     let (pipeline, apply_opts) =
         surreal_sync_runtime::load_transforms_from_args(args.transforms_config.as_deref())?;
@@ -92,51 +98,4 @@ pub async fn query_debug(
             Ok(format!("{r:?}"))
         }
     }
-}
-
-pub fn ordinary_schema_sql() -> &'static str {
-    r#"
-CREATE TABLE dbo.users (
-  id INT NOT NULL PRIMARY KEY,
-  name NVARCHAR(64) NOT NULL
-);
-CREATE UNIQUE INDEX UX_users_name ON dbo.users(name);
-CREATE TABLE dbo.posts (
-  id INT NOT NULL PRIMARY KEY,
-  user_id INT NOT NULL,
-  title NVARCHAR(128) NOT NULL,
-  CONSTRAINT FK_posts_users FOREIGN KEY (user_id) REFERENCES dbo.users(id)
-);
-CREATE TABLE dbo.authored (
-  user_id INT NOT NULL,
-  post_id INT NOT NULL,
-  PRIMARY KEY (user_id, post_id),
-  CONSTRAINT FK_authored_users FOREIGN KEY (user_id) REFERENCES dbo.users(id),
-  CONSTRAINT FK_authored_posts FOREIGN KEY (post_id) REFERENCES dbo.posts(id)
-);
-INSERT INTO dbo.users (id, name) VALUES (1, N'alice'), (2, N'bob');
-INSERT INTO dbo.posts (id, user_id, title) VALUES (10, 1, N'hello'), (11, 2, N'world');
-INSERT INTO dbo.authored (user_id, post_id) VALUES (1, 10), (2, 11);
-"#
-}
-
-pub fn temporal_schema_sql() -> &'static str {
-    r#"
-CREATE TABLE dbo.Article (
-  Id INT NOT NULL PRIMARY KEY,
-  Title NVARCHAR(128) NOT NULL,
-  ValidFrom DATETIME2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
-  ValidTo DATETIME2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
-  PERIOD FOR SYSTEM_TIME (ValidFrom, ValidTo)
-) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = dbo.ArticleHistory));
-CREATE TABLE dbo.Comment (
-  Id INT NOT NULL PRIMARY KEY,
-  ArticleId INT NOT NULL,
-  Body NVARCHAR(256) NOT NULL,
-  CONSTRAINT FK_comment_article FOREIGN KEY (ArticleId) REFERENCES dbo.Article(Id)
-);
-INSERT INTO dbo.Article (Id, Title) VALUES (1, N'first');
-UPDATE dbo.Article SET Title = N'second' WHERE Id = 1;
-INSERT INTO dbo.Comment (Id, ArticleId, Body) VALUES (1, 1, N'note');
-"#
 }

--- a/tests/mssql/main.rs
+++ b/tests/mssql/main.rs
@@ -1,0 +1,7 @@
+mod common;
+mod mssql_schemafull_lib;
+mod mssql_sequential_lib;
+mod mssql_sync_cli;
+mod mssql_sync_lib;
+mod mssql_temporal_lib;
+mod mssql_transforms_config_cli;

--- a/tests/mssql/mssql_schemafull_lib.rs
+++ b/tests/mssql/mssql_schemafull_lib.rs
@@ -1,11 +1,15 @@
 //! `--schemafull` emits DEFINE TABLE/INDEX; default stays schemaless.
 
 use surreal_sync::testing::checkpoint::cleanup_checkpoint_dir;
-use surreal_sync::testing::surreal::{cleanup_auto, connect_auto};
-use surreal_sync::testing::{generate_test_id, TestConfig};
+use surreal_sync::testing::mssql::{
+    assert_synced_mssql_temporal, cleanup_unified_dataset_tables, create_tables_and_indices,
+    insert_rows, unified_table_args,
+};
+use surreal_sync::testing::surreal::{cleanup_surrealdb_auto, connect_auto};
+use surreal_sync::testing::{create_unified_full_dataset, generate_test_id, TestConfig};
 use surreal_sync_mssql::from_mssql::cli::{SnapshotModeArg, SyncStrategy};
 
-use crate::common::{exec_sql, query_debug, run_mssql_sync, sync_args, temporal_schema_sql};
+use crate::common::{mssql_client, query_debug, run_mssql_sync, sync_args};
 
 #[tokio::test]
 async fn test_mssql_schemafull_emits_define_default_does_not(
@@ -19,22 +23,13 @@ async fn test_mssql_schemafull_emits_define_default_does_not(
     let test_id = generate_test_id();
     let conn_str =
         surreal_sync::testing::shared_containers::create_mssql_test_db(container, test_id).await?;
-    exec_sql(
-        &conn_str,
-        &format!(
-            "{}\n{}",
-            r#"
-CREATE TABLE dbo.users (
-  id INT NOT NULL PRIMARY KEY,
-  name NVARCHAR(64) NOT NULL
-);
-CREATE UNIQUE INDEX UX_users_name ON dbo.users(name);
-INSERT INTO dbo.users (id, name) VALUES (1, N'alice');
-"#,
-            temporal_schema_sql()
-        ),
-    )
-    .await?;
+    let client = mssql_client(&conn_str).await?;
+
+    // Ordinary users (unique email index) + temporal posts (cookbook indexes).
+    let dataset = create_unified_full_dataset();
+    cleanup_unified_dataset_tables(&client).await?;
+    create_tables_and_indices(&client, &dataset, &["all_types_posts"]).await?;
+    insert_rows(&client, &dataset).await?;
 
     let surrealdb = surreal_sync::testing::shared_containers::shared_surrealdb();
     let full_config = TestConfig::with_surreal_endpoint(test_id, &surrealdb.ws_endpoint());
@@ -44,14 +39,11 @@ INSERT INTO dbo.users (id, name) VALUES (1, N'alice');
 
     let full = connect_auto(&full_config).await?;
     let sl = connect_auto(&schemaless_config).await?;
-    cleanup_auto(&full, &["users", "Article", "Comment"]).await?;
-    cleanup_auto(&sl, &["users", "Article", "Comment"]).await?;
+    cleanup_surrealdb_auto(&full, &dataset).await?;
+    cleanup_surrealdb_auto(&sl, &dataset).await?;
 
-    let tables = vec![
-        "dbo.users".into(),
-        "dbo.Article".into(),
-        "dbo.Comment".into(),
-    ];
+    let tables = unified_table_args();
+    let relations = vec!["authored_by".into()];
 
     let checkpoint_full = format!(".test-mssql-schemafull-{test_id}");
     let checkpoint_sl = format!(".test-mssql-schemaless-{test_id}");
@@ -67,7 +59,7 @@ INSERT INTO dbo.users (id, name) VALUES (1, N'alice');
         Some(checkpoint_full.clone()),
         true,
         None,
-        vec![],
+        relations.clone(),
     ))
     .await?;
 
@@ -80,35 +72,50 @@ INSERT INTO dbo.users (id, name) VALUES (1, N'alice');
         Some(checkpoint_sl.clone()),
         false,
         None,
-        vec![],
+        relations,
     ))
     .await?;
 
-    let users_info = query_debug(&full, "INFO FOR TABLE users").await?;
+    assert_synced_mssql_temporal(
+        &full,
+        &dataset,
+        "MSSQL schemafull content",
+        &["all_types_posts"],
+    )
+    .await?;
+    assert_synced_mssql_temporal(
+        &sl,
+        &dataset,
+        "MSSQL schemaless content",
+        &["all_types_posts"],
+    )
+    .await?;
+
+    let users_info = query_debug(&full, "INFO FOR TABLE all_types_users").await?;
     assert!(
-        users_info.contains("UX_users_name") || users_info.contains("UNIQUE"),
+        users_info.contains("idx_users_email") || users_info.contains("UNIQUE"),
         "ordinary unique index missing under --schemafull: {users_info}"
     );
 
-    let article_info = query_debug(&full, "INFO FOR TABLE Article").await?;
+    let posts_info = query_debug(&full, "INFO FOR TABLE all_types_posts").await?;
     assert!(
-        article_info.contains("is_current"),
-        "temporal cookbook index missing: {article_info}"
+        posts_info.contains("is_current"),
+        "temporal cookbook index missing: {posts_info}"
     );
     assert!(
-        !article_info.to_ascii_uppercase().contains("UNIQUE") || !article_info.contains("Id"),
-        "must not copy source UNIQUE/PK onto unified temporal table: {article_info}"
+        !posts_info.to_ascii_uppercase().contains("UNIQUE") || !posts_info.contains("post_id"),
+        "must not copy source UNIQUE/PK onto unified temporal table: {posts_info}"
     );
 
-    let sl_users = query_debug(&sl, "INFO FOR TABLE users").await?;
+    let sl_users = query_debug(&sl, "INFO FOR TABLE all_types_users").await?;
     assert!(
-        !sl_users.contains("UX_users_name"),
+        !sl_users.contains("idx_users_email"),
         "default run must not copy indexes: {sl_users}"
     );
-    let sl_article = query_debug(&sl, "INFO FOR TABLE Article").await?;
+    let sl_posts = query_debug(&sl, "INFO FOR TABLE all_types_posts").await?;
     assert!(
-        !sl_article.contains("Article_is_current"),
-        "default run must not emit cookbook indexes: {sl_article}"
+        !sl_posts.contains("all_types_posts_is_current"),
+        "default run must not emit cookbook indexes: {sl_posts}"
     );
 
     cleanup_checkpoint_dir(&checkpoint_full)?;

--- a/tests/mssql/mssql_schemafull_lib.rs
+++ b/tests/mssql/mssql_schemafull_lib.rs
@@ -1,0 +1,117 @@
+//! `--schemafull` emits DEFINE TABLE/INDEX; default stays schemaless.
+
+use surreal_sync::testing::checkpoint::cleanup_checkpoint_dir;
+use surreal_sync::testing::surreal::{cleanup_auto, connect_auto};
+use surreal_sync::testing::{generate_test_id, TestConfig};
+use surreal_sync_mssql::from_mssql::cli::{SnapshotModeArg, SyncStrategy};
+
+use crate::common::{exec_sql, query_debug, run_mssql_sync, sync_args, temporal_schema_sql};
+
+#[tokio::test]
+async fn test_mssql_schemafull_emits_define_default_does_not(
+) -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter("surreal_sync=info")
+        .try_init()
+        .ok();
+
+    let container = surreal_sync::testing::shared_containers::shared_mssql().await;
+    let test_id = generate_test_id();
+    let conn_str =
+        surreal_sync::testing::shared_containers::create_mssql_test_db(container, test_id).await?;
+    exec_sql(
+        &conn_str,
+        &format!(
+            "{}\n{}",
+            r#"
+CREATE TABLE dbo.users (
+  id INT NOT NULL PRIMARY KEY,
+  name NVARCHAR(64) NOT NULL
+);
+CREATE UNIQUE INDEX UX_users_name ON dbo.users(name);
+INSERT INTO dbo.users (id, name) VALUES (1, N'alice');
+"#,
+            temporal_schema_sql()
+        ),
+    )
+    .await?;
+
+    let surrealdb = surreal_sync::testing::shared_containers::shared_surrealdb();
+    let full_config = TestConfig::with_surreal_endpoint(test_id, &surrealdb.ws_endpoint());
+    let mut schemaless_config = full_config.clone();
+    schemaless_config.surreal_namespace = format!("test_ns_sl_{test_id}");
+    schemaless_config.surreal_database = format!("test_db_sl_{test_id}");
+
+    let full = connect_auto(&full_config).await?;
+    let sl = connect_auto(&schemaless_config).await?;
+    cleanup_auto(&full, &["users", "Article", "Comment"]).await?;
+    cleanup_auto(&sl, &["users", "Article", "Comment"]).await?;
+
+    let tables = vec![
+        "dbo.users".into(),
+        "dbo.Article".into(),
+        "dbo.Comment".into(),
+    ];
+
+    let checkpoint_full = format!(".test-mssql-schemafull-{test_id}");
+    let checkpoint_sl = format!(".test-mssql-schemaless-{test_id}");
+    cleanup_checkpoint_dir(&checkpoint_full)?;
+    cleanup_checkpoint_dir(&checkpoint_sl)?;
+
+    run_mssql_sync(sync_args(
+        conn_str.clone(),
+        tables.clone(),
+        &full_config,
+        SnapshotModeArg::Only,
+        SyncStrategy::InterleavedSnapshot,
+        Some(checkpoint_full.clone()),
+        true,
+        None,
+        vec![],
+    ))
+    .await?;
+
+    run_mssql_sync(sync_args(
+        conn_str,
+        tables,
+        &schemaless_config,
+        SnapshotModeArg::Only,
+        SyncStrategy::InterleavedSnapshot,
+        Some(checkpoint_sl.clone()),
+        false,
+        None,
+        vec![],
+    ))
+    .await?;
+
+    let users_info = query_debug(&full, "INFO FOR TABLE users").await?;
+    assert!(
+        users_info.contains("UX_users_name") || users_info.contains("UNIQUE"),
+        "ordinary unique index missing under --schemafull: {users_info}"
+    );
+
+    let article_info = query_debug(&full, "INFO FOR TABLE Article").await?;
+    assert!(
+        article_info.contains("is_current"),
+        "temporal cookbook index missing: {article_info}"
+    );
+    assert!(
+        !article_info.to_ascii_uppercase().contains("UNIQUE") || !article_info.contains("Id"),
+        "must not copy source UNIQUE/PK onto unified temporal table: {article_info}"
+    );
+
+    let sl_users = query_debug(&sl, "INFO FOR TABLE users").await?;
+    assert!(
+        !sl_users.contains("UX_users_name"),
+        "default run must not copy indexes: {sl_users}"
+    );
+    let sl_article = query_debug(&sl, "INFO FOR TABLE Article").await?;
+    assert!(
+        !sl_article.contains("Article_is_current"),
+        "default run must not emit cookbook indexes: {sl_article}"
+    );
+
+    cleanup_checkpoint_dir(&checkpoint_full)?;
+    cleanup_checkpoint_dir(&checkpoint_sl)?;
+    Ok(())
+}

--- a/tests/mssql/mssql_sequential_lib.rs
+++ b/tests/mssql/mssql_sequential_lib.rs
@@ -1,0 +1,95 @@
+//! Sequential SNAPSHOT-isolation dump, and the disabled-isolation error.
+
+use surreal_sync::testing::checkpoint::cleanup_checkpoint_dir;
+use surreal_sync::testing::surreal::{cleanup_auto, connect_auto};
+use surreal_sync::testing::{generate_test_id, TestConfig};
+use surreal_sync_mssql::from_mssql::cli::{SnapshotModeArg, SyncStrategy};
+
+use crate::common::{exec_sql, ordinary_schema_sql, query_debug, run_mssql_sync, sync_args};
+
+#[tokio::test]
+async fn test_mssql_sequential_snapshot_lib() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter("surreal_sync=info")
+        .try_init()
+        .ok();
+
+    let container = surreal_sync::testing::shared_containers::shared_mssql().await;
+    let test_id = generate_test_id();
+    let conn_str =
+        surreal_sync::testing::shared_containers::create_mssql_test_db(container, test_id).await?;
+    exec_sql(&conn_str, ordinary_schema_sql()).await?;
+
+    let surrealdb = surreal_sync::testing::shared_containers::shared_surrealdb();
+    let config = TestConfig::with_surreal_endpoint(test_id, &surrealdb.ws_endpoint());
+    let surreal = connect_auto(&config).await?;
+    cleanup_auto(&surreal, &["users", "posts", "authored"]).await?;
+
+    let checkpoint_dir = format!(".test-mssql-sequential-{test_id}");
+    cleanup_checkpoint_dir(&checkpoint_dir)?;
+
+    let args = sync_args(
+        conn_str,
+        vec!["dbo.users".into(), "dbo.posts".into()],
+        &config,
+        SnapshotModeArg::Only,
+        SyncStrategy::SequentialSnapshot,
+        Some(checkpoint_dir.clone()),
+        false,
+        None,
+        vec![],
+    );
+    run_mssql_sync(args).await?;
+
+    let users = query_debug(&surreal, "SELECT * FROM users").await?;
+    assert!(users.contains("alice"), "{users}");
+    let posts = query_debug(&surreal, "SELECT * FROM posts").await?;
+    assert!(posts.contains("hello"), "{posts}");
+
+    cleanup_checkpoint_dir(&checkpoint_dir)?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_mssql_sequential_snapshot_isolation_disabled(
+) -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter("surreal_sync=info")
+        .try_init()
+        .ok();
+
+    let container = surreal_sync::testing::shared_containers::shared_mssql().await;
+    let test_id = generate_test_id();
+    let db_name = format!("nosnap_{test_id}");
+    let master = container.connection_string_for("master");
+    exec_sql(
+        &master,
+        &format!("IF DB_ID(N'{db_name}') IS NULL CREATE DATABASE [{db_name}];"),
+    )
+    .await?;
+    let conn_str = container.connection_string_for(&db_name);
+
+    let surrealdb = surreal_sync::testing::shared_containers::shared_surrealdb();
+    let config = TestConfig::with_surreal_endpoint(test_id, &surrealdb.ws_endpoint());
+
+    let args = sync_args(
+        conn_str,
+        vec![],
+        &config,
+        SnapshotModeArg::Only,
+        SyncStrategy::SequentialSnapshot,
+        None,
+        false,
+        None,
+        vec![],
+    );
+    let err = run_mssql_sync(args)
+        .await
+        .expect_err("sequential dump must fail when snapshot isolation is off");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("ALTER DATABASE") && msg.contains("ALLOW_SNAPSHOT_ISOLATION ON"),
+        "expected copy-paste T-SQL, got: {msg}"
+    );
+    Ok(())
+}

--- a/tests/mssql/mssql_sequential_lib.rs
+++ b/tests/mssql/mssql_sequential_lib.rs
@@ -1,11 +1,15 @@
 //! Sequential SNAPSHOT-isolation dump, and the disabled-isolation error.
 
 use surreal_sync::testing::checkpoint::cleanup_checkpoint_dir;
-use surreal_sync::testing::surreal::{cleanup_auto, connect_auto};
-use surreal_sync::testing::{generate_test_id, TestConfig};
+use surreal_sync::testing::mssql::{
+    assert_synced_mssql, cleanup_unified_dataset_tables, create_tables_and_indices, insert_rows,
+    unified_table_args,
+};
+use surreal_sync::testing::surreal::{cleanup_surrealdb_auto, connect_auto};
+use surreal_sync::testing::{create_unified_full_dataset, generate_test_id, TestConfig};
 use surreal_sync_mssql::from_mssql::cli::{SnapshotModeArg, SyncStrategy};
 
-use crate::common::{exec_sql, ordinary_schema_sql, query_debug, run_mssql_sync, sync_args};
+use crate::common::{exec_sql, mssql_client, run_mssql_sync, sync_args};
 
 #[tokio::test]
 async fn test_mssql_sequential_snapshot_lib() -> Result<(), Box<dyn std::error::Error>> {
@@ -18,33 +22,35 @@ async fn test_mssql_sequential_snapshot_lib() -> Result<(), Box<dyn std::error::
     let test_id = generate_test_id();
     let conn_str =
         surreal_sync::testing::shared_containers::create_mssql_test_db(container, test_id).await?;
-    exec_sql(&conn_str, ordinary_schema_sql()).await?;
+    let client = mssql_client(&conn_str).await?;
+
+    let dataset = create_unified_full_dataset();
+    cleanup_unified_dataset_tables(&client).await?;
+    create_tables_and_indices(&client, &dataset, &[]).await?;
+    insert_rows(&client, &dataset).await?;
 
     let surrealdb = surreal_sync::testing::shared_containers::shared_surrealdb();
     let config = TestConfig::with_surreal_endpoint(test_id, &surrealdb.ws_endpoint());
     let surreal = connect_auto(&config).await?;
-    cleanup_auto(&surreal, &["users", "posts", "authored"]).await?;
+    cleanup_surrealdb_auto(&surreal, &dataset).await?;
 
     let checkpoint_dir = format!(".test-mssql-sequential-{test_id}");
     cleanup_checkpoint_dir(&checkpoint_dir)?;
 
     let args = sync_args(
         conn_str,
-        vec!["dbo.users".into(), "dbo.posts".into()],
+        unified_table_args(),
         &config,
         SnapshotModeArg::Only,
         SyncStrategy::SequentialSnapshot,
         Some(checkpoint_dir.clone()),
         false,
         None,
-        vec![],
+        vec!["authored_by".into()],
     );
     run_mssql_sync(args).await?;
 
-    let users = query_debug(&surreal, "SELECT * FROM users").await?;
-    assert!(users.contains("alice"), "{users}");
-    let posts = query_debug(&surreal, "SELECT * FROM posts").await?;
-    assert!(posts.contains("hello"), "{posts}");
+    assert_synced_mssql(&surreal, &dataset, "MSSQL sequential snapshot").await?;
 
     cleanup_checkpoint_dir(&checkpoint_dir)?;
     Ok(())

--- a/tests/mssql/mssql_sync_cli.rs
+++ b/tests/mssql/mssql_sync_cli.rs
@@ -1,0 +1,60 @@
+//! CLI e2e: `from mssql sync --snapshot-mode only`.
+
+use surreal_sync::testing::cli::{assert_cli_success, execute_surreal_sync};
+use surreal_sync::testing::surreal::{cleanup_auto, connect_auto};
+use surreal_sync::testing::{generate_test_id, TestConfig};
+
+use crate::common::{exec_sql, ordinary_schema_sql, query_debug};
+
+#[tokio::test]
+async fn test_mssql_sync_snapshot_only_cli() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter("surreal_sync=info")
+        .try_init()
+        .ok();
+
+    let container = surreal_sync::testing::shared_containers::shared_mssql().await;
+    let test_id = generate_test_id();
+    let conn_str =
+        surreal_sync::testing::shared_containers::create_mssql_test_db(container, test_id).await?;
+    exec_sql(&conn_str, ordinary_schema_sql()).await?;
+
+    let surrealdb = surreal_sync::testing::shared_containers::shared_surrealdb();
+    let config = TestConfig::with_surreal_endpoint(test_id, &surrealdb.ws_endpoint());
+    let surreal = connect_auto(&config).await?;
+    cleanup_auto(&surreal, &["users", "posts", "authored"]).await?;
+
+    let args = [
+        "from",
+        "mssql",
+        "sync",
+        "--snapshot-mode",
+        "only",
+        "--connection-string",
+        &conn_str,
+        "--tables",
+        "dbo.users,dbo.posts,dbo.authored",
+        "--relation-tables",
+        "authored",
+        "--surreal-endpoint",
+        &config.surreal_endpoint,
+        "--to-namespace",
+        &config.surreal_namespace,
+        "--to-database",
+        &config.surreal_database,
+        "--surreal-username",
+        "root",
+        "--surreal-password",
+        "root",
+        "--chunk-size",
+        "32",
+    ];
+    let output = execute_surreal_sync(&args)?;
+    assert_cli_success(&output, "from mssql sync snapshot-only");
+
+    let users = query_debug(&surreal, "SELECT * FROM users").await?;
+    assert!(users.contains("alice"), "{users}");
+    let posts = query_debug(&surreal, "SELECT * FROM posts").await?;
+    assert!(posts.contains("hello"), "{posts}");
+    Ok(())
+}

--- a/tests/mssql/mssql_sync_cli.rs
+++ b/tests/mssql/mssql_sync_cli.rs
@@ -1,10 +1,14 @@
-//! CLI e2e: `from mssql sync --snapshot-mode only`.
+//! CLI e2e: `from mssql sync --snapshot-mode only` with the unified dataset.
 
 use surreal_sync::testing::cli::{assert_cli_success, execute_surreal_sync};
-use surreal_sync::testing::surreal::{cleanup_auto, connect_auto};
-use surreal_sync::testing::{generate_test_id, TestConfig};
+use surreal_sync::testing::mssql::{
+    assert_synced_mssql, cleanup_unified_dataset_tables, create_tables_and_indices, insert_rows,
+    unified_table_args,
+};
+use surreal_sync::testing::surreal::{cleanup_surrealdb_auto, connect_auto};
+use surreal_sync::testing::{create_unified_full_dataset, generate_test_id, TestConfig};
 
-use crate::common::{exec_sql, ordinary_schema_sql, query_debug};
+use crate::common::mssql_client;
 
 #[tokio::test]
 async fn test_mssql_sync_snapshot_only_cli() -> Result<(), Box<dyn std::error::Error>> {
@@ -17,13 +21,19 @@ async fn test_mssql_sync_snapshot_only_cli() -> Result<(), Box<dyn std::error::E
     let test_id = generate_test_id();
     let conn_str =
         surreal_sync::testing::shared_containers::create_mssql_test_db(container, test_id).await?;
-    exec_sql(&conn_str, ordinary_schema_sql()).await?;
+    let client = mssql_client(&conn_str).await?;
+
+    let dataset = create_unified_full_dataset();
+    cleanup_unified_dataset_tables(&client).await?;
+    create_tables_and_indices(&client, &dataset, &[]).await?;
+    insert_rows(&client, &dataset).await?;
 
     let surrealdb = surreal_sync::testing::shared_containers::shared_surrealdb();
     let config = TestConfig::with_surreal_endpoint(test_id, &surrealdb.ws_endpoint());
     let surreal = connect_auto(&config).await?;
-    cleanup_auto(&surreal, &["users", "posts", "authored"]).await?;
+    cleanup_surrealdb_auto(&surreal, &dataset).await?;
 
+    let tables = unified_table_args().join(",");
     let args = [
         "from",
         "mssql",
@@ -33,9 +43,9 @@ async fn test_mssql_sync_snapshot_only_cli() -> Result<(), Box<dyn std::error::E
         "--connection-string",
         &conn_str,
         "--tables",
-        "dbo.users,dbo.posts,dbo.authored",
+        &tables,
         "--relation-tables",
-        "authored",
+        "authored_by",
         "--surreal-endpoint",
         &config.surreal_endpoint,
         "--to-namespace",
@@ -52,9 +62,6 @@ async fn test_mssql_sync_snapshot_only_cli() -> Result<(), Box<dyn std::error::E
     let output = execute_surreal_sync(&args)?;
     assert_cli_success(&output, "from mssql sync snapshot-only");
 
-    let users = query_debug(&surreal, "SELECT * FROM users").await?;
-    assert!(users.contains("alice"), "{users}");
-    let posts = query_debug(&surreal, "SELECT * FROM posts").await?;
-    assert!(posts.contains("hello"), "{posts}");
+    assert_synced_mssql(&surreal, &dataset, "MSSQL full sync CLI").await?;
     Ok(())
 }

--- a/tests/mssql/mssql_sync_lib.rs
+++ b/tests/mssql/mssql_sync_lib.rs
@@ -1,11 +1,15 @@
-//! Interleaved watermark snapshot + CDC tail (library).
+//! Interleaved watermark snapshot + CDC tail (library) on the unified dataset.
 
 use surreal_sync::testing::checkpoint::cleanup_checkpoint_dir;
-use surreal_sync::testing::surreal::{cleanup_auto, connect_auto};
-use surreal_sync::testing::{generate_test_id, TestConfig};
+use surreal_sync::testing::mssql::{
+    assert_synced_mssql, cleanup_unified_dataset_tables, create_tables_and_indices, insert_rows,
+    unified_table_args,
+};
+use surreal_sync::testing::surreal::{cleanup_surrealdb_auto, connect_auto};
+use surreal_sync::testing::{create_unified_full_dataset, generate_test_id, TestConfig};
 use surreal_sync_mssql::from_mssql::cli::{SnapshotModeArg, SyncStrategy};
 
-use crate::common::{exec_sql, ordinary_schema_sql, query_debug, run_mssql_sync, sync_args};
+use crate::common::{exec_sql, mssql_client, query_debug, run_mssql_sync, sync_args};
 
 #[tokio::test]
 async fn test_mssql_interleaved_snapshot_and_tail_lib() -> Result<(), Box<dyn std::error::Error>> {
@@ -18,79 +22,67 @@ async fn test_mssql_interleaved_snapshot_and_tail_lib() -> Result<(), Box<dyn st
     let test_id = generate_test_id();
     let conn_str =
         surreal_sync::testing::shared_containers::create_mssql_test_db(container, test_id).await?;
-    exec_sql(&conn_str, ordinary_schema_sql()).await?;
+    let client = mssql_client(&conn_str).await?;
+
+    let dataset = create_unified_full_dataset();
+    cleanup_unified_dataset_tables(&client).await?;
+    create_tables_and_indices(&client, &dataset, &[]).await?;
+    insert_rows(&client, &dataset).await?;
 
     let surrealdb = surreal_sync::testing::shared_containers::shared_surrealdb();
     let config = TestConfig::with_surreal_endpoint(test_id, &surrealdb.ws_endpoint());
     let surreal = connect_auto(&config).await?;
-    cleanup_auto(&surreal, &["users", "posts", "authored"]).await?;
+    cleanup_surrealdb_auto(&surreal, &dataset).await?;
 
     let checkpoint_dir = format!(".test-mssql-sync-lib-{test_id}");
     cleanup_checkpoint_dir(&checkpoint_dir)?;
 
     let args = sync_args(
         conn_str.clone(),
-        vec![
-            "dbo.users".into(),
-            "dbo.posts".into(),
-            "dbo.authored".into(),
-        ],
+        unified_table_args(),
         &config,
         SnapshotModeArg::Only,
         SyncStrategy::InterleavedSnapshot,
         Some(checkpoint_dir.clone()),
         false,
         None,
-        vec!["authored".into()],
+        vec!["authored_by".into()],
     );
     run_mssql_sync(args).await?;
 
-    let users = query_debug(&surreal, "SELECT * FROM users").await?;
-    assert!(users.contains("alice"), "{users}");
-    assert!(users.contains("bob"), "{users}");
-    let posts = query_debug(&surreal, "SELECT * FROM posts").await?;
-    assert!(posts.contains("hello"), "{posts}");
-    assert!(
-        posts.contains("users") || posts.contains("user_id"),
-        "FK to users should be a record link: {posts}"
-    );
-    let authored = query_debug(&surreal, "SELECT * FROM authored").await?;
-    assert!(
-        !authored.trim().is_empty(),
-        "expected relation rows: {authored}"
-    );
+    assert_synced_mssql(&surreal, &dataset, "MSSQL interleaved snapshot").await?;
 
     exec_sql(
         &conn_str,
-        "INSERT INTO dbo.users (id, name) VALUES (3, N'carol'); \
-         UPDATE dbo.posts SET title = N'updated' WHERE id = 10; \
-         DELETE FROM dbo.authored WHERE post_id = 11; \
-         DELETE FROM dbo.posts WHERE id = 11;",
+        "INSERT INTO dbo.all_types_users (user_id, name, email) \
+         VALUES (N'user_003', N'Carol Lee', N'carol@example.com'); \
+         UPDATE dbo.all_types_posts SET title = N'updated' WHERE post_id = N'post_001'; \
+         DELETE FROM dbo.authored_by WHERE post_id = N'post_002'; \
+         DELETE FROM dbo.all_types_posts WHERE post_id = N'post_002';",
     )
     .await?;
 
     let tail = sync_args(
         conn_str,
-        vec![
-            "dbo.users".into(),
-            "dbo.posts".into(),
-            "dbo.authored".into(),
-        ],
+        unified_table_args(),
         &config,
         SnapshotModeArg::Never,
         SyncStrategy::InterleavedSnapshot,
         Some(checkpoint_dir.clone()),
         false,
         Some("20s".into()),
-        vec!["authored".into()],
+        vec!["authored_by".into()],
     );
     run_mssql_sync(tail).await?;
 
-    let users = query_debug(&surreal, "SELECT * FROM users").await?;
-    assert!(users.contains("carol"), "CDC insert missing: {users}");
-    let posts = query_debug(&surreal, "SELECT * FROM posts").await?;
+    let users = query_debug(&surreal, "SELECT * FROM all_types_users").await?;
+    assert!(users.contains("Carol Lee"), "CDC insert missing: {users}");
+    let posts = query_debug(&surreal, "SELECT * FROM all_types_posts").await?;
     assert!(posts.contains("updated"), "CDC update missing: {posts}");
-    assert!(!posts.contains("world"), "CDC delete missing: {posts}");
+    assert!(
+        !posts.contains("Advanced Sync Patterns"),
+        "CDC delete missing: {posts}"
+    );
 
     cleanup_checkpoint_dir(&checkpoint_dir)?;
     Ok(())

--- a/tests/mssql/mssql_sync_lib.rs
+++ b/tests/mssql/mssql_sync_lib.rs
@@ -1,0 +1,97 @@
+//! Interleaved watermark snapshot + CDC tail (library).
+
+use surreal_sync::testing::checkpoint::cleanup_checkpoint_dir;
+use surreal_sync::testing::surreal::{cleanup_auto, connect_auto};
+use surreal_sync::testing::{generate_test_id, TestConfig};
+use surreal_sync_mssql::from_mssql::cli::{SnapshotModeArg, SyncStrategy};
+
+use crate::common::{exec_sql, ordinary_schema_sql, query_debug, run_mssql_sync, sync_args};
+
+#[tokio::test]
+async fn test_mssql_interleaved_snapshot_and_tail_lib() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter("surreal_sync=info")
+        .try_init()
+        .ok();
+
+    let container = surreal_sync::testing::shared_containers::shared_mssql().await;
+    let test_id = generate_test_id();
+    let conn_str =
+        surreal_sync::testing::shared_containers::create_mssql_test_db(container, test_id).await?;
+    exec_sql(&conn_str, ordinary_schema_sql()).await?;
+
+    let surrealdb = surreal_sync::testing::shared_containers::shared_surrealdb();
+    let config = TestConfig::with_surreal_endpoint(test_id, &surrealdb.ws_endpoint());
+    let surreal = connect_auto(&config).await?;
+    cleanup_auto(&surreal, &["users", "posts", "authored"]).await?;
+
+    let checkpoint_dir = format!(".test-mssql-sync-lib-{test_id}");
+    cleanup_checkpoint_dir(&checkpoint_dir)?;
+
+    let args = sync_args(
+        conn_str.clone(),
+        vec![
+            "dbo.users".into(),
+            "dbo.posts".into(),
+            "dbo.authored".into(),
+        ],
+        &config,
+        SnapshotModeArg::Only,
+        SyncStrategy::InterleavedSnapshot,
+        Some(checkpoint_dir.clone()),
+        false,
+        None,
+        vec!["authored".into()],
+    );
+    run_mssql_sync(args).await?;
+
+    let users = query_debug(&surreal, "SELECT * FROM users").await?;
+    assert!(users.contains("alice"), "{users}");
+    assert!(users.contains("bob"), "{users}");
+    let posts = query_debug(&surreal, "SELECT * FROM posts").await?;
+    assert!(posts.contains("hello"), "{posts}");
+    assert!(
+        posts.contains("users") || posts.contains("user_id"),
+        "FK to users should be a record link: {posts}"
+    );
+    let authored = query_debug(&surreal, "SELECT * FROM authored").await?;
+    assert!(
+        !authored.trim().is_empty(),
+        "expected relation rows: {authored}"
+    );
+
+    exec_sql(
+        &conn_str,
+        "INSERT INTO dbo.users (id, name) VALUES (3, N'carol'); \
+         UPDATE dbo.posts SET title = N'updated' WHERE id = 10; \
+         DELETE FROM dbo.authored WHERE post_id = 11; \
+         DELETE FROM dbo.posts WHERE id = 11;",
+    )
+    .await?;
+
+    let tail = sync_args(
+        conn_str,
+        vec![
+            "dbo.users".into(),
+            "dbo.posts".into(),
+            "dbo.authored".into(),
+        ],
+        &config,
+        SnapshotModeArg::Never,
+        SyncStrategy::InterleavedSnapshot,
+        Some(checkpoint_dir.clone()),
+        false,
+        Some("20s".into()),
+        vec!["authored".into()],
+    );
+    run_mssql_sync(tail).await?;
+
+    let users = query_debug(&surreal, "SELECT * FROM users").await?;
+    assert!(users.contains("carol"), "CDC insert missing: {users}");
+    let posts = query_debug(&surreal, "SELECT * FROM posts").await?;
+    assert!(posts.contains("updated"), "CDC update missing: {posts}");
+    assert!(!posts.contains("world"), "CDC delete missing: {posts}");
+
+    cleanup_checkpoint_dir(&checkpoint_dir)?;
+    Ok(())
+}

--- a/tests/mssql/mssql_temporal_lib.rs
+++ b/tests/mssql/mssql_temporal_lib.rs
@@ -1,11 +1,15 @@
-//! Temporal UNION ALL snapshot + live UPDATE versions (library).
+//! Temporal UNION ALL snapshot + live UPDATE versions on unified users.
 
 use surreal_sync::testing::checkpoint::cleanup_checkpoint_dir;
-use surreal_sync::testing::surreal::{cleanup_auto, connect_auto};
-use surreal_sync::testing::{generate_test_id, TestConfig};
+use surreal_sync::testing::mssql::{
+    assert_synced_mssql_temporal, cleanup_unified_dataset_tables, create_tables_and_indices,
+    insert_rows, unified_table_args,
+};
+use surreal_sync::testing::surreal::{cleanup_surrealdb_auto, connect_auto};
+use surreal_sync::testing::{create_unified_full_dataset, generate_test_id, TestConfig};
 use surreal_sync_mssql::from_mssql::cli::{SnapshotModeArg, SyncStrategy};
 
-use crate::common::{exec_sql, query_debug, run_mssql_sync, sync_args, temporal_schema_sql};
+use crate::common::{exec_sql, mssql_client, query_debug, run_mssql_sync, sync_args};
 
 #[tokio::test]
 async fn test_mssql_temporal_versions_and_scalar_fk_lib() -> Result<(), Box<dyn std::error::Error>>
@@ -19,80 +23,86 @@ async fn test_mssql_temporal_versions_and_scalar_fk_lib() -> Result<(), Box<dyn 
     let test_id = generate_test_id();
     let conn_str =
         surreal_sync::testing::shared_containers::create_mssql_test_db(container, test_id).await?;
-    exec_sql(&conn_str, temporal_schema_sql()).await?;
+    let client = mssql_client(&conn_str).await?;
+
+    let dataset = create_unified_full_dataset();
+    cleanup_unified_dataset_tables(&client).await?;
+    create_tables_and_indices(&client, &dataset, &["all_types_users"]).await?;
+    insert_rows(&client, &dataset).await?;
 
     let surrealdb = surreal_sync::testing::shared_containers::shared_surrealdb();
     let config = TestConfig::with_surreal_endpoint(test_id, &surrealdb.ws_endpoint());
     let surreal = connect_auto(&config).await?;
-    cleanup_auto(&surreal, &["Article", "Comment"]).await?;
+    cleanup_surrealdb_auto(&surreal, &dataset).await?;
 
     let checkpoint_dir = format!(".test-mssql-temporal-{test_id}");
     cleanup_checkpoint_dir(&checkpoint_dir)?;
 
     let args = sync_args(
         conn_str.clone(),
-        vec!["dbo.Article".into(), "dbo.Comment".into()],
+        unified_table_args(),
         &config,
         SnapshotModeArg::Only,
         SyncStrategy::InterleavedSnapshot,
         Some(checkpoint_dir.clone()),
         false,
         None,
-        vec![],
+        vec!["authored_by".into()],
     );
     run_mssql_sync(args).await?;
 
-    let articles = query_debug(&surreal, "SELECT * FROM Article").await?;
-    assert!(
-        articles.contains("first"),
-        "history version missing: {articles}"
-    );
-    assert!(
-        articles.contains("second"),
-        "current version missing: {articles}"
-    );
-    assert!(articles.contains("is_current"), "{articles}");
+    assert_synced_mssql_temporal(
+        &surreal,
+        &dataset,
+        "MSSQL temporal unified snapshot",
+        &["all_types_users"],
+    )
+    .await?;
 
-    let current = query_debug(&surreal, "SELECT * FROM Article WHERE is_current").await?;
-    assert!(current.contains("second"), "{current}");
-    assert!(!current.contains("first"), "{current}");
-
-    let comments = query_debug(&surreal, "SELECT * FROM Comment").await?;
-    assert!(comments.contains("note"), "{comments}");
+    let posts = query_debug(&surreal, "SELECT * FROM all_types_posts").await?;
     assert!(
-        !comments.contains("Article:"),
-        "FK to temporal table must stay scalar: {comments}"
+        !surreal_sync::testing::mssql::dump_has_record_link(&posts, "all_types_users"),
+        "FK to temporal users must stay scalar: {posts}"
     );
 
     exec_sql(
         &conn_str,
-        "UPDATE dbo.Article SET Title = N'third' WHERE Id = 1;",
+        "UPDATE dbo.all_types_users SET name = N'Alice Smith v2' WHERE user_id = N'user_001';",
     )
     .await?;
 
     let tail = sync_args(
         conn_str,
-        vec!["dbo.Article".into(), "dbo.Comment".into()],
+        unified_table_args(),
         &config,
         SnapshotModeArg::Never,
         SyncStrategy::InterleavedSnapshot,
         Some(checkpoint_dir.clone()),
         false,
         Some("20s".into()),
-        vec![],
+        vec!["authored_by".into()],
     );
     run_mssql_sync(tail).await?;
 
-    let articles = query_debug(&surreal, "SELECT * FROM Article").await?;
+    let users = query_debug(&surreal, "SELECT * FROM all_types_users").await?;
     assert!(
-        articles.contains("third"),
-        "live UPDATE version missing: {articles}"
+        users.contains("Alice Smith v2"),
+        "live UPDATE version missing: {users}"
     );
-    let current = query_debug(&surreal, "SELECT * FROM Article WHERE is_current").await?;
-    assert!(current.contains("third"), "{current}");
+    let current = query_debug(
+        &surreal,
+        "SELECT * FROM all_types_users WHERE is_current AND user_id = 'user_001'",
+    )
+    .await?;
+    assert!(current.contains("Alice Smith v2"), "{current}");
+    let history = query_debug(
+        &surreal,
+        "SELECT * FROM all_types_users WHERE is_current = false AND user_id = 'user_001'",
+    )
+    .await?;
     assert!(
-        !current.contains("second"),
-        "prior is_current should be cleared: {current}"
+        history.contains("Alice Smith"),
+        "history version missing original unified name: {history}"
     );
 
     cleanup_checkpoint_dir(&checkpoint_dir)?;

--- a/tests/mssql/mssql_temporal_lib.rs
+++ b/tests/mssql/mssql_temporal_lib.rs
@@ -1,0 +1,100 @@
+//! Temporal UNION ALL snapshot + live UPDATE versions (library).
+
+use surreal_sync::testing::checkpoint::cleanup_checkpoint_dir;
+use surreal_sync::testing::surreal::{cleanup_auto, connect_auto};
+use surreal_sync::testing::{generate_test_id, TestConfig};
+use surreal_sync_mssql::from_mssql::cli::{SnapshotModeArg, SyncStrategy};
+
+use crate::common::{exec_sql, query_debug, run_mssql_sync, sync_args, temporal_schema_sql};
+
+#[tokio::test]
+async fn test_mssql_temporal_versions_and_scalar_fk_lib() -> Result<(), Box<dyn std::error::Error>>
+{
+    tracing_subscriber::fmt()
+        .with_env_filter("surreal_sync=info")
+        .try_init()
+        .ok();
+
+    let container = surreal_sync::testing::shared_containers::shared_mssql().await;
+    let test_id = generate_test_id();
+    let conn_str =
+        surreal_sync::testing::shared_containers::create_mssql_test_db(container, test_id).await?;
+    exec_sql(&conn_str, temporal_schema_sql()).await?;
+
+    let surrealdb = surreal_sync::testing::shared_containers::shared_surrealdb();
+    let config = TestConfig::with_surreal_endpoint(test_id, &surrealdb.ws_endpoint());
+    let surreal = connect_auto(&config).await?;
+    cleanup_auto(&surreal, &["Article", "Comment"]).await?;
+
+    let checkpoint_dir = format!(".test-mssql-temporal-{test_id}");
+    cleanup_checkpoint_dir(&checkpoint_dir)?;
+
+    let args = sync_args(
+        conn_str.clone(),
+        vec!["dbo.Article".into(), "dbo.Comment".into()],
+        &config,
+        SnapshotModeArg::Only,
+        SyncStrategy::InterleavedSnapshot,
+        Some(checkpoint_dir.clone()),
+        false,
+        None,
+        vec![],
+    );
+    run_mssql_sync(args).await?;
+
+    let articles = query_debug(&surreal, "SELECT * FROM Article").await?;
+    assert!(
+        articles.contains("first"),
+        "history version missing: {articles}"
+    );
+    assert!(
+        articles.contains("second"),
+        "current version missing: {articles}"
+    );
+    assert!(articles.contains("is_current"), "{articles}");
+
+    let current = query_debug(&surreal, "SELECT * FROM Article WHERE is_current").await?;
+    assert!(current.contains("second"), "{current}");
+    assert!(!current.contains("first"), "{current}");
+
+    let comments = query_debug(&surreal, "SELECT * FROM Comment").await?;
+    assert!(comments.contains("note"), "{comments}");
+    assert!(
+        !comments.contains("Article:"),
+        "FK to temporal table must stay scalar: {comments}"
+    );
+
+    exec_sql(
+        &conn_str,
+        "UPDATE dbo.Article SET Title = N'third' WHERE Id = 1;",
+    )
+    .await?;
+
+    let tail = sync_args(
+        conn_str,
+        vec!["dbo.Article".into(), "dbo.Comment".into()],
+        &config,
+        SnapshotModeArg::Never,
+        SyncStrategy::InterleavedSnapshot,
+        Some(checkpoint_dir.clone()),
+        false,
+        Some("20s".into()),
+        vec![],
+    );
+    run_mssql_sync(tail).await?;
+
+    let articles = query_debug(&surreal, "SELECT * FROM Article").await?;
+    assert!(
+        articles.contains("third"),
+        "live UPDATE version missing: {articles}"
+    );
+    let current = query_debug(&surreal, "SELECT * FROM Article WHERE is_current").await?;
+    assert!(current.contains("third"), "{current}");
+    assert!(
+        !current.contains("second"),
+        "prior is_current should be cleared: {current}"
+    );
+
+    cleanup_checkpoint_dir(&checkpoint_dir)?;
+    Ok(())
+}

--- a/tests/mssql/mssql_transforms_config_cli.rs
+++ b/tests/mssql/mssql_transforms_config_cli.rs
@@ -4,10 +4,13 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use surreal_sync::testing::cli::{assert_cli_success, execute_surreal_sync};
-use surreal_sync::testing::surreal::{cleanup_auto, connect_auto, SurrealConnection};
-use surreal_sync::testing::{generate_test_id, TestConfig};
+use surreal_sync::testing::mssql::{
+    cleanup_unified_dataset_tables, create_tables_and_indices, inject_test_table_mssql,
+};
+use surreal_sync::testing::surreal::{cleanup_surrealdb_auto, connect_auto, SurrealConnection};
+use surreal_sync::testing::{create_unified_full_dataset, generate_test_id, TestConfig};
 
-use crate::common::exec_sql;
+use crate::common::mssql_client;
 
 fn fixture_worker_path() -> PathBuf {
     let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -57,16 +60,15 @@ async fn test_mssql_stream_cli_transforms_config_mutate() -> Result<(), Box<dyn 
 
     let conn_str =
         surreal_sync::testing::shared_containers::create_mssql_test_db(container, test_id).await?;
-    exec_sql(
-        &conn_str,
-        "CREATE TABLE dbo.people (id INT NOT NULL PRIMARY KEY, name NVARCHAR(64) NOT NULL);",
-    )
-    .await?;
+    let client = mssql_client(&conn_str).await?;
+    let dataset = create_unified_full_dataset();
+    cleanup_unified_dataset_tables(&client).await?;
+    create_tables_and_indices(&client, &dataset, &[]).await?;
 
     let surrealdb = surreal_sync::testing::shared_containers::shared_surrealdb();
     let config = TestConfig::with_surreal_endpoint(test_id, &surrealdb.ws_endpoint());
     let conn = connect_auto(&config).await?;
-    cleanup_auto(&conn, &["people"]).await?;
+    cleanup_surrealdb_auto(&conn, &dataset).await?;
 
     let snapshot_args = [
         "from",
@@ -77,7 +79,7 @@ async fn test_mssql_stream_cli_transforms_config_mutate() -> Result<(), Box<dyn 
         "--connection-string",
         &conn_str,
         "--tables",
-        "dbo.people",
+        "dbo.all_types_users",
         "--surreal-endpoint",
         &config.surreal_endpoint,
         "--to-namespace",
@@ -96,11 +98,12 @@ async fn test_mssql_stream_cli_transforms_config_mutate() -> Result<(), Box<dyn 
     let output = execute_surreal_sync(&snapshot_args)?;
     assert_cli_success(&output, "mssql snapshot phase CLI");
 
-    exec_sql(
-        &conn_str,
-        "INSERT INTO dbo.people (id, name) VALUES (1, N'alice'), (2, N'bob');",
-    )
-    .await?;
+    let users = dataset
+        .tables
+        .iter()
+        .find(|t| t.name == "all_types_users")
+        .expect("unified users table");
+    inject_test_table_mssql(&client, users).await?;
 
     let transforms_toml = format!(
         r#"
@@ -132,7 +135,7 @@ stdio.framer = "ndjson"
         "--connection-string",
         &conn_str,
         "--tables",
-        "dbo.people",
+        "dbo.all_types_users",
         "--surreal-endpoint",
         &config.surreal_endpoint,
         "--to-namespace",
@@ -171,12 +174,12 @@ stdio.framer = "ndjson"
 
     let names: Vec<Option<String>> = match &conn {
         SurrealConnection::V2(db) => {
-            let mut resp = db.query("SELECT name FROM people").await?;
+            let mut resp = db.query("SELECT name FROM all_types_users").await?;
             let rows: Vec<PeopleRowV2> = resp.take(0)?;
             rows.into_iter().map(|r| r.name).collect()
         }
         SurrealConnection::V3(db) => {
-            let mut resp = db.query("SELECT name FROM people").await?;
+            let mut resp = db.query("SELECT name FROM all_types_users").await?;
             let rows: Vec<PeopleRowV3> = resp.take(0)?;
             rows.into_iter().map(|r| r.name).collect()
         }
@@ -184,7 +187,7 @@ stdio.framer = "ndjson"
     assert_eq!(
         names.len(),
         2,
-        "expected two people docs after transform stream, got {names:?}"
+        "expected two unified users after transform stream, got {names:?}"
     );
     for name in &names {
         assert_eq!(

--- a/tests/mssql/mssql_transforms_config_cli.rs
+++ b/tests/mssql/mssql_transforms_config_cli.rs
@@ -1,0 +1,199 @@
+//! CLI e2e: `from mssql sync --transforms-config` mutate worker.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use surreal_sync::testing::cli::{assert_cli_success, execute_surreal_sync};
+use surreal_sync::testing::surreal::{cleanup_auto, connect_auto, SurrealConnection};
+use surreal_sync::testing::{generate_test_id, TestConfig};
+
+use crate::common::exec_sql;
+
+fn fixture_worker_path() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("target");
+    p.push("debug");
+    p.push("sync-transform-fixture-worker");
+    p
+}
+
+fn ensure_fixture_worker() -> PathBuf {
+    let path = fixture_worker_path();
+    if !path.is_file() {
+        let status = Command::new("cargo")
+            .args([
+                "build",
+                "-p",
+                "surreal-sync-runtime",
+                "--features",
+                "test-support",
+                "--bin",
+                "sync-transform-fixture-worker",
+            ])
+            .current_dir(env!("CARGO_MANIFEST_DIR"))
+            .status()
+            .expect("spawn cargo build fixture worker");
+        assert!(
+            status.success(),
+            "failed to build sync-transform-fixture-worker"
+        );
+    }
+    path
+}
+
+#[tokio::test]
+async fn test_mssql_stream_cli_transforms_config_mutate() -> Result<(), Box<dyn std::error::Error>>
+{
+    tracing_subscriber::fmt()
+        .with_env_filter("surreal_sync=info")
+        .try_init()
+        .ok();
+
+    let worker = ensure_fixture_worker();
+    let container = surreal_sync::testing::shared_containers::shared_mssql().await;
+    let test_id = generate_test_id();
+    let checkpoint_dir = format!(".test-mssql-transforms-cli-{test_id}");
+    surreal_sync::testing::checkpoint::cleanup_checkpoint_dir(&checkpoint_dir)?;
+
+    let conn_str =
+        surreal_sync::testing::shared_containers::create_mssql_test_db(container, test_id).await?;
+    exec_sql(
+        &conn_str,
+        "CREATE TABLE dbo.people (id INT NOT NULL PRIMARY KEY, name NVARCHAR(64) NOT NULL);",
+    )
+    .await?;
+
+    let surrealdb = surreal_sync::testing::shared_containers::shared_surrealdb();
+    let config = TestConfig::with_surreal_endpoint(test_id, &surrealdb.ws_endpoint());
+    let conn = connect_auto(&config).await?;
+    cleanup_auto(&conn, &["people"]).await?;
+
+    let snapshot_args = [
+        "from",
+        "mssql",
+        "sync",
+        "--snapshot-mode",
+        "only",
+        "--connection-string",
+        &conn_str,
+        "--tables",
+        "dbo.people",
+        "--surreal-endpoint",
+        &config.surreal_endpoint,
+        "--to-namespace",
+        &config.surreal_namespace,
+        "--to-database",
+        &config.surreal_database,
+        "--surreal-username",
+        "root",
+        "--surreal-password",
+        "root",
+        "--checkpoint-dir",
+        &checkpoint_dir,
+        "--chunk-size",
+        "32",
+    ];
+    let output = execute_surreal_sync(&snapshot_args)?;
+    assert_cli_success(&output, "mssql snapshot phase CLI");
+
+    exec_sql(
+        &conn_str,
+        "INSERT INTO dbo.people (id, name) VALUES (1, N'alice'), (2, N'bob');",
+    )
+    .await?;
+
+    let transforms_toml = format!(
+        r#"
+[pipeline]
+failure_policy = "fail"
+batch_size = 1
+batch_max_wait = "500ms"
+timeout = "60s"
+max_in_flight = 1
+
+[[transforms]]
+type = "command"
+mode = "persistent"
+command = ["{}", "mutate"]
+stdio.framer = "ndjson"
+"#,
+        worker.display()
+    );
+    std::fs::create_dir_all(&checkpoint_dir)?;
+    let transforms_path = format!("{checkpoint_dir}/transforms-mutate.toml");
+    std::fs::write(&transforms_path, transforms_toml)?;
+
+    let stream_args = [
+        "from",
+        "mssql",
+        "sync",
+        "--snapshot-mode",
+        "never",
+        "--connection-string",
+        &conn_str,
+        "--tables",
+        "dbo.people",
+        "--surreal-endpoint",
+        &config.surreal_endpoint,
+        "--to-namespace",
+        &config.surreal_namespace,
+        "--to-database",
+        &config.surreal_database,
+        "--surreal-username",
+        "root",
+        "--surreal-password",
+        "root",
+        "--timeout",
+        "25s",
+        "--checkpoint-dir",
+        &checkpoint_dir,
+        "--transforms-config",
+        &transforms_path,
+        "--chunk-size",
+        "32",
+    ];
+    let stream_output = execute_surreal_sync(&stream_args)?;
+    assert_cli_success(
+        &stream_output,
+        "mssql stream CLI with --transforms-config mutate",
+    );
+
+    #[derive(Debug, serde::Deserialize)]
+    struct PeopleRowV2 {
+        name: Option<String>,
+    }
+    use surrealdb3::types::SurrealValue;
+    #[derive(SurrealValue, Debug)]
+    #[surreal(crate = "surrealdb3::types")]
+    struct PeopleRowV3 {
+        name: Option<String>,
+    }
+
+    let names: Vec<Option<String>> = match &conn {
+        SurrealConnection::V2(db) => {
+            let mut resp = db.query("SELECT name FROM people").await?;
+            let rows: Vec<PeopleRowV2> = resp.take(0)?;
+            rows.into_iter().map(|r| r.name).collect()
+        }
+        SurrealConnection::V3(db) => {
+            let mut resp = db.query("SELECT name FROM people").await?;
+            let rows: Vec<PeopleRowV3> = resp.take(0)?;
+            rows.into_iter().map(|r| r.name).collect()
+        }
+    };
+    assert_eq!(
+        names.len(),
+        2,
+        "expected two people docs after transform stream, got {names:?}"
+    );
+    for name in &names {
+        assert_eq!(
+            name.as_deref(),
+            Some("mutated"),
+            "CLI --transforms-config external mutate should rewrite name; got {names:?}"
+        );
+    }
+
+    surreal_sync::testing::checkpoint::cleanup_checkpoint_dir(&checkpoint_dir)?;
+    Ok(())
+}

--- a/tests/postgresql/postgresql_fk_incremental_test.rs
+++ b/tests/postgresql/postgresql_fk_incremental_test.rs
@@ -74,6 +74,7 @@ async fn test_trigger_fk_incremental_only() -> Result<(), Box<dyn std::error::Er
     let sync_opts = surreal_sync_postgresql::SyncOpts {
         batch_size: 1000,
         dry_run: false,
+        schemafull: false,
     };
 
     let checkpoint_store =

--- a/tests/postgresql/postgresql_fk_sync_test.rs
+++ b/tests/postgresql/postgresql_fk_sync_test.rs
@@ -94,6 +94,7 @@ async fn test_postgresql_fk_full_sync() -> Result<(), Box<dyn std::error::Error>
     let sync_opts = surreal_sync_postgresql::SyncOpts {
         batch_size: 1000,
         dry_run: false,
+        schemafull: false,
     };
     let pipeline = surreal_sync_runtime::Pipeline::new();
     let apply_opts = surreal_sync_runtime::ApplyOpts::identity();
@@ -280,6 +281,7 @@ async fn test_postgresql_fk_config_override() -> Result<(), Box<dyn std::error::
     let sync_opts = surreal_sync_postgresql::SyncOpts {
         batch_size: 1000,
         dry_run: false,
+        schemafull: false,
     };
     let pipeline = surreal_sync_runtime::Pipeline::new();
     let apply_opts = surreal_sync_runtime::ApplyOpts::identity();

--- a/tests/postgresql/postgresql_full_sync_only_lib.rs
+++ b/tests/postgresql/postgresql_full_sync_only_lib.rs
@@ -56,6 +56,7 @@ async fn test_postgresql_full_sync_lib() -> Result<(), Box<dyn std::error::Error
     let sync_opts = surreal_sync_postgresql::SyncOpts {
         batch_size: 1000,
         dry_run: false,
+        schemafull: false,
     };
 
     // Execute full sync with appropriate sink based on detected version

--- a/tests/postgresql/postgresql_incremental_sync_only_lib.rs
+++ b/tests/postgresql/postgresql_incremental_sync_only_lib.rs
@@ -61,6 +61,7 @@ async fn test_postgresql_incremental_sync_lib() -> Result<(), Box<dyn std::error
     let sync_opts = surreal_sync_postgresql::SyncOpts {
         batch_size: 1000,
         dry_run: false,
+        schemafull: false,
     };
 
     // Create sync manager with filesystem checkpoint store

--- a/tests/postgresql_logical/postgresql_logical_fk_incremental_test.rs
+++ b/tests/postgresql_logical/postgresql_logical_fk_incremental_test.rs
@@ -84,6 +84,7 @@ async fn test_wal2json_fk_incremental_only() -> Result<(), Box<dyn std::error::E
     let sync_opts = surreal_sync_postgresql::SyncOpts {
         batch_size: 1000,
         dry_run: false,
+        schemafull: false,
     };
 
     let checkpoint_store =

--- a/tests/postgresql_logical/postgresql_logical_full_sync_only_lib.rs
+++ b/tests/postgresql_logical/postgresql_logical_full_sync_only_lib.rs
@@ -67,6 +67,7 @@ async fn test_postgresql_logical_full_sync_lib() -> Result<(), Box<dyn std::erro
     let sync_opts = surreal_sync_postgresql::SyncOpts {
         batch_size: 1000,
         dry_run: false,
+        schemafull: false,
     };
 
     // Run full sync with appropriate sink based on detected version


### PR DESCRIPTION
`surreal-sync from mssql sync` copies SQL Server tables into SurrealDB and keeps them current with native CDC.

The default is an interleaved watermark snapshot while CDC runs, then a live tail. Source writers are not locked: the copy is ordinary reads plus the CDC stream.

`--strategy sequential-snapshot` copies in one `SNAPSHOT` isolation transaction and catches up from that LSN. Writers are still not locked; isolation is MVCC (row versions in tempdb), not table locks.

`--schemafull` is opt-in; the default stays schemaless. System-versioned temporal tables become one SurrealDB table: every version, the source period columns (even if `HIDDEN` in SQL Server), and an `is_current` flag we add. Query pairs for `FOR SYSTEM_TIME` are in `docs/mssql.md`.

Ref #158